### PR TITLE
Issue 534: pdf export for deliveries

### DIFF
--- a/apps/backend-functions/src/data/index.ts
+++ b/apps/backend-functions/src/data/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Data module for the backend,
+ * defines the interface for client code and internal data storage operations.
+ *
+ * This module will (TODO) define a human-readable, business oriented interface,
+ * and introduce separation of concern between the client code (create delivery, generate notification, etc)
+ * and the storage layer (firestore, retrieve document, access path `/delivery/${deliveryId}/x/y`
+ *
+ * Right now this module only contains types & low level data manipulation,
+ * this is the initial step of a three step refactoring:
+ *
+ * - Regroup, organize and prepare the data manipulation code we already have,
+ * - Build a layer of abstraction atop this layer to abstract the implementation details (firestore)
+ *   and our business code (Materials, Delivery, etc),
+ * - Reunite the backend and frontend data layers in a single shared library,
+ *   to keep a single, up-to-date codebase.
+ */

--- a/apps/backend-functions/src/data/index.ts
+++ b/apps/backend-functions/src/data/index.ts
@@ -2,7 +2,7 @@
  * Data module for the backend,
  * defines the interface for client code and internal data storage operations.
  *
- * This module will (TODO) define a human-readable, business oriented interface,
+ * This module will (TODO) expose our human-readable, business oriented interface,
  * and introduce separation of concern between the client code (create delivery, generate notification, etc)
  * and the storage layer (firestore, retrieve document, access path `/delivery/${deliveryId}/x/y`
  *
@@ -12,6 +12,6 @@
  * - Regroup, organize and prepare the data manipulation code we already have,
  * - Build a layer of abstraction atop this layer to abstract the implementation details (firestore)
  *   and our business code (Materials, Delivery, etc),
- * - Reunite the backend and frontend data layers in a single shared library,
+ * - Reunite the backend and frontend data layers in the library corresponding to each model,
  *   to keep a single, up-to-date codebase.
  */

--- a/apps/backend-functions/src/data/internals.ts
+++ b/apps/backend-functions/src/data/internals.ts
@@ -30,6 +30,8 @@ export async function getOrgsOfDocument(
 }
 
 export function getCount(collection: string) {
+  // TODO: implement counters to make this function scalable.
+  // relevant docs: https://firebase.google.com/docs/firestore/solutions/counters
   return db
     .collection(collection)
     .get()

--- a/apps/backend-functions/src/data/internals.ts
+++ b/apps/backend-functions/src/data/internals.ts
@@ -20,6 +20,16 @@ export function getDocument<T>(path: string): Promise<T> {
     .then(doc => doc.data() as T);
 }
 
+/**
+ * Try to get all the organization in the stakeholders subcollection of `/{collection}/{documentId}`.
+ *
+ * Use with care: this function assumes the stakeholders collection exists and
+ * it doesn't not deduplicate the orgs.
+ *
+ * @param documentId
+ * @param collection
+ * @returns the organization that are in the document's stakeholders.
+ */
 export async function getOrgsOfDocument(
   documentId: string,
   collection: string

--- a/apps/backend-functions/src/data/internals.ts
+++ b/apps/backend-functions/src/data/internals.ts
@@ -1,0 +1,37 @@
+/**
+ * Collection & Document manipulation
+ *
+ * This code deals directly with the low level parts of firebase,
+ */
+import { db } from '../firebase';
+import { Organization, Stakeholder } from './types';
+
+export async function getCollection<T>(path: string): Promise<T[]> {
+  return db
+    .collection(path)
+    .get()
+    .then(collection => collection.docs.map(doc => doc.data() as T));
+}
+
+export async function getDocument<T>(path: string): Promise<T> {
+  return db
+    .doc(path)
+    .get()
+    .then(doc => doc.data() as T);
+}
+
+export async function getOrgsOfDocument(
+  documentId: string,
+  collection: string
+): Promise<Organization[]> {
+  const stakeholders = await getCollection<Stakeholder>(`${collection}/${documentId}/stakeholders`);
+  const promises = stakeholders.map(({ orgId }) => getDocument<Organization>(`orgs/${orgId}`));
+  return Promise.all(promises);
+}
+
+export function getCount(collection: string) {
+  return db
+    .collection(collection)
+    .get()
+    .then(col => col.size);
+}

--- a/apps/backend-functions/src/data/internals.ts
+++ b/apps/backend-functions/src/data/internals.ts
@@ -6,14 +6,14 @@
 import { db } from '../firebase';
 import { Organization, Stakeholder } from './types';
 
-export async function getCollection<T>(path: string): Promise<T[]> {
+export function getCollection<T>(path: string): Promise<T[]> {
   return db
     .collection(path)
     .get()
     .then(collection => collection.docs.map(doc => doc.data() as T));
 }
 
-export async function getDocument<T>(path: string): Promise<T> {
+export function getDocument<T>(path: string): Promise<T> {
   return db
     .doc(path)
     .get()

--- a/apps/backend-functions/src/data/types.ts
+++ b/apps/backend-functions/src/data/types.ts
@@ -5,9 +5,7 @@
  * details on why, what and what's up next.
  */
 
-export interface IDMap<T> {
-  [id: string]: T;
-}
+export type IDMap<T> = Record<string, T>;
 
 interface DocWithID {
   id: string;
@@ -87,12 +85,13 @@ export interface SnapObject {
   count?: number;
 }
 
+/**
+ * Turn a list of items with ids into the corresponding mapping.
+ *
+ * @param items A list of item with an ID
+ * @returns an object that maps each id to its item,
+ *          `{id_x: item_x, id_y: item_y, ...}`
+ */
 export function asIDMap<T extends DocWithID>(items: T[]): IDMap<T> {
-  const result: IDMap<T> = {};
-
-  items.forEach(item => {
-    result[item.id] = item;
-  });
-
-  return result;
+  return items.reduce((result, item) => ({ ...result, [item.id]: item }), {});
 }

--- a/apps/backend-functions/src/data/types.ts
+++ b/apps/backend-functions/src/data/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Types used by the firebase backend.
+ *
+ * Define all type to be used in the codebase. Please see the index.ts for more
+ * details on why, what and what's up next.
+ */
+
+export interface IDMap<T> {
+  [id: string]: T;
+}
+
+interface DocWithID {
+  id: string;
+}
+
+export interface DocID {
+  id: string;
+  type: 'movie' | 'delivery' | 'material';
+}
+
+export interface Organization {
+  id: string;
+  userIds: string[];
+  name: string;
+  address: string;
+}
+
+export interface Stakeholder {
+  id: string;
+  orgId: string;
+}
+
+export interface Step {
+  id: string;
+  date: Date;
+  name: string;
+}
+
+export interface Delivery {
+  id: string;
+  movieId: string;
+  processedId: string;
+  stakeholders: string[];
+  materials: string[];
+  steps: Step[];
+}
+
+export interface Movie {
+  id: string;
+  title: {
+    original: string;
+  };
+}
+
+export interface Material {
+  id: string;
+  value: string;
+  description: string;
+  category: string;
+  deliveriesIds: string[];
+  state: string;
+  stepId: string;
+}
+
+export interface BaseNotification {
+  message: string;
+  userId: string;
+  docID: DocID;
+  stakeholderId?: string;
+  path?: string;
+}
+
+export interface Notification extends BaseNotification {
+  id: string;
+  isRead: boolean;
+  date: any;
+  app: string;
+}
+
+export interface SnapObject {
+  movie: Movie;
+  docID: DocID;
+  org: Organization;
+  eventType: string;
+  delivery?: Delivery | null;
+  newStakeholderId?: string;
+  count?: number;
+}
+
+export function asIDMap<T extends DocWithID>(items: T[]): IDMap<T> {
+  const result: IDMap<T> = {};
+
+  items.forEach(item => {
+    result[item.id] = item;
+  });
+
+  return result;
+}

--- a/apps/backend-functions/src/delete.ts
+++ b/apps/backend-functions/src/delete.ts
@@ -1,6 +1,8 @@
 import { db, functions } from './firebase';
 import { prepareNotification, triggerNotifications } from './notify';
-import { getDocument, Delivery, Material, getCollection, isTheSame, getOrgsOfDocument } from './utils';
+import { isTheSame } from './utils';
+import { getDocument, getCollection, getOrgsOfDocument } from './data/internals';
+import { Delivery, Material } from './data/types';
 
 export async function deleteFirestoreMovie (
   snap: FirebaseFirestore.DocumentSnapshot,
@@ -158,4 +160,4 @@ export async function deleteFirestoreMaterial (
     }
   }
   return true;
-};
+}

--- a/apps/backend-functions/src/delivery.ts
+++ b/apps/backend-functions/src/delivery.ts
@@ -1,17 +1,8 @@
 import { db, functions } from './firebase';
 import { triggerNotifications, prepareNotification } from './notify';
-import {
-  Organization,
-  getDocument,
-  getCollection,
-  Stakeholder,
-  Movie,
-  Material,
-  getCount,
-  Delivery,
-  isTheSame,
-  getOrgsOfDocument
-} from './utils';
+import { getDocument, getCollection, getCount, getOrgsOfDocument } from './data/internals';
+import { Organization, Stakeholder, Movie, Material, Delivery } from './data/types';
+import { isTheSame } from './utils';
 
 export async function onDeliveryUpdate(
   change: functions.Change<FirebaseFirestore.DocumentSnapshot>,

--- a/apps/backend-functions/src/local/testPDFExport.ts
+++ b/apps/backend-functions/src/local/testPDFExport.ts
@@ -7,17 +7,19 @@ const testData = {
     id2: '0x8e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8',
     id3: '0x7e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8'
   },
-  stakeholders: {
-    id1: { name: 'John Doe', organization: 'LogicalPicture' },
-    id2: { name: 'Tomme Hardy', organization: '20Th Century Fox' },
-    id3: { name: 'Francis Munster', organization: 'Disney' }
+  orgs: {
+    id1: { name: 'John Doe', address: 'LogicalPicture', userIds: [], id: '' },
+    id2: { name: 'Tomme Hardy', address: '20Th Century Fox', userIds: [], id: '' },
+    id3: { name: 'Francis Munster', address: 'Disney', userIds: [], id: '' }
   },
   steps: {
-    i36vwU1eVdlNObEafOre: { name: 'A', date: new Date() },
-    P8uVlb5CD0i6NU8fegAf: { name: 'B', date: new Date() }
+    i36vwU1eVdlNObEafOre: { id: '', name: 'A', date: new Date() },
+    P8uVlb5CD0i6NU8fegAf: { id: '', name: 'B', date: new Date() }
   },
   materials: [
     {
+      deliveriesIds: [],
+      state: '',
       value: 'My Second Material',
       category: 'Some Category',
       id: '0DL3qyDacTcsyIQUCU0R',
@@ -25,6 +27,8 @@ const testData = {
       stepId: 'i36vwU1eVdlNObEafOre'
     },
     {
+      deliveriesIds: [],
+      state: '',
       value: 'My Third Material',
       category: 'Another Category',
       id: 'Ci3RPg5qLLNTo1e5n7L0',
@@ -32,6 +36,8 @@ const testData = {
       stepId: 'i36vwU1eVdlNObEafOre'
     },
     {
+      deliveriesIds: [],
+      state: '',
       description: 'Yet Another Material With a Description',
       stepId: 'P8uVlb5CD0i6NU8fegAf',
       value: 'Yet Another Material',
@@ -39,6 +45,8 @@ const testData = {
       id: 'OtTFuS6Lq3MdjfGicU8v'
     },
     {
+      deliveriesIds: [],
+      state: '',
       description: 'My Material No Step Description',
       stepId: '',
       value: 'My Material No Step',
@@ -46,6 +54,8 @@ const testData = {
       id: 'byVmOtNzxPNJZv8qs1OX'
     },
     {
+      deliveriesIds: [],
+      state: '',
       description: 'My Material Description',
       stepId: 'i36vwU1eVdlNObEafOre',
       value: 'My Material',
@@ -57,7 +67,6 @@ const testData = {
 
 function main() {
   const pdf = buildDeliveryPDF(testData);
-
   pdf.pipe(fs.createWriteStream('/tmp/delivery.pdf'));
   pdf.end();
 }

--- a/apps/backend-functions/src/local/testPDFExport.ts
+++ b/apps/backend-functions/src/local/testPDFExport.ts
@@ -2,18 +2,55 @@ import { buildDeliveryPDF } from '../pdf';
 import * as fs from 'fs';
 
 const testData = {
-  txID: ['0x9e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8'],
-  stakeholders: [
-    { name: 'John Doe', organization: 'LogicalPicture' },
-    { name: 'Tomme Hardy', organization: '20Th Century Fox' },
-    { name: 'Francis Munster', organization: 'Disney' }
-  ],
+  txID: {
+    id1: '0x9e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8',
+    id2: '0x8e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8',
+    id3: '0x7e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8'
+  },
+  stakeholders: {
+    id1: { name: 'John Doe', organization: 'LogicalPicture' },
+    id2: { name: 'Tomme Hardy', organization: '20Th Century Fox' },
+    id3: { name: 'Francis Munster', organization: 'Disney' }
+  },
+  steps: {
+    i36vwU1eVdlNObEafOre: { name: 'A', date: new Date() },
+    P8uVlb5CD0i6NU8fegAf: { name: 'B', date: new Date() }
+  },
   materials: [
     {
-      name: 'Version Originale'
+      value: 'My Second Material',
+      category: 'Some Category',
+      id: '0DL3qyDacTcsyIQUCU0R',
+      description: 'My Second Material Description',
+      stepId: 'i36vwU1eVdlNObEafOre'
     },
     {
-      name: 'Subtitles FR'
+      value: 'My Third Material',
+      category: 'Another Category',
+      id: 'Ci3RPg5qLLNTo1e5n7L0',
+      description: 'My Third Material Description',
+      stepId: 'i36vwU1eVdlNObEafOre'
+    },
+    {
+      description: 'Yet Another Material With a Description',
+      stepId: 'P8uVlb5CD0i6NU8fegAf',
+      value: 'Yet Another Material',
+      category: 'Another Category',
+      id: 'OtTFuS6Lq3MdjfGicU8v'
+    },
+    {
+      description: 'My Material No Step Description',
+      stepId: '',
+      value: 'My Material No Step',
+      category: 'Another Category',
+      id: 'byVmOtNzxPNJZv8qs1OX'
+    },
+    {
+      description: 'My Material Description',
+      stepId: 'i36vwU1eVdlNObEafOre',
+      value: 'My Material',
+      category: 'Some Category',
+      id: 'jYpavkTXisbfGfQT873I'
     }
   ]
 };

--- a/apps/backend-functions/src/local/testPDFExport.ts
+++ b/apps/backend-functions/src/local/testPDFExport.ts
@@ -1,0 +1,28 @@
+import { buildDeliveryPDF } from '../pdf';
+import * as fs from 'fs';
+
+const testData = {
+  txID: ['0x9e91a0b95412093e639189a05a2dbf68e16c3062001e673826616222baffcac8'],
+  stakeholders: [
+    { name: 'John Doe', organization: 'LogicalPicture' },
+    { name: 'Tomme Hardy', organization: '20Th Century Fox' },
+    { name: 'Francis Munster', organization: 'Disney' }
+  ],
+  materials: [
+    {
+      name: 'Version Originale'
+    },
+    {
+      name: 'Subtitles FR'
+    }
+  ]
+};
+
+function main() {
+  const pdf = buildDeliveryPDF(testData);
+
+  pdf.pipe(fs.createWriteStream('/tmp/delivery.pdf'));
+  pdf.end();
+}
+
+main();

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -27,14 +27,12 @@ import * as backup from './backup';
 import * as migrations from './migrations';
 import { onDocumentCreate, onDocumentDelete, onDocumentUpdate } from './utils';
 import { mnemonic, relayer } from './environments/environment';
-
+import { onGenerateDeliveryPDFRequest } from './pdf';
 
 /**
  * Trigger: when eth-events-server pushes contract events.
  */
-export const onIpHashEvent = functions.pubsub
-  .topic('eth-events.ipHash')
-  .onPublish(onIpHash);
+export const onIpHashEvent = functions.pubsub.topic('eth-events.ipHash').onPublish(onIpHash);
 
 /**
  * Trigger: when user uploads document to firestore.
@@ -120,6 +118,11 @@ export const onMovieStakeholderCreateEvent = onDocumentCreate(
   'movies/{movieID}/stakeholders/{stakeholerID}',
   onMovieStakeholderCreate
 );
+
+/**
+ * Trigger: REST call to generate a delivery PDF
+ */
+export const generateDeliveryPDF = functions.https.onRequest(onGenerateDeliveryPDFRequest);
 
 /**
  * Trigger: when a stakeholder is removed from a movie

--- a/apps/backend-functions/src/material.ts
+++ b/apps/backend-functions/src/material.ts
@@ -1,7 +1,8 @@
 import { flatten, uniqBy } from 'lodash';
 import { db, functions } from './firebase';
 import { triggerNotifications, prepareNotification } from './notify';
-import { getDocument, Organization, Material, Movie, getOrgsOfDocument } from './utils';
+import { getDocument, getOrgsOfDocument } from './data/internals';
+import { Organization, Material, Movie } from './data/types';
 
 export const onMaterialUpdate = async (
   change: functions.Change<FirebaseFirestore.DocumentSnapshot>,

--- a/apps/backend-functions/src/migrations.ts
+++ b/apps/backend-functions/src/migrations.ts
@@ -1,4 +1,5 @@
-import { getCollection, getCount, Organization, Material } from './utils';
+import { getCollection, getCount } from './data/internals';
+import { Organization, Material } from './data/types';
 import { db, serverTimestamp } from './firebase';
 import { WriteBatch, FieldValue, Timestamp } from '@google-cloud/firestore';
 import { setRestoreFlag } from './backup';
@@ -28,7 +29,7 @@ function migrateMaterialToNewCollection(
   material: Material
 ) {
   if (template.materialsId.includes(material.id)) {
-    const materialRef = db.doc(`templates/${template.id}/materials/${material.id}`)
+    const materialRef = db.doc(`templates/${template.id}/materials/${material.id}`);
     batch.set(materialRef, material);
   }
 }

--- a/apps/backend-functions/src/notify.ts
+++ b/apps/backend-functions/src/notify.ts
@@ -1,20 +1,6 @@
 import { db, serverTimestamp } from './firebase';
-import { DocID, SnapObject, APP_DELIVERY_ICON, APP_MOVIE_ICON } from './utils';
-
-interface BaseNotification {
-  message: string;
-  userId: string;
-  docID: DocID;
-  stakeholderId?: string;
-  path?: string;
-}
-
-interface Notification extends BaseNotification {
-  id: string;
-  isRead: boolean;
-  date: any;
-  app: string;
-}
+import { APP_DELIVERY_ICON, APP_MOVIE_ICON } from './utils';
+import { BaseNotification, Notification, SnapObject } from './data/types';
 
 /** Takes one or more notifications and add them on the notifications collection */
 export async function triggerNotifications(notifications: Notification[]): Promise<any> {
@@ -57,12 +43,12 @@ export function customMessage(userId: string, snap: SnapObject) {
   }
   if (snap.eventType === 'google.firestore.document.delete') {
     if (snap.docID.type === 'movie') {
-      return `${snap.org.name} has been removed from movie ${snap.movie.title.original}.`
+      return `${snap.org.name} has been removed from movie ${snap.movie.title.original}.`;
     }
     if (snap.docID.type === 'delivery') {
-      return `${snap.org.name} has been removed from ${snap.movie.title.original} delivery.`
+      return `${snap.org.name} has been removed from ${snap.movie.title.original} delivery.`;
     }
-    throw new Error('Document type is not defined.')
+    throw new Error('Document type is not defined.');
   }
-  throw new Error('Invalid message.')
+  throw new Error('Invalid message.');
 }

--- a/apps/backend-functions/src/pdf.ts
+++ b/apps/backend-functions/src/pdf.ts
@@ -5,6 +5,10 @@ import { groupBy, sortBy } from 'lodash';
 
 const PdfPrinter = require('pdfmake');
 
+// Types
+// =====
+
+// TODO: extract and sync with the rest of the backend codebase
 interface StakeHolder {
   name: string;
   organization: string;
@@ -30,6 +34,8 @@ interface DeliveryContent {
   materials: Material[];
 }
 
+// Constants for styles & fonts
+// ============================
 const FONTS = {
   Helvetica: {
     normal: 'Helvetica',
@@ -39,20 +45,24 @@ const FONTS = {
   }
 };
 
-const HEADER = 'header';
-const SUBHEADER = 'subheader';
-const DESCRIPTION = 'description';
-const BOLD = 'bold';
+const STYLE_HEADER = 'header';
+const STYLE_SUBHEADER = 'subheader';
+const STYLE_DESCRIPTION = 'description';
+const STYLE_BOLD = 'bold';
+const STYLE_TABLE_MATERIALS = 'styleTableMaterials';
+
+// Helpers
+// -------
 
 const withStyle = (text: string, style: string): any => ({
   text,
   style
 });
 
-const header = (text: string) => withStyle(text, HEADER);
-const subHeader = (text: string) => withStyle(text, SUBHEADER);
-const description = (text: string) => withStyle(text, DESCRIPTION);
-const bold = (text: string) => withStyle(text, BOLD);
+const header = (text: string) => withStyle(text, STYLE_HEADER);
+const subHeader = (text: string) => withStyle(text, STYLE_SUBHEADER);
+const description = (text: string) => withStyle(text, STYLE_DESCRIPTION);
+const bold = (text: string) => withStyle(text, STYLE_BOLD);
 
 const center = (content: string | { [k: string]: any }): any => {
   if (typeof content === typeof 'string') {
@@ -63,91 +73,120 @@ const center = (content: string | { [k: string]: any }): any => {
   }
 };
 
-export function buildDeliveryPDF({ txID, stakeholders, materials, steps }: DeliveryContent) {
-  // We store keys first to make sure order is preserved along the way
-  const stakeholdersId = Object.keys(stakeholders);
-  const stakeholdersHeader: any = stakeholdersId.map((id: string) => {
+// PDF Generation
+// ==============
+
+// These functions take our blockframes model and generate data the pdf rendering.
+
+function rowStakeholders(
+  stakeholdersIds: string[],
+  stakeholders: { [id: string]: StakeHolder }
+): any {
+  const columns: any = stakeholdersIds.map((id: string) => {
     const stakeholder = stakeholders[id];
     return [subHeader(stakeholder.name), description(stakeholder.organization)];
   });
+  return [
+    header('Stakeholders'),
+    {
+      alignment: 'center',
+      columns
+    }
+  ];
+}
 
+function rowMaterials(materials: Material[], steps: { [id: string]: Step }): any {
+  // NOTE: pdfmake side-effect over the data provided, we can reuse the same objects
+  // multiple time, we have to keep this variable definition INSIDE the forEach.
+  const tableHeader = [bold('material'), center(bold('step'))];
+
+  const tableBody = materials.map(material => [
+    [bold(material.value), description(material.description)],
+    center({
+      text: material.stepId ? steps[material.stepId].name : '',
+      margin: [0, 4, 0, 0]
+    })
+  ]);
+
+  return {
+    style: STYLE_TABLE_MATERIALS,
+    table: {
+      headerRows: 1,
+      widths: ['80%', '20%'],
+      body: [[...tableHeader], ...tableBody]
+    }
+  };
+}
+
+function rowMaterialsPerCategory(materials: Material[], steps: { [id: string]: Step }): any {
   const materialsPerCategory = groupBy(materials, (material: Material) => material.category);
   const categories = sortBy(Object.keys(materialsPerCategory));
 
-  const tables: any = [];
+  const tables: any[] = [];
+
   categories.forEach(category => {
-    // NOTE: pdfmake side-effect over the data provided, we can reuse the same objects
-    // multiple time, we have to keep this variable definition INSIDE the forEach.
-    const tableHeader = [bold('material'), center(bold('step'))];
-
     tables.push(subHeader(category));
-
-    const tableBody = materialsPerCategory[category].map(material => [
-      [bold(material.value), description(material.description)],
-      center({
-        text: material.stepId ? steps[material.stepId].name : '',
-        margin: [0, 4, 0, 0]
-      })
-    ]);
-
-    tables.push({
-      style: 'materialsTable',
-      table: {
-        headerRows: 1,
-        widths: ['80%', '20%'],
-        body: [[...tableHeader], ...tableBody]
-      }
-    });
+    tables.push(rowMaterials(materialsPerCategory[category], steps));
   });
 
-  const signatures = {
-    alignment: 'center',
-    columns: stakeholdersId.map((id: string) => {
-      const stakeholder = stakeholders[id];
-      const tx = txID[id];
+  return [header('Materials'), ...tables];
+}
 
-      return [bold(stakeholder.name), { qr: tx, fit: '100' }];
-    })
-  };
+function rowSignatures(
+  stakeholdersIds: string[],
+  stakeholders: { [id: string]: StakeHolder },
+  txID: { [stkID: string]: string }
+): any {
+  const columns = stakeholdersIds.map((id: string) => {
+    const stakeholder = stakeholders[id];
+    const tx = txID[id];
 
-  //const materials: any = materials.map((x: any) => ['A', x.name, '20 July 2019']);
+    return [bold(stakeholder.name), { qr: tx, fit: '100' }];
+  });
+
+  return [
+    header('Signatures'),
+    {
+      alignment: 'center',
+      columns
+    }
+  ];
+}
+
+export function buildDeliveryPDF({ txID, stakeholders, materials, steps }: DeliveryContent) {
+  // We store keys first to make sure order is preserved along the way
+  const stakeholdersIds = Object.keys(stakeholders);
 
   const docDefinition = {
+    content: [
+      ...rowStakeholders(stakeholdersIds, stakeholders),
+      ...rowMaterialsPerCategory(materials, steps),
+      ...rowSignatures(stakeholdersIds, stakeholders, txID)
+    ],
+    defaultStyle: {
+      font: 'Helvetica'
+    },
     styles: {
-      materialsTable: {
+      [STYLE_TABLE_MATERIALS]: {
         margin: [5, 5, 5, 5]
       },
-      [HEADER]: {
+      [STYLE_HEADER]: {
         fontSize: 18,
         bold: true,
         margin: [5, 20, 5, 5]
       },
-      [SUBHEADER]: {
+      [STYLE_SUBHEADER]: {
         fontSize: 14,
         bold: true,
         margin: [5, 10, 5, 5]
       },
-      [DESCRIPTION]: {
+      [STYLE_DESCRIPTION]: {
         fontSize: 10,
         italics: true
       },
-      [BOLD]: {
+      [STYLE_BOLD]: {
         bold: true
       }
-    },
-    content: [
-      header('Stakeholders'),
-      {
-        alignment: 'center',
-        columns: stakeholdersHeader
-      },
-      header('Materials'),
-      ...tables,
-      header('Signatures'),
-      signatures
-    ],
-    defaultStyle: {
-      font: 'Helvetica'
     }
   };
   const printer = new PdfPrinter(FONTS);

--- a/apps/backend-functions/src/pdf.ts
+++ b/apps/backend-functions/src/pdf.ts
@@ -1,9 +1,34 @@
 /**
  * Deals with PDF exports for various parts of the application.
  */
+import { groupBy, sortBy } from 'lodash';
+
 const PdfPrinter = require('pdfmake');
 
-type DeliveryContent = any;
+interface StakeHolder {
+  name: string;
+  organization: string;
+}
+
+interface Step {
+  name: string;
+  date: Date;
+}
+
+interface Material {
+  value: string;
+  category: string;
+  description: string;
+  id: string;
+  stepId: string;
+}
+
+interface DeliveryContent {
+  txID: { [stakeholderID: string]: string };
+  stakeholders: { [stakeholderID: string]: StakeHolder };
+  steps: { [id: string]: Step };
+  materials: Material[];
+}
 
 const FONTS = {
   Helvetica: {
@@ -14,43 +39,112 @@ const FONTS = {
   }
 };
 
-export function buildDeliveryPDF(content: DeliveryContent) {
-  let header: any = content.stakeholders.map((x: any) => [
-    { text: x.name },
-    { text: x.organization }
-  ]);
+const HEADER = 'header';
+const SUBHEADER = 'subheader';
+const DESCRIPTION = 'description';
+const BOLD = 'bold';
 
-  if (content.txID) {
-    header = [{ qr: content.txID }, ...header];
+const withStyle = (text: string, style: string): any => ({
+  text,
+  style
+});
+
+const header = (text: string) => withStyle(text, HEADER);
+const subHeader = (text: string) => withStyle(text, SUBHEADER);
+const description = (text: string) => withStyle(text, DESCRIPTION);
+const bold = (text: string) => withStyle(text, BOLD);
+
+const center = (content: string | { [k: string]: any }): any => {
+  if (typeof content === typeof 'string') {
+    return { text: content, alignment: 'center' };
+  } else {
+    // @ts-ignore: TODO: debug this switch
+    return { ...content, alignment: 'center' };
   }
+};
 
-  const materials: any = content.materials.map((x: any) => ['A', x.name, '20 July 2019']);
+export function buildDeliveryPDF({ txID, stakeholders, materials, steps }: DeliveryContent) {
+  // We store keys first to make sure order is preserved along the way
+  const stakeholdersId = Object.keys(stakeholders);
+  const stakeholdersHeader: any = stakeholdersId.map((id: string) => {
+    const stakeholder = stakeholders[id];
+    return [subHeader(stakeholder.name), description(stakeholder.organization)];
+  });
+
+  const materialsPerCategory = groupBy(materials, (material: Material) => material.category);
+  const categories = sortBy(Object.keys(materialsPerCategory));
+
+  const tables: any = [];
+  categories.forEach(category => {
+    // NOTE: pdfmake side-effect over the data provided, we can reuse the same objects
+    // multiple time, we have to keep this variable definition INSIDE the forEach.
+    const tableHeader = [bold('material'), center(bold('step'))];
+
+    tables.push(subHeader(category));
+
+    const tableBody = materialsPerCategory[category].map(material => [
+      [bold(material.value), description(material.description)],
+      center({
+        text: material.stepId ? steps[material.stepId].name : '',
+        margin: [0, 4, 0, 0]
+      })
+    ]);
+
+    tables.push({
+      style: 'materialsTable',
+      table: {
+        headerRows: 1,
+        widths: ['80%', '20%'],
+        body: [[...tableHeader], ...tableBody]
+      }
+    });
+  });
+
+  const signatures = {
+    alignment: 'center',
+    columns: stakeholdersId.map((id: string) => {
+      const stakeholder = stakeholders[id];
+      const tx = txID[id];
+
+      return [bold(stakeholder.name), { qr: tx, fit: '100' }];
+    })
+  };
+
+  //const materials: any = materials.map((x: any) => ['A', x.name, '20 July 2019']);
 
   const docDefinition = {
     styles: {
       materialsTable: {
         margin: [5, 5, 5, 5]
       },
-      header: {
+      [HEADER]: {
         fontSize: 18,
+        bold: true,
+        margin: [5, 20, 5, 5]
+      },
+      [SUBHEADER]: {
+        fontSize: 14,
+        bold: true,
+        margin: [5, 10, 5, 5]
+      },
+      [DESCRIPTION]: {
+        fontSize: 10,
+        italics: true
+      },
+      [BOLD]: {
         bold: true
       }
     },
     content: [
-      { text: 'Stakeholders', style: 'header' },
+      header('Stakeholders'),
       {
-        alignment: 'justify',
-        columns: header
+        alignment: 'center',
+        columns: stakeholdersHeader
       },
-      { text: 'Materials', style: 'header' },
-      {
-        style: 'materialsTable',
-        table: {
-          headerRows: 1,
-          widths: [40, '*', 140],
-          body: [['A', 'Name', 'Due Date'], ...materials]
-        }
-      }
+      header('Materials'),
+      ...tables,
+      header('Signatures'),
+      signatures
     ],
     defaultStyle: {
       font: 'Helvetica'

--- a/apps/backend-functions/src/pdf.ts
+++ b/apps/backend-functions/src/pdf.ts
@@ -1,24 +1,21 @@
 /**
  * Deals with PDF exports for various parts of the application.
+ *
+ * Designed to work both locally (for demo, testing & debugging)
+ * and in a firebase function.
  */
 import { groupBy, sortBy, isEmpty } from 'lodash';
-import {
-  asIDMap,
-  Delivery,
-  getCollection,
-  getDocument,
-  IDMap,
-  Material,
-  Organization,
-  Stakeholder,
-  Step
-} from './utils';
+import { asIDMap, Delivery, IDMap, Material, Organization, Stakeholder, Step } from './data/types';
+import { getCollection, getDocument } from './data/internals';
 
 const PdfPrinter = require('pdfmake');
 
 // Types
 // =====
 
+/**
+ * Internal type expected by the pdf generation for delivery.
+ */
 interface DeliveryContent {
   txID: { [stakeholderID: string]: string };
   orgs: IDMap<Organization>;
@@ -191,7 +188,7 @@ export async function onGenerateDeliveryPDFRequest(req: any, resp: any) {
 
   // TODO: factor out the data layer
   const delivery = await getDocument<Delivery>(`deliveries/${deliveryId}`);
-  const stakeholders = await getCollection<Stakeholder>(`deliveries/${deliveryId}/stakeholders`)
+  const stakeholders = await getCollection<Stakeholder>(`deliveries/${deliveryId}/stakeholders`);
 
   const orgs = await Promise.all(
     stakeholders.map(stk => getDocument<Organization>(`orgs/${stk.orgId}`))

--- a/apps/backend-functions/src/pdf.ts
+++ b/apps/backend-functions/src/pdf.ts
@@ -1,0 +1,61 @@
+/**
+ * Deals with PDF exports for various parts of the application.
+ */
+const PdfPrinter = require('pdfmake');
+
+type DeliveryContent = any;
+
+const FONTS = {
+  Helvetica: {
+    normal: 'Helvetica',
+    bold: 'Helvetica-Bold',
+    italics: 'Helvetica-Oblique',
+    bolditalics: 'Helvetica-BoldOblique'
+  }
+};
+
+export function buildDeliveryPDF(content: DeliveryContent) {
+  let header: any = content.stakeholders.map((x: any) => [
+    { text: x.name },
+    { text: x.organization }
+  ]);
+
+  if (content.txID) {
+    header = [{ qr: content.txID }, ...header];
+  }
+
+  const materials: any = content.materials.map((x: any) => ['A', x.name, '20 July 2019']);
+
+  const docDefinition = {
+    styles: {
+      materialsTable: {
+        margin: [5, 5, 5, 5]
+      },
+      header: {
+        fontSize: 18,
+        bold: true
+      }
+    },
+    content: [
+      { text: 'Stakeholders', style: 'header' },
+      {
+        alignment: 'justify',
+        columns: header
+      },
+      { text: 'Materials', style: 'header' },
+      {
+        style: 'materialsTable',
+        table: {
+          headerRows: 1,
+          widths: [40, '*', 140],
+          body: [['A', 'Name', 'Due Date'], ...materials]
+        }
+      }
+    ],
+    defaultStyle: {
+      font: 'Helvetica'
+    }
+  };
+  const printer = new PdfPrinter(FONTS);
+  return printer.createPdfKitDocument(docDefinition);
+}

--- a/apps/backend-functions/src/stakeholder.ts
+++ b/apps/backend-functions/src/stakeholder.ts
@@ -3,13 +3,15 @@ import { prepareNotification, triggerNotifications, customMessage } from './noti
 import {
   getDocument,
   getCount,
+  getOrgsOfDocument
+} from './data/internals';
+import {
   Delivery,
   DocID,
   Organization,
   Movie,
   SnapObject,
-  getOrgsOfDocument
-} from './utils';
+} from './data/types';
 
 export async function onDeliveryStakeholderCreate(
   snap: FirebaseFirestore.DocumentSnapshot,

--- a/apps/backend-functions/src/utils.ts
+++ b/apps/backend-functions/src/utils.ts
@@ -1,5 +1,6 @@
-import { db, functions } from './firebase';
+import { functions } from './firebase';
 import * as backup from './backup';
+import { Material } from './data/types';
 
 ///////////////
 // VARIABLES //
@@ -8,123 +9,6 @@ import * as backup from './backup';
 // String refers to svg icon name
 export const APP_DELIVERY_ICON = 'media_delivering';
 export const APP_MOVIE_ICON = 'media_financiers';
-
-////////////////
-// INTERFACES //
-////////////////
-
-// TODO: Figure out how we can access our front models
-
-export interface IDMap<T> {
-  [id: string]: T;
-}
-
-export interface Organization {
-  id: string;
-  userIds: string[];
-  name: string;
-  address: string;
-}
-
-export interface Stakeholder {
-  id: string;
-  orgId: string;
-}
-
-export interface Step {
-  id: string;
-  date: Date;
-  name: string;
-}
-
-export interface Delivery {
-  id: string;
-  movieId: string;
-  processedId: string;
-  stakeholders: string[];
-  materials: string[];
-  steps: Step[];
-}
-
-export interface Movie {
-  id: string;
-  title: {
-    original: string;
-  };
-}
-
-export interface Material {
-  id: string;
-  value: string;
-  description: string;
-  category: string;
-  deliveriesIds: string[];
-  state: string;
-  stepId: string;
-}
-
-export interface SnapObject {
-  movie: Movie;
-  docID: DocID;
-  org: Organization;
-  eventType: string;
-  delivery?: Delivery | null;
-  newStakeholderId?: string;
-  count?: number;
-}
-
-export interface DocID {
-  id: string;
-  type: 'movie' | 'delivery' | 'material';
-}
-
-interface DocWithID {
-  id: string;
-}
-
-export function asIDMap<T extends DocWithID>(items: T[]): IDMap<T> {
-  const result: IDMap<T> = {};
-
-  items.forEach(item => {
-    result[item.id] = item;
-  });
-
-  return result;
-}
-
-////////////////////////////////////
-// COLLECTIONS & DOCUMENT GETTERS //
-////////////////////////////////////
-
-export async function getCollection<T>(path: string): Promise<T[]> {
-  return db
-    .collection(path)
-    .get()
-    .then(collection => collection.docs.map(doc => doc.data() as T));
-}
-
-export async function getDocument<T>(path: string): Promise<T> {
-  return db
-    .doc(path)
-    .get()
-    .then(doc => doc.data() as T);
-}
-
-export async function getOrgsOfDocument(
-  documentId: string,
-  collection: string
-): Promise<Organization[]> {
-  const stakeholders = await getCollection<Stakeholder>(`${collection}/${documentId}/stakeholders`);
-  const promises = stakeholders.map(({ orgId }) => getDocument<Organization>(`orgs/${orgId}`));
-  return Promise.all(promises);
-}
-
-export function getCount(collection: string) {
-  return db
-    .collection(collection)
-    .get()
-    .then(col => col.size);
-}
 
 ///////////////////////////////////
 // DOCUMENT ON-CHANGES FUNCTIONS //

--- a/apps/backend-functions/src/utils.ts
+++ b/apps/backend-functions/src/utils.ts
@@ -1,4 +1,4 @@
-import { db, functions } from "./firebase";
+import { db, functions } from './firebase';
 import * as backup from './backup';
 
 ///////////////
@@ -15,10 +15,15 @@ export const APP_MOVIE_ICON = 'media_financiers';
 
 // TODO: Figure out how we can access our front models
 
+export interface IDMap<T> {
+  [id: string]: T;
+}
+
 export interface Organization {
   id: string;
   userIds: string[];
   name: string;
+  address: string;
 }
 
 export interface Stakeholder {
@@ -26,16 +31,25 @@ export interface Stakeholder {
   orgId: string;
 }
 
+export interface Step {
+  id: string;
+  date: Date;
+  name: string;
+}
+
 export interface Delivery {
   id: string;
   movieId: string;
   processedId: string;
+  stakeholders: string[];
+  materials: string[];
+  steps: Step[];
 }
 
 export interface Movie {
   id: string;
   title: {
-    original: string
+    original: string;
   };
 }
 
@@ -46,6 +60,7 @@ export interface Material {
   category: string;
   deliveriesIds: string[];
   state: string;
+  stepId: string;
 }
 
 export interface SnapObject {
@@ -59,8 +74,22 @@ export interface SnapObject {
 }
 
 export interface DocID {
-  id: string,
-  type : 'movie' | 'delivery' | 'material'
+  id: string;
+  type: 'movie' | 'delivery' | 'material';
+}
+
+interface DocWithID {
+  id: string;
+}
+
+export function asIDMap<T extends DocWithID>(items: T[]): IDMap<T> {
+  const result: IDMap<T> = {};
+
+  items.forEach(item => {
+    result[item.id] = item;
+  });
+
+  return result;
 }
 
 ////////////////////////////////////
@@ -81,14 +110,20 @@ export async function getDocument<T>(path: string): Promise<T> {
     .then(doc => doc.data() as T);
 }
 
-export async function getOrgsOfDocument(documentId: string, collection: string): Promise<Organization[]> {
+export async function getOrgsOfDocument(
+  documentId: string,
+  collection: string
+): Promise<Organization[]> {
   const stakeholders = await getCollection<Stakeholder>(`${collection}/${documentId}/stakeholders`);
   const promises = stakeholders.map(({ orgId }) => getDocument<Organization>(`orgs/${orgId}`));
   return Promise.all(promises);
 }
 
 export function getCount(collection: string) {
-  return db.collection(collection).get().then(col => col.size)
+  return db
+    .collection(collection)
+    .get()
+    .then(col => col.size);
 }
 
 ///////////////////////////////////

--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,10 @@
         "destination": "/ip-upload/index.html"
       },
       {
+        "source": "/delivery/contract.pdf",
+        "function": "generateDeliveryPDF"
+      },
+      {
         "source": "/delivery{,/**}",
         "destination": "/delivery/index.html"
       },

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.html
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.html
@@ -30,7 +30,7 @@
         class="download-delivery-contract mat-elevation-z0"
         mat-raised-button
         target="_blank"
-        attr.href="{{ deliveryContractURL | async }}"
+        [href]="deliveryContractURL$ | async"
       >
         Download Contract
         <mat-icon class="icon">cloud_download</mat-icon>

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.html
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.html
@@ -21,6 +21,22 @@
       </button>
     </article>
     <article
+      *ngIf="(isDeliveryValidated$ | async)"
+      class="container-button"
+      fxLayout="row"
+      fxLayoutAlign="center center"
+    >
+      <a
+        class="download-delivery-contract mat-elevation-z0"
+        mat-raised-button
+        target="_blank"
+        attr.href="{{ deliveryContractURL | async }}"
+      >
+        Download Contract
+        <mat-icon class="icon">cloud_download</mat-icon>
+      </a>
+    </article>
+    <article
       *ngIf="!(isDeliveryValidated$ | async)"
       class="container-button"
       fxLayout="row"

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.scss
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.scss
@@ -58,6 +58,12 @@ section {
   border: solid 1px var(--primary);
 }
 
+.download-delivery-contract {
+  @extend .save-template;
+  border-radius: 0;
+
+}
+
 .save-template:hover:enabled {
   background-color: var(--primary);
   color: #FFFFFF;

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
@@ -151,7 +151,7 @@ export class DeliveryEditableComponent implements OnInit {
     this.service.signDelivery();
   }
 
-  public get deliveryContractURL(): Observable<string> {
+  public get deliveryContractURL$(): Observable<string> {
     return this.delivery$.pipe(
       map(({id}) => `/delivery/contract.pdf?deliveryId=${id}`)
     )

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
@@ -12,6 +12,7 @@ import { MovieQuery, Movie } from '@blockframes/movie';
 import { DeliveryQuery, Delivery } from '../../+state';
 import { ConfirmComponent } from '@blockframes/ui';
 import { applyTransaction } from '@datorama/akita';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'delivery-editable',
@@ -148,5 +149,11 @@ export class DeliveryEditableComponent implements OnInit {
 
   public signDelivery() {
     this.service.signDelivery();
+  }
+
+  public get deliveryContractURL(): Observable<string> {
+    return this.delivery$.pipe(
+      map(x => `/delivery/contract.pdf?deliveryId=${x.id}`)
+    )
   }
 }

--- a/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
+++ b/libs/material/src/lib/delivery/pages/delivery-editable/delivery-editable.component.ts
@@ -153,7 +153,7 @@ export class DeliveryEditableComponent implements OnInit {
 
   public get deliveryContractURL(): Observable<string> {
     return this.delivery$.pipe(
-      map(x => `/delivery/contract.pdf?deliveryId=${x.id}`)
+      map(({id}) => `/delivery/contract.pdf?deliveryId=${id}`)
     )
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4800,8 +4800,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -5072,7 +5071,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
       "integrity": "sha1-dJRAWIh9goPhidlUYAlHvJj+AGI=",
-      "dev": true,
       "requires": {
         "escodegen": "~1.2.0",
         "esprima": "~1.0.4",
@@ -5083,7 +5081,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
           "integrity": "sha1-Cd55Z3kcyVi3+Jot220jRRrzJ+E=",
-          "dev": true,
           "requires": {
             "esprima": "~1.0.4",
             "estraverse": "~1.5.0",
@@ -5094,26 +5091,22 @@
         "esprima": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-          "dev": true
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
         },
         "estraverse": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=",
-          "dev": true
+          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
         },
         "esutils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=",
-          "dev": true
+          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
           "optional": true,
           "requires": {
             "amdefine": ">=0.0.4"
@@ -5124,8 +5117,7 @@
     "ast-types": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
-      "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
-      "dev": true
+      "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -5343,7 +5335,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -5648,7 +5639,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
       "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
-      "dev": true,
       "requires": {
         "quote-stream": "^1.0.1",
         "resolve": "^1.1.5",
@@ -5660,7 +5650,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -5677,7 +5666,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
       "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
-      "dev": true,
       "requires": {
         "base64-js": "^1.1.2"
       }
@@ -5692,7 +5680,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -5700,8 +5687,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -5746,7 +5732,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.1.tgz",
       "integrity": "sha1-HhNyLP3g2F8SFnbCpyztUzoBiGk=",
-      "dev": true,
       "requires": {
         "ast-transform": "0.0.0",
         "ast-types": "^0.7.0",
@@ -5836,8 +5821,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
-      "dev": true
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -6639,7 +6623,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -6812,8 +6795,7 @@
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
-      "dev": true
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -7122,8 +7104,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "2.2.1",
@@ -7307,7 +7288,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.1.0.tgz",
       "integrity": "sha1-0wIYvRDQMPpCHfPrvIIoVGOjF4E=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.11.6"
       }
@@ -7415,7 +7395,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
       }
@@ -7614,7 +7593,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
-      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -7626,14 +7604,12 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -7666,8 +7642,7 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "estree-walker": {
       "version": "0.6.1",
@@ -7678,8 +7653,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -8098,7 +8072,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
-      "dev": true,
       "requires": {
         "acorn": "^5.0.0",
         "foreach": "^2.0.5",
@@ -8109,14 +8082,12 @@
         "acorn": {
           "version": "5.7.3",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
@@ -8133,8 +8104,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-text-encoding": {
       "version": "1.0.0",
@@ -8573,7 +8543,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.8.0.tgz",
       "integrity": "sha512-EFDRCca7khfQWYu1iFhsqeABpi87f03MBdkT93ZE6YhqCdMzb5Eojb6c4dlJikGv5liuhByyzA7ikpIPTSBWbQ==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.11.6",
         "brfs": "^1.4.0",
@@ -8591,8 +8560,7 @@
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         }
       }
     },
@@ -8613,8 +8581,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -9207,8 +9174,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -21799,7 +21765,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -24107,7 +24072,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -24132,7 +24096,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-0.3.0.tgz",
       "integrity": "sha1-BSZICmLAW9Z58+nZmDDgnGp9DtY=",
-      "dev": true,
       "requires": {
         "base64-js": "0.0.8",
         "brfs": "^1.3.0",
@@ -24142,8 +24105,7 @@
         "base64-js": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-          "dev": true
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
         }
       }
     },
@@ -24797,7 +24759,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
       "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-      "dev": true,
       "requires": {
         "source-map": "^0.5.6"
       },
@@ -24805,8 +24766,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -28717,14 +28677,12 @@
     "object-inspect": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-      "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
-      "dev": true
+      "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -28853,7 +28811,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -28866,8 +28823,7 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -29297,6 +29253,37 @@
         "saslprep": "1.0.1"
       }
     },
+    "pdfmake": {
+      "version": "0.1.57",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.57.tgz",
+      "integrity": "sha512-s6Bs71Ylh06yNgJfP61xicHZSEvFrwo8lvI/BOU4+6eDddO8lwOZi5A42RA0V8zQr6hrI1XYxtLkk/7oJ+5w+w==",
+      "requires": {
+        "iconv-lite": "^0.4.24",
+        "linebreak": "^0.3.0",
+        "pdfkit": "^0.10.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "pdfkit": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.10.0.tgz",
+          "integrity": "sha512-mRJ6iuDzpIQ4ftKp5GvijLXNVRK86xjnyIPBraYSPrUPubNqWM5/oYmc7FZKUWz3wusRTj3PLR9HJ1X5ooqfsg==",
+          "requires": {
+            "crypto-js": "^3.1.9-1",
+            "fontkit": "^1.0.0",
+            "linebreak": "^0.3.0",
+            "png-js": ">=0.1.0"
+          }
+        }
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -29373,8 +29360,7 @@
     "png-js": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
-      "integrity": "sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM=",
-      "dev": true
+      "integrity": "sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM="
     },
     "pnglib": {
       "version": "0.0.1",
@@ -29480,8 +29466,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -29716,7 +29701,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
       "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
-      "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
         "minimist": "^1.1.3",
@@ -29726,14 +29710,12 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "through2": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -29990,8 +29972,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -30237,7 +30218,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-0.5.4.tgz",
       "integrity": "sha1-9U591WNZD7NP1r9Vh2EJrsyyjeg=",
-      "dev": true,
       "requires": {
         "browserify-optional": "^1.0.0"
       }
@@ -30707,8 +30687,7 @@
     "shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
-      "dev": true
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -31450,7 +31429,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
       "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dev": true,
       "requires": {
         "escodegen": "^1.8.1"
       }
@@ -31478,7 +31456,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
       "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
-      "dev": true,
       "requires": {
         "concat-stream": "~1.6.0",
         "convert-source-map": "^1.5.1",
@@ -31500,7 +31477,6 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
           "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-          "dev": true,
           "requires": {
             "esprima": "^3.1.3",
             "estraverse": "^4.2.0",
@@ -31512,14 +31488,12 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "magic-string": {
           "version": "0.22.5",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-          "dev": true,
           "requires": {
             "vlq": "^0.2.2"
           }
@@ -31528,14 +31502,12 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         },
         "through2": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -31967,8 +31939,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "3.0.1",
@@ -31996,8 +31967,7 @@
     "tiny-inflate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz",
-      "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c=",
-      "dev": true
+      "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c="
     },
     "tmp": {
       "version": "0.0.33",
@@ -32301,7 +32271,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -32356,7 +32325,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.1.0.tgz",
       "integrity": "sha1-epbu9J91aC6mnSMV7smsQ//fAME=",
-      "dev": true,
       "requires": {
         "brfs": "^1.4.0",
         "unicode-trie": "^0.3.0"
@@ -32366,7 +32334,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
       "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
-      "dev": true,
       "requires": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
@@ -32375,8 +32342,7 @@
         "pako": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-          "dev": true
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         }
       }
     },
@@ -32685,8 +32651,7 @@
     "vlq": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-      "dev": true
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "vm-browserify": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4304,6 +4304,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/pdfmake": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.1.7.tgz",
+      "integrity": "sha512-UEfT5yAnydLwrEWGuAq+lw2K6uyd6fDtBh3R/1/oLRHHjahmiduWmTU+zBM7ZygCSUg7URg69o41vbEXGZ62Yw==",
+      "dev": true
+    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ngx-mat-select-search": "^1.7.2",
     "node-gyp": "^4.0.0",
     "npm": "^6.9.0",
+    "pdfmake": "^0.1.57",
     "punycode": "^2.1.1",
     "request": "^2.88.0",
     "rxjs": "~6.5.2",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@types/line-reader": "0.0.28",
     "@types/lodash": "^4.14.123",
     "@types/node": "~10.12.23",
+    "@types/pdfmake": "^0.1.7",
     "@types/tmp": "0.0.34",
     "akita-schematics": "^2.0.0",
     "codelyzer": "~4.5.0",


### PR DESCRIPTION
- [x] Add basics to generate the PDF contract for a delivery,
- [x] Add a "download delivery" button in the delivery once it has been sealed.
- [x] Introduce the first step of a data SoC refactoring to avoid complexity explosion, and move towards a unified backend-frontend data layer.

Contributes to #534 next steps are blocked by other tasks, details in the linked issue.