### PR TITLE
Dockerized eth-events server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10
+
+WORKDIR /app
+COPY package*.json ./
+
+RUN npm install --only=production
+COPY dist/apps/eth-events-server ./
+EXPOSE 3333
+
+ENV GOOGLE_APPLICATION_CREDENTIALS "./creds.json"
+CMD [ "node", "./main.js" ]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ Download the keys and export an `env` variable that points to your json key
 ```
 export GOOGLE_APPLICATION_CREDENTIALS=./blockframes-laurent-230215-ccf4f1949393.json
 ```
+
+### Build & Run with Docker
+
+```
+ng build eth-events-server
+docker build . --tag=eth-events-server:0.0.1
+docker run -v ${PWD}/blockframes-laurent-702feef93c99.json:/app/creds.json \
+    --rm -p 3333 -t -i eth-events-server:0.0.1
+```


### PR DESCRIPTION
Basic to bundle the eth-events server into a Docker container.
For simplicity we do it from the repos' root for now.