### PR TITLE
One transaction movie

### DIFF
--- a/libs/material/src/lib/delivery/+state/delivery.query.ts
+++ b/libs/material/src/lib/delivery/+state/delivery.query.ts
@@ -86,8 +86,8 @@ export class DeliveryQuery extends QueryEntity<DeliveryState, Delivery> {
 
   /** Find the stakeholder from the movie and logged user organizations */
   public findActiveStakeholder() {
-    const currentOrgId = this.organizationQuery.getValue().org.id;
+    const organizationId = this.organizationQuery.getValue().org.id;
     const stakeholders = this.movieQuery.getActive().stakeholders;
-    return stakeholders.find(({id}) => id === currentOrgId);
+    return stakeholders.find(({id}) => id === organizationId);
   }
 }

--- a/libs/material/src/lib/delivery/+state/delivery.query.ts
+++ b/libs/material/src/lib/delivery/+state/delivery.query.ts
@@ -88,6 +88,6 @@ export class DeliveryQuery extends QueryEntity<DeliveryState, Delivery> {
   public findActiveStakeholder() {
     const currentOrgId = this.organizationQuery.getValue().org.id;
     const stakeholders = this.movieQuery.getActive().stakeholders;
-    return stakeholders.find(({orgId}) => orgId === currentOrgId);
+    return stakeholders.find(({id}) => id === currentOrgId);
   }
 }

--- a/libs/material/src/lib/delivery/+state/delivery.service.ts
+++ b/libs/material/src/lib/delivery/+state/delivery.service.ts
@@ -86,17 +86,17 @@ export class DeliveryService {
    */
   public async addDelivery(templateId?: string) {
     const id = this.db.createId();
-    const org = this.organizationQuery.getValue().org;
+    const organization = this.organizationQuery.getValue().org;
     const movieId = this.movieQuery.getActiveId();
     const delivery = createDelivery({ id, movieId, validated: [] });
     const deliveryStakeholder = this.makeDeliveryStakeholder(
-      org.id,
+      organization.id,
       ['canValidateDelivery'],
       true
     );
 
     // Create document permissions
-    await this.permissionsService.createDocAndPermissions(delivery, org);
+    await this.permissionsService.createDocAndPermissions(delivery, organization);
 
     const promises = [];
 
@@ -120,15 +120,15 @@ export class DeliveryService {
   public async addDeliveryWithMovieMaterials() {
     const movie = this.movieQuery.getActive();
     const id = this.db.createId();
-    const org = this.organizationQuery.getValue().org;
+    const organization = this.organizationQuery.getValue().org;
     const delivery = createDelivery({ id, movieId: movie.id, validated: [] });
     const deliveryStakeholder = this.makeDeliveryStakeholder(
-      org.id,
+      organization.id,
       ['canValidateDelivery'],
       true
     );
 
-    await this.permissionsService.createDocAndPermissions(delivery, org);
+    await this.permissionsService.createDocAndPermissions(delivery, organization);
 
     await Promise.all([
       this.copyMaterials(delivery, movie),
@@ -196,11 +196,11 @@ export class DeliveryService {
   /** Sign array validated of delivery with stakeholder logged */
   public signDelivery() {
     const delivery = this.query.getActive();
-    const orgIdsOfUser = this.organizationQuery.getValue().org.id;
+    const organizationId = this.organizationQuery.getValue().org.id;
     const { validated } = delivery;
     const { stakeholders } = delivery;
 
-    const stakeholderSignee = stakeholders.find(({ id }) => orgIdsOfUser.includes(id));
+    const stakeholderSignee = stakeholders.find(({ id }) => organizationId === id);
 
     if (!validated.includes(stakeholderSignee.id)) {
       const updatedValidated = [...validated, stakeholderSignee.id];

--- a/libs/material/src/lib/delivery/components/delivery-sign/delivery-sign.component.ts
+++ b/libs/material/src/lib/delivery/components/delivery-sign/delivery-sign.component.ts
@@ -43,7 +43,7 @@ export class DeliverySignComponent {
     this.loading = true;
     const delivery = this.deliveryQuery.getActive();
     const orgIdsOfUser = this.organizationQuery.getValue().org.id;
-    const stakeholderId = delivery.stakeholders.find(({ orgId }) => orgIdsOfUser.includes(orgId)).id;
+    const stakeholderId = delivery.stakeholders.find(({ id }) => orgIdsOfUser.includes(id)).id;
     // await this.service.signDelivery(delivery.id, stakeholderId);// TODO WALLET SERVICE ISSUE #315, make this logic in delivery-editable
 
     this.sign();

--- a/libs/material/src/lib/delivery/components/delivery-sign/delivery-sign.component.ts
+++ b/libs/material/src/lib/delivery/components/delivery-sign/delivery-sign.component.ts
@@ -42,8 +42,8 @@ export class DeliverySignComponent {
   public async confirm() {
     this.loading = true;
     const delivery = this.deliveryQuery.getActive();
-    const orgIdsOfUser = this.organizationQuery.getValue().org.id;
-    const stakeholderId = delivery.stakeholders.find(({ id }) => orgIdsOfUser.includes(id)).id;
+    const organizationId = this.organizationQuery.getValue().org.id;
+    const stakeholderId = delivery.stakeholders.find(({ id }) => organizationId === id);
     // await this.service.signDelivery(delivery.id, stakeholderId);// TODO WALLET SERVICE ISSUE #315, make this logic in delivery-editable
 
     this.sign();

--- a/libs/material/src/lib/delivery/guards/delivery-active.guard.ts
+++ b/libs/material/src/lib/delivery/guards/delivery-active.guard.ts
@@ -9,7 +9,7 @@ export const deliveryActiveQuery = (deliveryId: string): Query<DeliveryDB> => ({
   stakeholders: delivery => ({
     path: `deliveries/${delivery.id}/stakeholders`,
     organization: stakeholder => ({
-      path: `orgs/${stakeholder.orgId}`
+      path: `orgs/${stakeholder.id}`
     })
   })
 });

--- a/libs/material/src/lib/delivery/guards/delivery-list.guard.ts
+++ b/libs/material/src/lib/delivery/guards/delivery-list.guard.ts
@@ -12,7 +12,7 @@ const deliveryQuery = (movieId: string): Query<DeliveryDB[]> => ({
   stakeholders: delivery => ({
     path: `deliveries/${delivery.id}/stakeholders`,
     organization: stakeholder => ({
-      path: `orgs/${stakeholder.orgId}`
+      path: `orgs/${stakeholder.id}`
     })
   })
 });

--- a/libs/material/src/lib/template/+state/template.service.ts
+++ b/libs/material/src/lib/template/+state/template.service.ts
@@ -27,7 +27,7 @@ export class TemplateService {
     });
 
     // Create document permissions
-    await this.permissionsService.createDocAndPermissions(template, org.id);
+    await this.permissionsService.createDocAndPermissions(template, org);
 
     // Push the new id in org.templateIds
     await this.db

--- a/libs/material/src/lib/template/+state/template.service.ts
+++ b/libs/material/src/lib/template/+state/template.service.ts
@@ -13,41 +13,41 @@ export class TemplateService {
     private query: TemplateQuery,
     private store: TemplateStore,
     private materialQuery: MaterialQuery,
-    private orgQuery: OrganizationQuery,
+    private organizationQuery: OrganizationQuery,
     private permissionsService: PermissionsService
   ) {}
 
   public async addTemplate(templateName: string): Promise<string> {
     const templateId = this.db.createId();
-    const org = this.orgQuery.getValue().org;
+    const organization = this.organizationQuery.getValue().org;
     const template = createTemplate({
       id: templateId,
       name: templateName,
-      orgId: org.id
+      orgId: organization.id
     });
 
     // Create document permissions
-    await this.permissionsService.createDocAndPermissions(template, org);
+    await this.permissionsService.createDocAndPermissions(template, organization);
 
-    // Push the new id in org.templateIds
+    // Push the new id in organization.templateIds
     await this.db
-      .doc<Organization>(`orgs/${org.id}`)
-      .update({ templateIds: [...org.templateIds, templateId] });
+      .doc<Organization>(`orgs/${organization.id}`)
+      .update({ templateIds: [...organization.templateIds, templateId] });
 
     return templateId;
   }
 
   public deleteTemplate(templateId: string): Promise<void> {
-    const org = this.orgQuery.getValue().org;
-    const templateIds = org.templateIds.filter(id => id !== templateId);
-    const orgDoc = this.db.doc<Organization>(`orgs/${org.id}`);
+    const organization = this.organizationQuery.getValue().org;
+    const templateIds = organization.templateIds.filter(id => id !== templateId);
+    const organizationDoc = this.db.doc<Organization>(`orgs/${organization.id}`);
     const templateDoc = this.db.doc<Template>(`templates/${templateId}`);
 
     const batch = this.db.firestore.batch();
     // Delete the template from the templates collection
     batch.delete(templateDoc.ref);
     // Delete templateId from org.templateIds
-    batch.update(orgDoc.ref, { templateIds });
+    batch.update(organizationDoc.ref, { templateIds });
     // Remove the template from the templates store
     this.store.remove(templateId);
 
@@ -94,10 +94,10 @@ export class TemplateService {
 
   /** Update template with delivery's materials */
   public async updateTemplate(name: string) {
-    const currentOrgId = this.orgQuery.getValue().org.id;
+    const organizationId = this.organizationQuery.getValue().org.id;
     const template = this.query
       .getAll()
-      .find(entity => entity.name === name && entity.orgId === currentOrgId);
+      .find(entity => entity.name === name && entity.orgId === organizationId);
     const templateMaterials = await this.db.snapshot<any>(`templates/${template.id}/materials`);
     const deliveryMaterials = this.materialQuery.getAll();
     if (deliveryMaterials.length > 0) {
@@ -119,7 +119,7 @@ export class TemplateService {
   }
 
   /** Check if name is already used in an already template */
-  public nameExists(name: string, org: Organization) {
-    return this.query.hasEntity(entity => entity.name === name && entity.orgId === org.id);
+  public nameExists(name: string, organization: Organization) {
+    return this.query.hasEntity(entity => entity.name === name && entity.orgId === organization.id);
   }
 }

--- a/libs/material/src/lib/template/guards/template-list.guard.ts
+++ b/libs/material/src/lib/template/guards/template-list.guard.ts
@@ -16,7 +16,7 @@ export class TemplateListGuard extends StateListGuard<Template> {
 
   constructor(
     private fireQuery: FireQuery,
-    private orgQuery: OrganizationQuery,
+    private organizationQuery: OrganizationQuery,
     store: TemplateStore,
     router: Router
   ) {
@@ -24,7 +24,7 @@ export class TemplateListGuard extends StateListGuard<Template> {
   }
 
   get query() {
-    return this.orgQuery
+    return this.organizationQuery
       .select(state => state.org.templateIds)
       .pipe(
         switchMap(ids => {

--- a/libs/movie/src/lib/movie/+state/movie.model.ts
+++ b/libs/movie/src/lib/movie/+state/movie.model.ts
@@ -16,7 +16,7 @@ export interface MovieAvailability {
 export interface Movie {
   _type: 'movies',
   id: string,
-  org?: Organization,
+  organization?: Organization,
   title: Title, // will contain all titles: original, international, suiss, etc
   directorName: string,
   poster: string,

--- a/libs/movie/src/lib/movie/+state/movie.service.ts
+++ b/libs/movie/src/lib/movie/+state/movie.service.ts
@@ -12,36 +12,33 @@ export class MovieService {
   constructor(
   private db: FireQuery,
   private shService: StakeholderService,
-  private orgQuery: OrganizationQuery,
+  private organizationQuery: OrganizationQuery,
   private permissionsService: PermissionsService,
   private store: MovieStore,
   ) {}
 
   public async addMovie(original: string): Promise<Movie> {
     const id = this.db.createId();
-    const org = this.orgQuery.getValue().org;
-    const orgDoc = this.db.doc<Organization>(`orgs/${org.id}`);
+    const organization = this.organizationQuery.getValue().org;
+    const organizationDoc = this.db.doc<Organization>(`orgs/${organization.id}`);
     const movie: Movie = createMovie({ id, title: { original }});
 
     await this.db.firestore.runTransaction(async (tx: firebase.firestore.Transaction) => {
-      const orgSnap = await tx.get(orgDoc.ref);
-      const movieIds = orgSnap.data().movieIds || [];
+      const organizationSnap = await tx.get(organizationDoc.ref);
+      const movieIds = organizationSnap.data().movieIds || [];
 
       // Create movie document and permissions
-      await this.permissionsService.createDocAndPermissions<Movie>(movie, org);
+      await this.permissionsService.createDocAndPermissions<Movie>(movie, organization);
 
       // Create the first stakeholder in sub-collection
-      await this.shService.addStakeholder(movie, org, true);
+      await this.shService.addStakeholder(movie, organization, true);
 
-      // Update the org movieIds
+      // Update the organization movieIds
       if (movieIds.includes(movie.id)) {
-        return tx.update(orgDoc.ref, {}); // every document read in a transaction must be written.
+        return tx.update(organizationDoc.ref, {}); // every document read in a transaction must be written.
       }
       const nextMovieIds = [...movieIds, movie.id];
-
-      return Promise.all([
-        tx.update(orgDoc.ref, { movieIds: nextMovieIds })
-      ]);
+      tx.update(organizationDoc.ref, { movieIds: nextMovieIds })
 
     });
     return movie;
@@ -49,7 +46,7 @@ export class MovieService {
 
   public update(id: string, movie: any) : Promise<void>{
     // we don't want to keep orgId in our Movie object
-    if (movie.org) delete movie.org;
+    if (movie.organization) delete movie.organization;
     if (movie.stakeholders) delete movie.stakeholders;
     if (movie.errors) delete movie.errors;
 
@@ -57,18 +54,18 @@ export class MovieService {
   }
 
   public remove(movieId: string): Promise<void> {
-    const org = this.orgQuery.getValue().org;
-    const movieIds = org.movieIds.filter(id => id !== movieId);
-    const orgDoc = this.db.doc<Organization>(`orgs/${org.id}`);
+    const organization = this.organizationQuery.getValue().org;
+    const movieIds = organization.movieIds.filter(id => id !== movieId);
+    const organizationDoc = this.db.doc<Organization>(`orgs/${organization.id}`);
     const movieDoc = this.db.doc<Movie>(`movies/${movieId}`);
 
     const batch = this.db.firestore.batch();
     // Delete the movie in movies collection
     batch.delete(movieDoc.ref);
-    // Delete the movie id in org.movieIds
-    batch.update(orgDoc.ref, { movieIds });
+    // Delete the movie id in organization.movieIds
+    batch.update(organizationDoc.ref, { movieIds });
     // Remove the movie from the movies store
-    // TODO: Wait for firestore response before removing the movie.
+    // TODO: Wait for firestore response before removing the movie. => ISSUE#611
     this.store.remove(movieId);
 
     return batch.commit();

--- a/libs/movie/src/lib/movie/+state/movie.service.ts
+++ b/libs/movie/src/lib/movie/+state/movie.service.ts
@@ -31,7 +31,7 @@ export class MovieService {
       await this.permissionsService.createDocAndPermissions<Movie>(movie, org);
 
       // Create the first stakeholder in sub-collection
-      await this.shService.addStakeholder(movie.id, org, true);
+      await this.shService.addStakeholder(movie, org, true);
 
       // Update the org movieIds
       if (movieIds.includes(movie.id)) {

--- a/libs/movie/src/lib/movie/components/movie-title-form/movie-title-form.component.ts
+++ b/libs/movie/src/lib/movie/components/movie-title-form/movie-title-form.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MovieService, MovieQuery } from '../../+state';
+import { MovieService } from '../../+state';
 import { Router } from '@angular/router';
 
 @Component({
@@ -20,7 +20,6 @@ export class MovieTitleFormComponent implements OnInit {
     private builder: FormBuilder,
     private service: MovieService,
     private router: Router,
-    private movieQuery: MovieQuery,
   ) { }
 
   ngOnInit() {
@@ -38,14 +37,14 @@ export class MovieTitleFormComponent implements OnInit {
     try {
       const { title } = this.titleForm.value;
       this.snackBar.open('Movie created! Redirecting..', 'close', { duration: 3000 });
-      const movie = await this.service.add(title, true);
+      const movie = await this.service.addMovie(title);
 
       this.router.navigate([`/layout/o/home/${movie.id}/edit`]);
       this.dialogRef.close();
     }
     catch (err) {
       this.snackBar.open('An error occured', 'close', { duration: 1000 });
-      throw new Error('An error occured');
+      throw new Error(err);
     }
   }
 

--- a/libs/movie/src/lib/movie/guards/movie-active.guard.ts
+++ b/libs/movie/src/lib/movie/guards/movie-active.guard.ts
@@ -8,7 +8,7 @@ export const movieActiveQuery = (id: string): Query<Movie> => ({
   stakeholders: (movie: Movie) => ({
     path: `movies/${movie.id}/stakeholders`,
     organization: stakeholder => ({
-      path: `orgs/${stakeholder.orgId}`
+      path: `orgs/${stakeholder.id}`
     })
   })
 });

--- a/libs/movie/src/lib/movie/guards/movie-list.guard.ts
+++ b/libs/movie/src/lib/movie/guards/movie-list.guard.ts
@@ -16,7 +16,7 @@ export class MovieListGuard extends StateListGuard<Movie> {
 
   constructor(
     private fireQuery: FireQuery,
-    private orgQuery: OrganizationQuery,
+    private organizationQuery: OrganizationQuery,
     store: MovieStore,
     router: Router
   ) {
@@ -24,7 +24,7 @@ export class MovieListGuard extends StateListGuard<Movie> {
   }
 
   get query() {
-    return this.orgQuery
+    return this.organizationQuery
       .select(state => state.org.movieIds)
       .pipe(
         switchMap(ids => {

--- a/libs/movie/src/lib/stakeholder/+state/stakeholder.model.ts
+++ b/libs/movie/src/lib/stakeholder/+state/stakeholder.model.ts
@@ -2,18 +2,16 @@ import { Organization } from "@blockframes/organization";
 
 export interface Stakeholder {
   id: string;
-  orgId: string;
   organization?: Organization;
+  authorizations?: string[];
   orgMovieRole: string;
   role: string
-  authorizations: string[];
   isAccepted: boolean;
 }
 
 export function createMovieStakeholder(params?: Partial<Stakeholder>) {
   if (params.organization) delete params.organization
   return {
-    authorizations: [],
     orgMovieRole: '',
     role: '',
     isAccepted: false,

--- a/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
+++ b/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
@@ -38,7 +38,7 @@ export class StakeholderRepertoryComponent implements OnInit, OnDestroy {
 
   public submit(org: Partial<Organization>) {
     // TODO: handle promises correctly (update loading status, send back error report, etc).
-    this.service.addStakeholder(this.movieQuery.getActiveId(), org);
+    this.service.addStakeholder(this.movieQuery.getActive(), org);
   }
 
   public displayFn(org?: Organization): string | undefined {

--- a/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
+++ b/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
@@ -36,11 +36,9 @@ export class StakeholderRepertoryComponent implements OnInit, OnDestroy {
     this.onChange();
   }
 
-  public submit(org: Organization) {
-    const sh = createMovieStakeholder({ orgId: org.id });
-
+  public submit(org: Partial<Organization>) {
     // TODO: handle promises correctly (update loading status, send back error report, etc).
-    this.service.add(this.movieQuery.getActiveId(), sh);
+    this.service.addStakeholder(this.movieQuery.getActiveId(), org);
   }
 
   public displayFn(org?: Organization): string | undefined {

--- a/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
+++ b/libs/movie/src/lib/stakeholder/components/stakeholder-repertory/stakeholder-repertory.component.ts
@@ -36,13 +36,13 @@ export class StakeholderRepertoryComponent implements OnInit, OnDestroy {
     this.onChange();
   }
 
-  public submit(org: Partial<Organization>) {
-    // TODO: handle promises correctly (update loading status, send back error report, etc).
-    this.service.addStakeholder(this.movieQuery.getActive(), org);
+  public submit(organization: Partial<Organization>) {
+    // TODO: handle promises correctly (update loading status, send back error report, etc). => ISSUE#612
+    this.service.addStakeholder(this.movieQuery.getActive(), organization);
   }
 
-  public displayFn(org?: Organization): string | undefined {
-    return org ? org.name : undefined;
+  public displayFn(organization?: Organization): string | undefined {
+    return organization ? organization.name : undefined;
   }
 
   private async listOrgsByName(prefix: string): Promise<Organization[]> {

--- a/libs/organization/src/lib/+state/organization.service.ts
+++ b/libs/organization/src/lib/+state/organization.service.ts
@@ -20,18 +20,18 @@ export class OrganizationService {
   public async addMember(member: OrgMember) {
     const orgId = this.query.getValue().org.id;
     const permissions = this.permissionsQuery.getValue();
-    const orgDoc = this.db.doc(`orgs/${orgId}`);
+    const organizationDoc = this.db.doc(`orgs/${orgId}`);
     const permissionsDoc = this.db.doc(`permissions/${orgId}`);
     const userDoc = this.db.doc(`users/${member.uid}`);
 
     await this.db.firestore
       .runTransaction(async tx => {
-        // Update the org
+        // Update the organization
         // Note: we don't use the store because we need to access fresh data IN the transaction
-        const org = await tx.get(orgDoc.ref);
+        const org = await tx.get(organizationDoc.ref);
         const { userIds } = org.data();
         const nextUserIds = [...userIds, member.uid];
-        const orgTransaction = tx.update(orgDoc.ref, { userIds: nextUserIds });
+        const organizationTransaction = tx.update(organizationDoc.ref, { userIds: nextUserIds });
         // Update the permissions and add the new member as an org admin
         const nextAdminsIds = [...permissions.admins, member.uid];
         const permissionsTransaction = tx.update(permissionsDoc.ref, { admins: nextAdminsIds });
@@ -39,7 +39,7 @@ export class OrganizationService {
         // TODO: Move this to the user side as we shouldn't be authorized to write in user document if we're not the concerned user
         const updateUserTransaction = tx.update(userDoc.ref, { orgId });
 
-        return Promise.all([orgTransaction, updateUserTransaction, permissionsTransaction]);
+        return Promise.all([organizationTransaction, updateUserTransaction, permissionsTransaction]);
       })
       .catch(error => {
         throw Error(error);
@@ -52,10 +52,10 @@ export class OrganizationService {
    * Add a new organization to the database and create/update
    * related documents (permissions, apps permissions, user...).
    */
-  public async add(org: Organization, user: User): Promise<string> {
+  public async add(organization: Organization, user: User): Promise<string> {
     const orgId: string = this.db.createId();
-    const newOrg: Organization = createOrganization({ ...org, id: orgId, userIds: [user.uid] });
-    const orgDoc = this.db.doc(`orgs/${orgId}`);
+    const newOrganization: Organization = createOrganization({ ...organization, id: orgId, userIds: [user.uid] });
+    const organizationDoc = this.db.doc(`orgs/${orgId}`);
     const permissions = createPermissions({ orgId, superAdmins: [user.uid] });
     const permissionsDoc = this.db.doc(`permissions/${orgId}`);
     const userDoc = this.db.doc(`users/${user.uid}`);
@@ -80,7 +80,7 @@ export class OrganizationService {
       .runTransaction(transaction => {
         const promises = [
           // Set the new organization in orgs collection.
-          transaction.set(orgDoc.ref, newOrg),
+          transaction.set(organizationDoc.ref, newOrganization),
           // Update user document with the new organization id.
           transaction.update(userDoc.ref, { orgId })
         ];
@@ -91,9 +91,9 @@ export class OrganizationService {
     return orgId;
   }
 
-  public update(org: Partial<Organization>) {
+  public update(organization: Partial<Organization>) {
     this.store.update(state => ({
-      org: { ...state.org, ...org }
+      org: { ...state.org, ...organization }
     }));
   }
 }

--- a/libs/organization/src/lib/components/org-widget/org-widget.component.html
+++ b/libs/organization/src/lib/components/org-widget/org-widget.component.html
@@ -3,11 +3,11 @@
   <span>Organization</span>
 </button>
 
-<a mat-menu-item routerLink="o/organization/form" *ngIf="!(org$ | async)">
+<a mat-menu-item routerLink="o/organization/form" *ngIf="!(organization$ | async)">
   <mat-icon>add_circle</mat-icon>
   <span>Create</span>
 </a>
 
-<ng-container *ngIf="(org$ | async) as org">
-  <a mat-menu-item [routerLink]="['o/organization/',org.id]">{{ org.name }}</a>
+<ng-container *ngIf="(organization$ | async) as organization">
+  <a mat-menu-item [routerLink]="['o/organization/',organization.id]">{{ organization.name }}</a>
 </ng-container>

--- a/libs/organization/src/lib/components/org-widget/org-widget.component.ts
+++ b/libs/organization/src/lib/components/org-widget/org-widget.component.ts
@@ -10,7 +10,7 @@ import { Observable } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrgWidgetComponent implements OnInit {
-  public org$: Observable<Organization>;
+  public organization$: Observable<Organization>;
   public user$: Observable<User>;
 
   constructor(
@@ -21,6 +21,6 @@ export class OrgWidgetComponent implements OnInit {
 
   ngOnInit() {
     this.user$ = this.auth.user$;
-    this.org$ = this.query.select('org');
+    this.organization$ = this.query.select('org');
   }
 }

--- a/libs/organization/src/lib/guard/organization.guard.ts
+++ b/libs/organization/src/lib/guard/organization.guard.ts
@@ -8,8 +8,8 @@ import { switchMap, tap } from 'rxjs/operators';
 
 export const orgQuery = (orgId: string): Query<Organization> => ({
   path: `orgs/${orgId}`,
-  members: (org: Organization) =>
-    org.userIds.map(id => ({
+  members: (organization: Organization) =>
+    organization.userIds.map(id => ({
       path: `users/${id}`
     }))
 });
@@ -35,7 +35,7 @@ export class OrganizationGuard {
             };
             return this.fireQuery.fromQuery<Organization>(orgQuery(user.orgId));
           }),
-          tap(org => this.store.update({org}))
+          tap(organization => this.store.update({org: organization}))
         )
         .subscribe({
           next: (result: Organization) => {

--- a/libs/organization/src/lib/pages/member-list/member-list.component.html
+++ b/libs/organization/src/lib/pages/member-list/member-list.component.html
@@ -1,5 +1,5 @@
 <section>
-  <ng-container *ngIf="(org$ | async).members as members">
+  <ng-container *ngIf="(organization$ | async).members as members">
     <mat-list *ngFor="let member of members">
       <org-member-view [member]="member"></org-member-view>
     </mat-list>

--- a/libs/organization/src/lib/pages/member-list/member-list.component.ts
+++ b/libs/organization/src/lib/pages/member-list/member-list.component.ts
@@ -8,11 +8,11 @@ import { Organization, OrganizationQuery } from '../../+state';
   styleUrls: ['./member-list.component.scss']
 })
 export class MemberListComponent implements OnInit {
-  public org$: Observable<Organization>;
+  public organization$: Observable<Organization>;
 
   constructor(private query: OrganizationQuery) {}
 
   ngOnInit() {
-    this.org$ = this.query.select('org');
+    this.organization$ = this.query.select('org');
   }
 }

--- a/libs/organization/src/lib/pages/org-view/org-view.component.html
+++ b/libs/organization/src/lib/pages/org-view/org-view.component.html
@@ -1,6 +1,6 @@
 <section>
-  <ng-container *ngIf="(org$ | async) as org">
-    <h2>{{ org.name }}</h2>
+  <ng-container *ngIf="(organization$ | async) as organization">
+    <h2>{{ organization.name }}</h2>
     <org-member-list></org-member-list>
     <mat-list>
       <mat-list-item><mat-icon color="primary">star</mat-icon>: Super Admin</mat-list-item>

--- a/libs/organization/src/lib/pages/org-view/org-view.component.ts
+++ b/libs/organization/src/lib/pages/org-view/org-view.component.ts
@@ -10,7 +10,7 @@ import { PermissionsQuery } from '../../permissions/+state';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OrgViewComponent implements OnInit {
-  public org$: Observable<Organization>;
+  public organization$: Observable<Organization>;
   public isSuperAdmin$: Observable<boolean>;
 
   constructor(
@@ -20,7 +20,7 @@ export class OrgViewComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.org$ = this.query.select('org');
+    this.organization$ = this.query.select('org');
     this.isSuperAdmin$ = this.permissionsQuery.isSuperAdmin$;
   }
 

--- a/libs/organization/src/lib/permissions/+state/permissions.service.ts
+++ b/libs/organization/src/lib/permissions/+state/permissions.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { BFDoc, FireQuery } from '@blockframes/utils';
 import { createOrgDocPermissions, createUserDocPermissions, Permissions } from './permissions.model';
 import { PermissionsQuery } from './permissions.query';
+import { Stakeholder, createMovieStakeholder } from '@blockframes/movie';
+import { Organization } from '../../+state';
 
 @Injectable({
   providedIn: 'root'
@@ -16,17 +18,17 @@ export class PermissionsService {
   /** Create a transaction for the document and add document permissions (organization document permissions and shared document permissions) at the same time */
   public async createDocAndPermissions<T>(
     document: BFDoc, // TODO: Go a bit further into type checking (e.g. BFDoc<T>)
-    orgId: string
+    org: Organization
   ) {
     const promises = [];
-    const orgDocPermissions = createOrgDocPermissions(document.id, orgId);
+    const orgDocPermissions = createOrgDocPermissions(document.id, org.id);
     const userDocPermissions = createUserDocPermissions(document.id);
 
     await this.db.firestore.runTransaction(async (tx: firebase.firestore.Transaction) => {
-      const orgDocPermissionsRef = this.db.doc<T>(`permissions/${orgId}/orgDocsPermissions/${document.id}`).ref;
+      const orgDocPermissionsRef = this.db.doc<T>(`permissions/${org.id}/orgDocsPermissions/${document.id}`).ref;
       promises.push(tx.set(orgDocPermissionsRef, orgDocPermissions));
 
-      const userDocPermissionsRef = this.db.doc<T>(`permissions/${orgId}/userDocsPermissions/${document.id}`).ref;
+      const userDocPermissionsRef = this.db.doc<T>(`permissions/${org.id}/userDocsPermissions/${document.id}`).ref;
       promises.push(tx.set(userDocPermissionsRef, userDocPermissions));
 
       const documentRef = this.db.doc<T>(`${document._type}/${document.id}`).ref;

--- a/libs/organization/src/lib/permissions/+state/permissions.service.ts
+++ b/libs/organization/src/lib/permissions/+state/permissions.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { BFDoc, FireQuery } from '@blockframes/utils';
 import { createOrgDocPermissions, createUserDocPermissions, Permissions } from './permissions.model';
 import { PermissionsQuery } from './permissions.query';
-import { Stakeholder, createMovieStakeholder } from '@blockframes/movie';
 import { Organization } from '../../+state';
 
 @Injectable({
@@ -17,18 +16,18 @@ export class PermissionsService {
 
   /** Create a transaction for the document and add document permissions (organization document permissions and shared document permissions) at the same time */
   public async createDocAndPermissions<T>(
-    document: BFDoc, // TODO: Go a bit further into type checking (e.g. BFDoc<T>)
-    org: Organization
+    document: BFDoc,
+    organization: Organization
   ) {
     const promises = [];
-    const orgDocPermissions = createOrgDocPermissions(document.id, org.id);
+    const orgDocPermissions = createOrgDocPermissions(document.id, organization.id);
     const userDocPermissions = createUserDocPermissions(document.id);
 
     await this.db.firestore.runTransaction(async (tx: firebase.firestore.Transaction) => {
-      const orgDocPermissionsRef = this.db.doc<T>(`permissions/${org.id}/orgDocsPermissions/${document.id}`).ref;
+      const orgDocPermissionsRef = this.db.doc<T>(`permissions/${organization.id}/orgDocsPermissions/${document.id}`).ref;
       promises.push(tx.set(orgDocPermissionsRef, orgDocPermissions));
 
-      const userDocPermissionsRef = this.db.doc<T>(`permissions/${org.id}/userDocsPermissions/${document.id}`).ref;
+      const userDocPermissionsRef = this.db.doc<T>(`permissions/${organization.id}/userDocsPermissions/${document.id}`).ref;
       promises.push(tx.set(userDocPermissionsRef, userDocPermissions));
 
       const documentRef = this.db.doc<T>(`${document._type}/${document.id}`).ref;

--- a/libs/organization/src/lib/permissions/guard/permissions.guard.ts
+++ b/libs/organization/src/lib/permissions/guard/permissions.guard.ts
@@ -8,14 +8,14 @@ import { Subscription } from 'rxjs';
 
 export const permissionsQuery = (orgId: string): Query<Permissions> => ({
   path: `permissions/${orgId}`,
-  userAppsPermissions: (org: Permissions) => ({
-    path: `permissions/${org.orgId}/userAppsPermissions`
+  userAppsPermissions: (permissions: Permissions) => ({
+    path: `permissions/${permissions.orgId}/userAppsPermissions`
   }),
-  userDocsPermissions: (org: Permissions) => ({
-    path: `permissions/${org.orgId}/userDocsPermissions`
+  userDocsPermissions: (permissions: Permissions) => ({
+    path: `permissions/${permissions.orgId}/userDocsPermissions`
   }),
-  orgDocsPermissions: (org: Permissions) => ({
-    path: `permissions/${org.orgId}/orgDocsPermissions`
+  orgDocsPermissions: (permissions: Permissions) => ({
+    path: `permissions/${permissions.orgId}/orgDocsPermissions`
   })
 });
 


### PR DESCRIPTION
- [x] As stakeholder is always an org, we now use the same id for both org and stakeholder doc.
- [x] All Firebase documents are created in the same transaction when adding a movie.
- [x] More generic addStakeholder function to match different type of documents.