### PR TITLE
Finalize organization search & invites

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,6 +40,7 @@
             "scripts": []
           },
           "configurations": {
+            "dev": {},
             "production": {
               "fileReplacements": [
                 {
@@ -135,6 +136,7 @@
             "browserTarget": "main:build"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "browserTarget": "main:build:production"
             },
@@ -182,6 +184,7 @@
             "baseUrl": "http://localhost:4200"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "devServerTarget": "main:serve:production"
             },
@@ -237,6 +240,7 @@
             "scripts": []
           },
           "configurations": {
+            "dev": {},
             "production": {
               "fileReplacements": [
                 {
@@ -332,6 +336,7 @@
             "browserTarget": "ip-upload:build"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "browserTarget": "ip-upload:build:production"
             },
@@ -379,6 +384,7 @@
             "baseUrl": "http://localhost:4200"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "devServerTarget": "ip-upload:serve:production"
             },
@@ -524,6 +530,7 @@
             "tsConfig": "apps/eth-events-server/tsconfig.app.json"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "optimization": true,
               "extractLicenses": true,
@@ -631,6 +638,7 @@
             "scripts": []
           },
           "configurations": {
+            "dev": {},
             "production": {
               "fileReplacements": [
                 {
@@ -723,6 +731,7 @@
             "browserTarget": "movie-financing:build"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "browserTarget": "movie-financing:build:production"
             }
@@ -767,6 +776,7 @@
             "baseUrl": "http://localhost:4200"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "devServerTarget": "movie-financing:serve:production"
             },
@@ -913,6 +923,7 @@
             "scripts": []
           },
           "configurations": {
+            "dev": {},
             "production": {
               "fileReplacements": [
                 {
@@ -1008,6 +1019,7 @@
             "browserTarget": "delivery:build"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "browserTarget": "delivery:build:production"
             },
@@ -1055,6 +1067,7 @@
             "baseUrl": "http://localhost:4200"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "devServerTarget": "delivery:serve:production"
             },
@@ -1109,6 +1122,7 @@
             "scripts": []
           },
           "configurations": {
+            "dev": {},
             "production": {
               "fileReplacements": [
                 {
@@ -1204,6 +1218,7 @@
             "browserTarget": "catalog:build"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "browserTarget": "catalog:build:production"
             },
@@ -1251,6 +1266,7 @@
             "baseUrl": "http://localhost:4200"
           },
           "configurations": {
+            "dev": {},
             "production": {
               "devServerTarget": "catalog:serve:production"
             },
@@ -1354,6 +1370,7 @@
             "assets": ["apps/backend-functions/src/assets"]
           },
           "configurations": {
+            "dev": {},
             "production": {
               "maxWorkers": 2,
               "optimization": true,
@@ -1448,6 +1465,7 @@
             ]
           },
           "configurations": {
+            "dev": {},
             "ci": {
               "maxWorkers": 2,
               "fileReplacements": [

--- a/apps/backend-functions/src/admin.ts
+++ b/apps/backend-functions/src/admin.ts
@@ -6,7 +6,7 @@
 import express from 'express';
 import { db, DocumentReference, functions, getUserMail } from './internals/firebase';
 import { sendMail } from './internals/email';
-import { AppAccessStatus, OrganizationPermissions, OrganizationStatus } from './data/types';
+import { AppAccessStatus, OrganizationStatus } from './data/types';
 import {
   ADMIN_ACCEPT_ORG_PATH,
   ADMIN_ACCESS_TO_APP_PATH,
@@ -20,6 +20,7 @@ import {
   allowAccessToAppPage,
   allowAccessToAppPageComplete
 } from './assets/admin-templates';
+import { getSuperAdmins } from './data/internals';
 
 // TODO(#714): Synchronize data types with the frontend
 const APPS = ['MediaDelivering', 'MediaFinanciers', 'StoriesAndMore'];
@@ -52,19 +53,6 @@ export async function onRequestAccessToAppWrite(
 // We serve an express app at the /admin URL
 // this let us deal easily with get / post, url params, etc.
 export const adminApp = express();
-
-/** Retrieve the list of superAdmins of an organization */
-async function getSuperAdmins(organizationId: string): Promise<string[]> {
-  const permissionsRef = db.collection('permissions').doc(organizationId);
-  const permissionsDoc = await permissionsRef.get();
-
-  if (!permissionsDoc.exists) {
-    throw new Error(`organization: ${organizationId} does not exists`);
-  }
-
-  const { superAdmins } = permissionsDoc.data() as OrganizationPermissions;
-  return superAdmins;
-}
 
 // Organization Administration: Accept new orgs
 // ============================================

--- a/apps/backend-functions/src/assets/mail-templates.ts
+++ b/apps/backend-functions/src/assets/mail-templates.ts
@@ -85,3 +85,19 @@ export function organizationRequestedAccessToApp(orgId: string, appId: string): 
     text: organizationRequestAccessToAppTemplate(orgId, appId)
   };
 }
+
+const userRequestedToJoinYourOrgTemplate = (userMail: string): string =>
+  `
+  The user ${userMail} requested to join your app,
+
+  Visit your organization teamwork page to accept them.
+  `;
+
+/** Generates a transactional email to let an admin now that a user requested to join their org */
+export function userRequestedToJoinYourOrg(adminMail: string, userMail: string): EmailRequest {
+  return {
+    to: adminMail,
+    subject: 'A user requested to join your organization',
+    text: userRequestedToJoinYourOrgTemplate(userMail)
+  }
+}

--- a/apps/backend-functions/src/assets/mail-templates.ts
+++ b/apps/backend-functions/src/assets/mail-templates.ts
@@ -99,5 +99,21 @@ export function userRequestedToJoinYourOrg(adminMail: string, userMail: string):
     to: adminMail,
     subject: 'A user requested to join your organization',
     text: userRequestedToJoinYourOrgTemplate(userMail)
+  };
+}
+
+export function userJoinedAnOrganization(userEmail: string): EmailRequest {
+  return {
+    to: userEmail,
+    subject: 'You joined a new organization',
+    text: 'TODO'
+  };
+}
+
+export function userJoinedYourOrganization(orgAdminEmail: string, userEmail: string): EmailRequest {
+  return {
+    to: orgAdminEmail,
+    subject: 'A user joined the organization',
+    text: `user: ${userEmail}`
   }
 }

--- a/apps/backend-functions/src/data/internals.ts
+++ b/apps/backend-functions/src/data/internals.ts
@@ -4,7 +4,13 @@
  * This code deals directly with the low level parts of firebase,
  */
 import { db } from '../internals/firebase';
-import { Organization, Stakeholder, UserDocPermissions, OrganizationDocPermissions } from './types';
+import {
+  Organization,
+  OrganizationDocPermissions,
+  OrganizationPermissions,
+  Stakeholder,
+  UserDocPermissions
+} from './types';
 
 export function getCollection<T>(path: string): Promise<T[]> {
   return db
@@ -77,4 +83,17 @@ export function getCount(collection: string): Promise<number> {
     .collection(collection)
     .get()
     .then(col => col.size);
+}
+
+/** Retrieve the list of superAdmins of an organization */
+export async function getSuperAdmins(organizationId: string): Promise<string[]> {
+  const permissionsRef = db.collection('permissions').doc(organizationId);
+  const permissionsDoc = await permissionsRef.get();
+
+  if (!permissionsDoc.exists) {
+    throw new Error(`organization: ${organizationId} does not exists`);
+  }
+
+  const { superAdmins } = permissionsDoc.data() as OrganizationPermissions;
+  return superAdmins;
 }

--- a/apps/backend-functions/src/data/types.ts
+++ b/apps/backend-functions/src/data/types.ts
@@ -167,11 +167,18 @@ export interface InvitationFromOrganizationToUser extends RawInvitation {
   organizationId: string;
 }
 
+/** A user requests to join an organization. */
+export interface InvitationFromUserToOrganization extends RawInvitation {
+  type: InvitationType.fromUserToOrganization;
+  userId: string;
+  organizationId: string;
+}
+
 /**
  * This is the generic type for invitation,
  * use the type field to figure out which kind of invitation you are working with.
  */
-export type Invitation = InvitationStakeholder | InvitationFromOrganizationToUser;
+export type Invitation = InvitationStakeholder | InvitationFromOrganizationToUser | InvitationFromUserToOrganization;
 export type InvitationOrUndefined = Invitation | undefined;
 
 // Notifications

--- a/apps/backend-functions/src/data/types.ts
+++ b/apps/backend-functions/src/data/types.ts
@@ -135,7 +135,8 @@ export const enum InvitationState {
 
 export const enum InvitationType {
   stakeholder = 'stakeholder',
-  toOrganization = 'toOrganization'
+  fromUserToOrganization = 'fromUserToOrganization',
+  fromOrganizationToUser = 'fromOrganizationToUser'
 }
 
 /**
@@ -160,8 +161,8 @@ export interface InvitationStakeholder extends RawInvitation {
 }
 
 /** Invite a user to an organization. */
-export interface InvitationToOrganization extends RawInvitation {
-  type: InvitationType.toOrganization;
+export interface InvitationFromOrganizationToUser extends RawInvitation {
+  type: InvitationType.fromOrganizationToUser;
   userId: string;
   organizationId: string;
 }
@@ -170,7 +171,7 @@ export interface InvitationToOrganization extends RawInvitation {
  * This is the generic type for invitation,
  * use the type field to figure out which kind of invitation you are working with.
  */
-export type Invitation = InvitationStakeholder | InvitationToOrganization;
+export type Invitation = InvitationStakeholder | InvitationFromOrganizationToUser;
 export type InvitationOrUndefined = Invitation | undefined;
 
 // Notifications

--- a/apps/backend-functions/src/internals/email.ts
+++ b/apps/backend-functions/src/internals/email.ts
@@ -24,5 +24,7 @@ export async function sendMail({ to, subject, text }: EmailRequest): Promise<any
     text,
     from: 'admin@blockframes.io'
   };
+
+  console.debug("sending mail:", msg);
   return SendGrid.send(msg);
 }

--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -251,7 +251,7 @@ async function onInvitationFromUserToJoinOrgAccept({
   userId,
   id
 }: InvitationFromUserToOrganization) {
-  // TODO: When a user is added to an org, clear other invitations
+  // TODO(issue#739): When a user is added to an org, clear other invitations
   await addUserToOrg(userId, organizationId);
   await deleteInvitation(id);
   return mailOnInvitationAccept(userId, organizationId);

--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -36,7 +36,6 @@ function wasCreated(before: InvitationOrUndefined, after: Invitation) {
 async function addUserToOrg(userId: string, organizationId: string) {
   if (!organizationId) {
     throw new Error('no organization id provided!');
-    return;
   }
 
   const userRef = db.collection('users').doc(userId);
@@ -56,7 +55,7 @@ async function addUserToOrg(userId: string, organizationId: string) {
 
     if (!userData || !organizationData || !permissionData) {
       console.error(
-        'Something went wrong with the invitation, a required document is not set\n',
+        'Something went wrong with the invitation, a required document is not set',
         userData,
         organizationData,
         permissionData
@@ -66,7 +65,7 @@ async function addUserToOrg(userId: string, organizationId: string) {
 
     return Promise.all([
       // Update user's orgId
-      tx.set(userRef, { ...user, orgId: organizationId }),
+      tx.set(userRef, { ...userData, orgId: organizationId }),
       // Update organization
       tx.set(organizationRef, {
         ...organizationData,

--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -34,9 +34,11 @@ function wasCreated(before: InvitationOrUndefined, after: Invitation) {
 }
 
 async function addUserToOrg(userId: string, organizationId: string) {
-  if (!organizationId) {
-    throw new Error('no organization id provided!');
+  if (!organizationId || !userId) {
+    throw new Error(`missing data: userId=${userId}, organizationId=${organizationId}`);
   }
+
+  console.debug("add user:", userId, "to org:", organizationId);
 
   const userRef = db.collection('users').doc(userId);
   const organizationRef = db.collection('orgs').doc(organizationId);

--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -13,7 +13,7 @@ import {
   InvitationOrUndefined,
   InvitationStakeholder,
   InvitationState,
-  InvitationToOrganization,
+  InvitationFromOrganizationToUser,
   InvitationType,
   Organization
 } from './data/types';
@@ -32,7 +32,7 @@ function wasCreated(before: InvitationOrUndefined, after: Invitation) {
 }
 
 /** Updates the user, orgs, and permissions when the user accepts an invitation to an organization. */
-async function onInvitationToOrgAccept(invitation: InvitationToOrganization) {
+async function onInvitationToOrgAccept(invitation: InvitationFromOrganizationToUser) {
   const { userId, organizationId } = invitation;
 
   if (!organizationId) {
@@ -80,7 +80,7 @@ async function onInvitationToOrgAccept(invitation: InvitationToOrganization) {
 }
 
 /** Sends an email when an organization invites a user to join. */
-async function onInvitationToOrgCreate({ userId }: InvitationToOrganization) {
+async function onInvitationToOrgCreate({ userId }: InvitationFromOrganizationToUser) {
   const userMail = await getUserMail(userId);
 
   if (!userMail) {
@@ -177,7 +177,7 @@ async function onStakeholderInvitationAccept({
 async function onInvitationToOrgUpdate(
   before: InvitationOrUndefined,
   after: Invitation,
-  invitation: InvitationToOrganization
+  invitation: InvitationFromOrganizationToUser
 ): Promise<any> {
   if (wasCreated(before, after)) {
     return onInvitationToOrgCreate(invitation);
@@ -246,7 +246,7 @@ export async function onInvitationUpdate(
     switch (invitation.type) {
       case InvitationType.stakeholder:
         return await onStakeholderInvitationUpdate(invitationDocBefore, invitationDoc, invitation);
-      case InvitationType.toOrganization:
+      case InvitationType.fromOrganizationToUser:
         return await onInvitationToOrgUpdate(invitationDocBefore, invitationDoc, invitation);
       default:
         throw new Error(`Unhandled invitation: ${JSON.stringify(invitation)}`);

--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -200,8 +200,8 @@ async function onStakeholderInvitationAccept({
 }
 
 /**
- * Dispatch 'creation' and 'accepted' events when an invitation to
- * join an organization is updated.
+ * Dispatch the invitation update call depending on whether the invitation
+ * was 'created' or 'accepted'.
  */
 async function onInvitationToOrgUpdate(
   before: InvitationOrUndefined,
@@ -258,8 +258,8 @@ async function onInvitationFromUserToJoinOrgAccept({
 }
 
 /**
- * Dispatch 'creation' and 'accepted' events when a request to
- * join an organization is updated.
+ * Dispatch the invitation update call depending on whether the invitation
+ * was 'created' or 'accepted'.
  */
 async function onInvitationFromUserToJoinOrgUpdate(
   before: InvitationOrUndefined,
@@ -274,7 +274,9 @@ async function onInvitationFromUserToJoinOrgUpdate(
   return;
 }
 
-/** Dispatch 'accepted' event when an invitation to join a document is accepted. */
+/**
+ * Dispatch the invitation update call when the invitation was 'accepted'.
+ */
 async function onStakeholderInvitationUpdate(
   before: InvitationOrUndefined,
   after: Invitation,

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -27,7 +27,7 @@ import * as migrations from './migrations';
 import { onDocumentCreate, onDocumentDelete, onDocumentUpdate, onDocumentWrite } from './utils';
 import { mnemonic, relayer } from './environments/environment';
 import { onGenerateDeliveryPDFRequest } from './internals/pdf';
-import { onInvitationUpdate } from './invitation';
+import { onInvitationWrite } from './invitation';
 import { onOrganizationCreate, onOrganizationDelete, onOrganizationUpdate } from './orgs';
 import { adminApp, onRequestAccessToAppWrite } from './admin';
 
@@ -145,9 +145,9 @@ export const onMovieStakeholderDeleteEvent = onDocumentDelete(
 /**
  * Trigger: when an invitation is updated (e. g. when invitation.state change)
  */
-export const onInvitationUpdateEvent = onDocumentUpdate(
+export const onInvitationUpdateEvent = onDocumentWrite(
   'invitations/{invitationID}',
-  onInvitationUpdate
+  onInvitationWrite
 );
 
 //--------------------------------

--- a/apps/delivery/delivery/src/app/layout/layout.component.html
+++ b/apps/delivery/delivery/src/app/layout/layout.component.html
@@ -1,6 +1,6 @@
 <toolbar-header id="navbar">
   <ng-container app-icon>
-    <button testId="home" mat-icon-button routerLink="/layout">
+    <button test-id="home" mat-icon-button routerLink="/layout">
       <mat-icon svgIcon="media_delivering" class="app-icon"></mat-icon>
     </button>
   </ng-container>

--- a/libs/account/src/lib/profile/profile-menu/profile-menu.component.html
+++ b/libs/account/src/lib/profile/profile-menu/profile-menu.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(user$ | async) as user">
-  <button mat-icon-button [matMenuTriggerFor]="menu" class="profile-button">
+  <button mat-icon-button [matMenuTriggerFor]="menu" class="profile-button" test-id="profile-button">
     <mat-icon class="account-icon" color="primary">account_circle</mat-icon>
   </button>
   <mat-menu #menu="matMenu" class="mat-elevation-z6">

--- a/libs/auth/src/lib/components/signin-form/signin-form.component.html
+++ b/libs/auth/src/lib/components/signin-form/signin-form.component.html
@@ -1,4 +1,4 @@
-<section testId="signin" fxLayout="column" fxLayoutAlign="center center">
+<section test-id="signin" fxLayout="column" fxLayoutAlign="center center">
   <h2>Sign in</h2>
   <form [formGroup]="signinForm" (ngSubmit)="submited.emit(signinForm)" fxLayout="column">
     <mat-form-field appearance="outline">

--- a/libs/movie/src/lib/movie/pages/movie-create/movie-create.component.html
+++ b/libs/movie/src/lib/movie/pages/movie-create/movie-create.component.html
@@ -1,4 +1,4 @@
-<section fxLayout="column" fxLayoutAlign="center center">
+<section fxLayout="column" fxLayoutAlign="center center" test-id="content" page-id="movie-create">
   <article>
     <p>
       Your organization has no movie yet. You can add a movie by clicking on the button "Add a

--- a/libs/notification/invitation/+state/invitation.model.ts
+++ b/libs/notification/invitation/+state/invitation.model.ts
@@ -1,6 +1,7 @@
 import { firestore } from 'firebase/app';
 import { DocInformations } from 'libs/notification/notification/+state';
 import { User } from '@blockframes/auth';
+import { Organization } from '@blockframes/organization';
 type Timestamp = firestore.Timestamp;
 
 export interface Invitation {
@@ -9,6 +10,7 @@ export interface Invitation {
   type: InvitationType;
   userId?: string;
   user?: User;
+  organization?: Organization;
   organizationId: string;
   docInformations?: DocInformations;
   state: 'accepted' | 'declined' | 'pending';

--- a/libs/notification/invitation/+state/invitation.model.ts
+++ b/libs/notification/invitation/+state/invitation.model.ts
@@ -16,8 +16,8 @@ export interface Invitation {
 }
 
 export const enum InvitationType {
-  joinOrganization = 'joinOrganization',
-  toOrganization = 'toOrganization'
+  fromUserToOrganization = 'fromUserToOrganization',
+  fromOrganizationToUser = 'fromOrganizationToUser'
 }
 
 /**
@@ -33,7 +33,7 @@ export function createInvitationToJoinOrganization(params: InvitationToJoinOrgan
   return {
     app: 'main',
     state: 'pending',
-    type: InvitationType.joinOrganization,
+    type: InvitationType.fromUserToOrganization,
     date: firestore.Timestamp.now(),
     ...params
   };
@@ -43,7 +43,7 @@ export function createInvitationToOrganization(params: InvitationToJoinOrganizat
   return {
     app: 'main',
     state: 'pending',
-    type: InvitationType.toOrganization,
+    type: InvitationType.fromOrganizationToUser,
     date: firestore.Timestamp.now(),
     ...params
   };

--- a/libs/notification/invitation/+state/invitation.query.ts
+++ b/libs/notification/invitation/+state/invitation.query.ts
@@ -15,11 +15,15 @@ export class InvitationQuery extends QueryEntity<InvitationState, Invitation> {
 
   /** Returns only invitations type of 'joinOrganization': members who ask organization to join it */
   public invitationsToJoinOrganization$: Observable<Invitation[]> = this.selectAll().pipe(
-    map(invitations => invitations.filter(invitation => invitation.type === InvitationType.fromUserToOrganization))
+    map(invitations =>
+      invitations.filter(invitation => invitation.type === InvitationType.fromUserToOrganization)
+    )
   );
 
   /** Returns only invitations type of 'toOrganization': members invited by the organization */
   public invitationsFromOrganization$: Observable<Invitation[]> = this.selectAll().pipe(
-    map(invitations => invitations.filter(invitation => invitation.type === InvitationType.fromOrganizationToUser))
+    map(invitations =>
+      invitations.filter(invitation => invitation.type === InvitationType.fromOrganizationToUser)
+    )
   );
 }

--- a/libs/notification/invitation/+state/invitation.query.ts
+++ b/libs/notification/invitation/+state/invitation.query.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { QueryEntity } from '@datorama/akita';
-import { Invitation } from './invitation.model';
+import { Invitation, InvitationType } from './invitation.model';
 import { InvitationStore, InvitationState } from './invitation.store';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -15,11 +15,11 @@ export class InvitationQuery extends QueryEntity<InvitationState, Invitation> {
 
   /** Returns only invitations type of 'joinOrganization': members who ask organization to join it */
   public invitationsToJoinOrganization$: Observable<Invitation[]> = this.selectAll().pipe(
-    map(invitations => invitations.filter(invitation => invitation.type === 'joinOrganization'))
+    map(invitations => invitations.filter(invitation => invitation.type === InvitationType.fromUserToOrganization))
   );
 
   /** Returns only invitations type of 'toOrganization': members invited by the organization */
   public invitationsFromOrganization$: Observable<Invitation[]> = this.selectAll().pipe(
-    map(invitations => invitations.filter(invitation => invitation.type === 'toOrganization'))
+    map(invitations => invitations.filter(invitation => invitation.type === InvitationType.fromOrganizationToUser))
   );
 }

--- a/libs/notification/invitation/+state/invitation.service.ts
+++ b/libs/notification/invitation/+state/invitation.service.ts
@@ -17,7 +17,7 @@ export function getInvitationsByOrgId(organizationId: string): Query<Invitation[
       ref.where('organizationId', '==', organizationId).where('state', '==', 'pending'),
     user: (invitation: Invitation) => ({
       // TODO: use profiles collections instead of users, issue#693
-      // TODO: when we create an invitation, the userDoc doesn't exist directly, so the doc is not found
+      // TODO(issue#740): when we create an invitation, the userDoc doesn't exist directly, so the doc is not found
       path: `users/${invitation.userId}`
     })
   };

--- a/libs/notification/invitation/+state/invitation.service.ts
+++ b/libs/notification/invitation/+state/invitation.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
 import { FireQuery, Query } from '@blockframes/utils';
-import { switchMap, tap, filter } from 'rxjs/operators';
+import { catchError, filter, switchMap, tap } from 'rxjs/operators';
 import { InvitationStore } from './invitation.store';
 import { AuthQuery, AuthService } from '@blockframes/auth';
 import {
-  Invitation,
   createInvitationToJoinOrganization,
-  createInvitationToOrganization
+  createInvitationToOrganization,
+  Invitation
 } from './invitation.model';
-import { Organization } from '@blockframes/organization';
+import { of } from 'rxjs';
 
 export function getInvitationsByOrgId(organizationId: string): Query<Invitation[]> {
   return {
@@ -23,6 +23,18 @@ export function getInvitationsByOrgId(organizationId: string): Query<Invitation[
   };
 }
 
+export function getInvitationsByUserId(userId: string): Query<Invitation[]> {
+  return {
+    path: `invitations`,
+    queryFn: ref => ref.where('userId', '==', userId).where('state', '==', 'pending'),
+    organization: (invitation: Invitation) => ({
+      // TODO: use profiles collections instead of users, issue#693
+      // TODO: when we create an invitation, the userDoc doesn't exist directly, so the doc is not found
+      path: `orgs/${invitation.organizationId}`
+    })
+  };
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -33,6 +45,28 @@ export class InvitationService {
     private db: FireQuery,
     private authService: AuthService
   ) {}
+
+  // TODO : move this in /layout guard => ISSUE#641
+  public get organizationInvitations$() {
+    return this.authQuery.user$.pipe(
+      filter(user => !!user),
+      switchMap(user => this.db.fromQuery(getInvitationsByOrgId(user.orgId))),
+      catchError(err => {
+        console.error(err);
+        return of([]);
+      }),
+      tap((invitations: Invitation[]) => this.store.set(invitations))
+    );
+  }
+
+  // TODO : move this in /layout guard => ISSUE#641
+  public get userInvitations$() {
+    return this.authQuery.user$.pipe(
+      filter(user => !!user),
+      switchMap(user => this.db.fromQuery(getInvitationsByUserId(user.uid))),
+      tap((invitations: Invitation[]) => this.store.set(invitations))
+    );
+  }
 
   /** Create an invitation when a user asks to join an organization */
   public sendInvitationToOrg(organizationId: string): Promise<void> {
@@ -55,15 +89,6 @@ export class InvitationService {
       userId: uid
     });
     return this.db.doc<Invitation>(`invitations/${invitation.id}`).set(invitation);
-  }
-
-  // TODO : move this in /layout guard => ISSUE#641
-  public get organizationInvitations$() {
-    return this.authQuery.user$.pipe(
-      filter(user => !!user),
-      switchMap(user => this.db.fromQuery(getInvitationsByOrgId(user.orgId))),
-      tap((invitations: Invitation[]) => this.store.set(invitations))
-    );
   }
 
   public acceptInvitation(invitationId: string) {

--- a/libs/notification/invitation/+state/invitation.service.ts
+++ b/libs/notification/invitation/+state/invitation.service.ts
@@ -35,11 +35,11 @@ export class InvitationService {
   ) {}
 
   /** Create an invitation when a user asks to join an organization */
-  public sendInvitationToOrg(organization: Partial<Organization>): Promise<void> {
+  public sendInvitationToOrg(organizationId: string): Promise<void> {
     const userId = this.authQuery.userId;
     const invitation = createInvitationToJoinOrganization({
       id: this.db.createId(),
-      organizationId: organization.id,
+      organizationId: organizationId,
       userId
     });
     return this.db.doc<Invitation>(`invitations/${invitation.id}`).set(invitation);

--- a/libs/notification/invitation/invitation-item/invitation-item.component.html
+++ b/libs/notification/invitation/invitation-item/invitation-item.component.html
@@ -4,8 +4,8 @@
     {{ message }}
   </span>
   <article fxLayoutAlign="space-around center">
-    <button mat-raised-button color="primary" (click)="acceptInvitation(invitation)">Accept</button>
-    <button mat-raised-button color="warn">Decline</button>
+    <button test-id="accept" mat-raised-button color="primary" (click)="acceptInvitation(invitation)">Accept</button>
+    <button test-id="decline" mat-raised-button color="warn">Decline</button>
   </article>
   <p class="date">
     Received {{ invitation.date.toDate() | date: 'MMM dd yyyy' }} at

--- a/libs/notification/invitation/invitation-item/invitation-item.component.ts
+++ b/libs/notification/invitation/invitation-item/invitation-item.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Invitation, InvitationService, InvitationType } from '../+state';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatSnackBar } from '@angular/material';
 
 @Component({
   selector: 'invitation-item',

--- a/libs/notification/invitation/invitation-item/invitation-item.component.ts
+++ b/libs/notification/invitation/invitation-item/invitation-item.component.ts
@@ -20,12 +20,8 @@ export class InvitationItemComponent {
     return ''; // TODO: issue#576, implement one message by type of invitation
   }
 
-  acceptInvitation(invitation: Invitation) {
-    this.service.acceptInvitation(invitation.id);
-    this.snackBar.open(
-      `You accepted to join the delivery's teamwork. You will receive another notification when you'll be able to navigate to the document`,
-      'close',
-      { duration: 5000 }
-    );
+  public async acceptInvitation(invitation: Invitation) {
+    await this.service.acceptInvitation(invitation.id);
+    this.snackBar.open(`You accepted the invitation!`, 'close', { duration: 5000 });
   }
 }

--- a/libs/notification/invitation/invitation-item/invitation-item.component.ts
+++ b/libs/notification/invitation/invitation-item/invitation-item.component.ts
@@ -1,6 +1,7 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
-import { Invitation, InvitationService } from '../+state';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Invitation, InvitationService, InvitationType } from '../+state';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatSnackBar } from '@angular/material';
 
 @Component({
   selector: 'invitation-item',
@@ -13,6 +14,13 @@ export class InvitationItemComponent {
 
   constructor(private service: InvitationService, private snackBar: MatSnackBar) {}
 
+  public get message(): string {
+    if (this.invitation.type === InvitationType.fromUserToOrganization) {
+      return 'A user wants to join your organization.';
+    }
+    return ''; // TODO: issue#576, implement one message by type of invitation
+  }
+
   acceptInvitation(invitation: Invitation) {
     this.service.acceptInvitation(invitation.id);
     this.snackBar.open(
@@ -20,12 +28,5 @@ export class InvitationItemComponent {
       'close',
       { duration: 5000 }
     );
-  }
-
-  public get message(): string {
-    if (this.invitation.type === 'joinOrganization') {
-      return 'A user wants to join your organization.'
-    }
-    return ''; // TODO: issue#576, implement one message by type of invitation
   }
 }

--- a/libs/notification/invitation/invitation-list/invitation-list.component.html
+++ b/libs/notification/invitation/invitation-list/invitation-list.component.html
@@ -1,4 +1,4 @@
-<section testId="invitations" *ngFor="let invitation of (invitations$ | async)">
+<section test-id="invitations" *ngFor="let invitation of (invitations$ | async)">
   <invitation-item [invitation]="invitation"></invitation-item>
   <mat-divider></mat-divider>
 </section>

--- a/libs/notification/notification-widget/notification-widget.component.html
+++ b/libs/notification/notification-widget/notification-widget.component.html
@@ -1,4 +1,4 @@
-<section *ngIf="(user$ | async) as user">
+<section *ngIf="(user$ | async) as user" test-id="notification-widget">
   <button
     mat-icon-button
     [matMenuTriggerFor]="notifications"
@@ -17,7 +17,7 @@
   </button>
 </section>
 <mat-menu #notifications="matMenu" xPosition="before" class="notifMenu mat-elevation-z6">
-  <section class="notification-list">
+  <section class="notification-list" test-id="notification-list">
     <mat-list> <invitation-list></invitation-list> </mat-list>
     <mat-list> <notification-list></notification-list> </mat-list>
   </section>

--- a/libs/organization/src/lib/components/member-add/member-add.component.html
+++ b/libs/organization/src/lib/components/member-add/member-add.component.html
@@ -1,11 +1,19 @@
-<h4>Send invitation</h4>
-<mat-form-field appearance="outline">
-  <mat-label>Add new member</mat-label>
-  <input matInput type="email" placeholder="Email" aria-label="Email" [formControl]="emailControl" />
-  <mat-error *ngIf="emailControl.hasError('email')">
-    Please enter a <strong>valid</strong> email address.
-  </mat-error>
-</mat-form-field>
-<button mat-button testId="addMember" (click)="sendInvitation()" color="primary">
-  Send invitation
-</button>
+<section test-id="member-add">
+  <h4>Send invitation</h4>
+  <mat-form-field appearance="outline">
+    <mat-label>Add new member</mat-label>
+    <input
+      matInput
+      type="email"
+      placeholder="Email"
+      aria-label="Email"
+      [formControl]="emailControl"
+    />
+    <mat-error *ngIf="emailControl.hasError('email')">
+      Please enter a <strong>valid</strong> email address.
+    </mat-error>
+  </mat-form-field>
+  <button mat-button test-id="add" (click)="sendInvitation()" color="primary">
+    Send invitation
+  </button>
+</section>

--- a/libs/organization/src/lib/components/organization-create/organization-create.component.html
+++ b/libs/organization/src/lib/components/organization-create/organization-create.component.html
@@ -1,4 +1,4 @@
-<section class="mat-typography" fxLayout="row" fxLayoutAlign="center center">
+<section class="mat-typography" fxLayout="row" fxLayoutAlign="center center" test-id="content" page-id="organization-create">
   <mat-card fxLayout="column" fxLayoutAlign="center none">
     <mat-card-header>
       <h1>Principal Informations</h1>

--- a/libs/organization/src/lib/components/organization-widget/organization-widget.component.html
+++ b/libs/organization/src/lib/components/organization-widget/organization-widget.component.html
@@ -9,5 +9,5 @@
 </a>
 
 <ng-container *ngIf="(organization$ | async) as organization">
-  <a mat-menu-item [routerLink]="['o/organization/',organization.id]">{{ organization.name }}</a>
+  <a test-id="organization-link" mat-menu-item [routerLink]="['o/organization/',organization.id]">{{ organization.name }}</a>
 </ng-container>

--- a/libs/organization/src/lib/pages/member-editable/member-editable.component.html
+++ b/libs/organization/src/lib/pages/member-editable/member-editable.component.html
@@ -1,4 +1,4 @@
-<editable-sidenav (closed)="opened = false" [opened]="opened" (saved)="updateRole()">
+<editable-sidenav test-id="content" page-id="organization-members" (closed)="opened = false" [opened]="opened" (saved)="updateRole()">
   <!-- Content -->
   <ng-container content>
     <member-pending

--- a/libs/organization/src/lib/pages/organization-feedback/organization-feedback.component.html
+++ b/libs/organization/src/lib/pages/organization-feedback/organization-feedback.component.html
@@ -1,4 +1,4 @@
-<section fxLayout="row" fxLayoutAlign="center center">
+<section fxLayout="row" fxLayoutAlign="center center" test-id="content" page-id="organization-feedback">
   <feedback-message
     title="Congratulation!"
     subTitle="Your organization is almost ready to use, a Cascade8 administrator is going to reach out soon."

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.html
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.html
@@ -14,13 +14,13 @@
         [matAutocomplete]="auto"
       />
       <mat-autocomplete #auto="matAutocomplete">
-        <mat-option *ngFor="let org of orgOptions" [value]="org.name" (click)="selectOrganization(org)">
+        <mat-option *ngFor="let org of searchResults$ | async" [value]="org.name" (click)="selectOrganization(org)">
           {{ org.name }}
         </mat-option>
       </mat-autocomplete>
     </mat-form-field>
     <div class="image"></div>
-    <button class="add-org" (click)="addOrganization()" mat-raised-button color="accent">Let's go !</button>
+    <button class="add-org" (click)="addOrganization()" mat-raised-button color="accent" [disabled]="!selected">Let's go !</button>
     <a routerLink="../home"><button mat-button color="primary">Back</button></a>
   </article>
 </section>

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.html
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.html
@@ -1,4 +1,4 @@
-<section fxLayout="row" fxLayoutAlign="center">
+<section fxLayout="row" fxLayoutAlign="center" test-id="content" page-id="organization-find">
   <article fxLayout="column" fxLayoutAlign="center center">
     <h2>Find your organization</h2>
     <p>
@@ -7,6 +7,7 @@
     </p>
     <mat-form-field appearance="outline">
       <input
+        aria-label="search"
         type="text"
         placeholder="Organization name"
         matInput
@@ -20,7 +21,7 @@
       </mat-autocomplete>
     </mat-form-field>
     <div class="image"></div>
-    <button class="add-org" (click)="addOrganization()" mat-raised-button color="accent" [disabled]="!selected">Let's go !</button>
+    <button test-id="join-org" class="add-org" (click)="addOrganization()" mat-raised-button color="accent" [disabled]="!selected">Let's go !</button>
     <a routerLink="../home"><button mat-button color="primary">Back</button></a>
   </article>
 </section>

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.html
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.html
@@ -21,7 +21,7 @@
       </mat-autocomplete>
     </mat-form-field>
     <div class="image"></div>
-    <button test-id="join-org" class="add-org" (click)="addOrganization()" mat-raised-button color="accent" [disabled]="!selected">Let's go !</button>
+    <button test-id="join-org" class="join-org" (click)="requestToJoinOrganization()" mat-raised-button color="accent" [disabled]="!selected">Let's go !</button>
     <a routerLink="../home"><button mat-button color="primary">Back</button></a>
   </article>
 </section>

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.scss
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.scss
@@ -19,7 +19,7 @@ h2 {
   margin: 0;
 }
 
-p{
+p {
   margin-top: 8px;
   margin-bottom: 50px;
 }
@@ -28,7 +28,7 @@ mat-form-field {
   width: 100%;
 }
 
-.add-org {
+.join-org {
   margin-top: 80px;
 }
 
@@ -40,7 +40,7 @@ mat-form-field {
   article {
     width: 80%;
   }
-  .addOrg {
+  .join-org {
     margin-top: 40px;
   }
 }

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.ts
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.ts
@@ -45,7 +45,7 @@ export class OrganizationFindComponent implements OnInit {
     this.selected = result;
   }
 
-  public async addOrganization() {
+  public async requestToJoinOrganization() {
     if (this.selected) {
       try {
         await this.invitationService.sendInvitationToOrg(this.selected.objectID);

--- a/libs/organization/src/lib/pages/organization-find/organization-find.component.ts
+++ b/libs/organization/src/lib/pages/organization-find/organization-find.component.ts
@@ -18,7 +18,7 @@ import { Index } from 'algoliasearch';
 })
 
 export class OrganizationFindComponent implements OnInit {
-  private selected: OrganizationAlgoliaResult;
+  public selected: OrganizationAlgoliaResult;
   public searchResults$: Observable<OrganizationAlgoliaResult[]>;
   public orgControl = new FormControl();
 

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.html
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.html
@@ -5,7 +5,7 @@
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis
       sagittis. Duis a auctor nulla, a finibus mauris. Nullam eu maximus lorem.
     </p>
-    <actions-list [items]="items"></actions-list>
+    <actions-list [items]="items$ | async"></actions-list>
     <div class="image"></div>
   </article>
 </section>

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.html
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.html
@@ -1,4 +1,4 @@
-<section fxLayout="row" fxLayoutAlign="center center">
+<section fxLayout="row" fxLayoutAlign="center center" test-id="content" page-id="join-the-community">
   <article fxLayout="column" fxLayoutAlign="center center">
     <h2>Join the community</h2>
     <p class="community">

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
@@ -1,8 +1,24 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActionItem } from '@blockframes/ui';
-import { InvitationService, InvitationType } from '@blockframes/notification';
+import { Invitation, InvitationService, InvitationType } from '@blockframes/notification';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+
+const invitationActionFromUserToOrganization = (invitation: Invitation) => ({
+  matIcon: 'alternate_email',
+  title: `Pending request to ${invitation.organization.name}`,
+  routerLink: '#',
+  description:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+});
+
+const invitationActionFromOrgToUser = (invitation: Invitation) => ({
+  matIcon: 'alternate_email',
+  title: `Join ${invitation.organization.name}`,
+  action: () => this.acceptInvitation(invitation),
+  description:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+});
 
 @Component({
   selector: 'organization-home',
@@ -35,23 +51,14 @@ export class OrganizationHomeComponent implements OnInit {
     this.items$ = this.invitationService.userInvitations$.pipe(
       map(invitations => {
         const actions = invitations.map(invitation => {
+          // Create the action item depending on which kind of invitation we have,
+          // - If the user created an invitation that is still pending, display with no action,
+          // - If an org sent them an invitation, display with an action that let them accept the invite.
           switch (invitation.type) {
             case InvitationType.fromUserToOrganization:
-              return {
-                matIcon: 'alternate_email',
-                title: `Pending request to ${invitation.organization.name}`,
-                routerLink: '#',
-                description:
-                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
-              };
+              return invitationActionFromUserToOrganization(invitation);
             case InvitationType.fromOrganizationToUser:
-              return {
-                matIcon: 'alternate_email',
-                title: `Join ${invitation.organization.name}`,
-                action: () => this.acceptInvitation(invitation),
-                description:
-                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
-              };
+              return invitationActionFromOrgToUser(invitation);
           }
         });
 

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActionItem } from '@blockframes/ui';
-import { InvitationService } from '@blockframes/notification';
+import { InvitationService, InvitationType } from '@blockframes/notification';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -35,13 +35,24 @@ export class OrganizationHomeComponent implements OnInit {
     this.items$ = this.invitationService.userInvitations$.pipe(
       map(invitations => {
         const actions = invitations.map(invitation => {
-          return {
-            matIcon: 'alternate_email',
-            title: `Join ${invitation.organization.name}`,
-            action: () => this.acceptInvitation(invitation),
-            description:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
-          };
+          switch (invitation.type) {
+            case InvitationType.fromUserToOrganization:
+              return {
+                matIcon: 'alternate_email',
+                title: `Pending request to ${invitation.organization.name}`,
+                routerLink: '#',
+                description:
+                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+              };
+            case InvitationType.fromOrganizationToUser:
+              return {
+                matIcon: 'alternate_email',
+                title: `Join ${invitation.organization.name}`,
+                action: () => this.acceptInvitation(invitation),
+                description:
+                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+              };
+          }
         });
 
         return [...actions, ...this.defaultItems];

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
@@ -1,5 +1,8 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActionItem } from '@blockframes/ui';
+import { InvitationService } from '@blockframes/notification';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'organization-home',
@@ -7,20 +10,46 @@ import { ActionItem } from '@blockframes/ui';
   styleUrls: ['./organization-home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-
-export class OrganizationHomeComponent {
-  items: ActionItem[] = [
+export class OrganizationHomeComponent implements OnInit {
+  defaultItems: ActionItem[] = [
     {
       routerLink: '../create',
       icon: 'adjustableWrench',
       title: 'Create your organization',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
     },
     {
       routerLink: '../find',
       icon: 'magnifyingGlass',
       title: 'Find your organization',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
     }
-  ]
+  ];
+  private items$: Observable<ActionItem[]>;
+
+  constructor(private invitationService: InvitationService) {}
+
+  ngOnInit(): void {
+    this.items$ = this.invitationService.userInvitations$.pipe(
+      map(invitations => {
+        const actions = invitations.map(invitation => {
+          return {
+            matIcon: 'alternate_email',
+            title: `Join ${invitation.organization.name}`,
+            action: () => this.acceptInvitation(invitation),
+            description:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
+          };
+        });
+
+        return [...actions, ...this.defaultItems];
+      })
+    );
+  }
+
+  private acceptInvitation(invitation) {
+    return this.invitationService.acceptInvitation(invitation.id);
+  }
 }

--- a/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
+++ b/libs/organization/src/lib/pages/organization-home/organization-home.component.ts
@@ -27,7 +27,7 @@ export class OrganizationHomeComponent implements OnInit {
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec luctus dictum metus quis sagittis.'
     }
   ];
-  private items$: Observable<ActionItem[]>;
+  public items$: Observable<ActionItem[]>;
 
   constructor(private invitationService: InvitationService) {}
 

--- a/libs/ui/src/lib/actions-list/actions-list.component.html
+++ b/libs/ui/src/lib/actions-list/actions-list.component.html
@@ -1,26 +1,24 @@
 <mat-nav-list>
   <ng-container *ngFor="let item of items; last as last">
     <ng-container *ngIf="item.routerLink">
-      <a [routerLink]="[item.routerLink]">
-        <mat-list-item>
-          <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">{{
-            item.matIcon
-          }}</mat-icon>
-          <h4 mat-line>
-            <b>{{ item.title }}</b>
-          </h4>
-          <p mat-line>{{ item.description }}</p>
-          <mat-icon class="right-icon">keyboard_arrow_right</mat-icon>
-        </mat-list-item>
-        <mat-divider *ngIf="!last"></mat-divider>
-      </a>
+      <mat-list-item [routerLink]="item.routerLink">
+        <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">
+          {{ item.matIcon }}
+        </mat-icon>
+        <h4 mat-line>
+          <b>{{ item.title }}</b>
+        </h4>
+        <p mat-line>{{ item.description }}</p>
+        <mat-icon class="right-icon">keyboard_arrow_right</mat-icon>
+      </mat-list-item>
+      <mat-divider *ngIf="!last"></mat-divider>
     </ng-container>
     <ng-container *ngIf="item.action">
       <a (click)="item.action()">
         <mat-list-item>
-          <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">{{
-            item.matIcon
-          }}</mat-icon>
+          <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">
+            {{ item.matIcon }}
+          </mat-icon>
           <h4 mat-line>
             <b>{{ item.title }}</b>
           </h4>

--- a/libs/ui/src/lib/actions-list/actions-list.component.html
+++ b/libs/ui/src/lib/actions-list/actions-list.component.html
@@ -1,13 +1,34 @@
 <mat-nav-list>
-  <a *ngFor="let item of items; last as last" [routerLink]="[item.routerLink]">
-    <mat-list-item>
-      <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon"></mat-icon>
-      <h4 mat-line>
-        <b>{{ item.title }}</b>
-      </h4>
-      <p mat-line>{{ item.description }}</p>
-      <mat-icon class="right-icon">keyboard_arrow_right</mat-icon>
-    </mat-list-item>
-    <mat-divider *ngIf="!last"></mat-divider>
-  </a>
+  <ng-container *ngFor="let item of items; last as last">
+    <ng-container *ngIf="item.routerLink">
+      <a [routerLink]="[item.routerLink]">
+        <mat-list-item>
+          <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">{{
+            item.matIcon
+          }}</mat-icon>
+          <h4 mat-line>
+            <b>{{ item.title }}</b>
+          </h4>
+          <p mat-line>{{ item.description }}</p>
+          <mat-icon class="right-icon">keyboard_arrow_right</mat-icon>
+        </mat-list-item>
+        <mat-divider *ngIf="!last"></mat-divider>
+      </a>
+    </ng-container>
+    <ng-container *ngIf="item.action">
+      <a (click)="item.action()">
+        <mat-list-item>
+          <mat-icon class="left-icon" matListIcon [svgIcon]="item.icon">{{
+            item.matIcon
+          }}</mat-icon>
+          <h4 mat-line>
+            <b>{{ item.title }}</b>
+          </h4>
+          <p mat-line>{{ item.description }}</p>
+          <mat-icon class="right-icon">keyboard_arrow_right</mat-icon>
+        </mat-list-item>
+        <mat-divider *ngIf="!last"></mat-divider>
+      </a>
+    </ng-container>
+  </ng-container>
 </mat-nav-list>

--- a/libs/ui/src/lib/actions-list/actions-list.component.ts
+++ b/libs/ui/src/lib/actions-list/actions-list.component.ts
@@ -1,11 +1,22 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-export interface ActionItem {
+interface ActionItemLink {
   routerLink: string;
-  icon: string;
+  icon?: string;
+  matIcon?: string;
   title: string;
   description: string;
 }
+
+interface ActionItemAction {
+  action: () => any;
+  icon?: string;
+  matIcon?: string;
+  title: string;
+  description: string;
+}
+
+export type ActionItem = ActionItemLink | ActionItemAction
 
 @Component({
   selector: 'actions-list',

--- a/libs/ui/src/lib/feedback/feedback-message.component.html
+++ b/libs/ui/src/lib/feedback/feedback-message.component.html
@@ -4,5 +4,5 @@
   <div fxLayout="row" fxLayoutAlign="center">
     <img [src]="imageUrl" alt="congratulation" />
   </div>
-  <a [disabled]="!enabled" (click)="redirectUser.emit()" mat-raised-button color="accent">{{ buttonMessage }}</a>
+  <a test-id="feedback-link" [disabled]="!enabled" (click)="redirectUser.emit()" mat-raised-button color="accent">{{ buttonMessage }}</a>
 </section>

--- a/libs/ui/src/lib/toolbar/context-menu/context-menu.component.html
+++ b/libs/ui/src/lib/toolbar/context-menu/context-menu.component.html
@@ -1,4 +1,4 @@
-<nav mat-tab-nav-bar color="primary">
+<nav test-id="context-menu" mat-tab-nav-bar color="primary">
   <a mat-tab-link *ngFor="let item of (items$ | async)" [routerLink]="[item.path]" [active]="isActive([item.path], item.exact)">
     {{item.name}}
   </a>

--- a/libs/utils/src/lib/firequery/firequery.ts
+++ b/libs/utils/src/lib/firequery/firequery.ts
@@ -51,7 +51,7 @@ export class FireQuery extends AngularFirestore {
     if (Array.isArray(query)) {
       return this.fromDocList(query);
     }
-    // If path is event, this is a doc, else, this is a collection
+    // If the count of path parts is even, this is a doc, else, this is a collection
     const isEven = query.path.split('/').length % 2 === 0;
     return isEven
       ? this.fromDoc(query)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:ip-upload": "npx ng build ip-upload --base-href /ip-upload/ --configuration=\"${ENV:-dev}\"",
     "build:catalog": "npx ng build catalog --base-href /catalog/ --configuration=\"${ENV:-dev}\"",
     "build:functions": "npx ng build backend-functions --configuration=\"${ENV:-dev}\"",
-    "build:root": "mv ./dist/apps/main/* ./dist/apps/",
+    "build:root": "rm -rf ./dist/apps/assets && mv ./dist/apps/main/* ./dist/apps/",
     "build:all": "npm run build:main && npm run build:delivery && npm run build:catalog && npm run build:movie-financing && npm run build:ip-upload && npm run build:functions && npm run build:root",
     "firebase:serve": "concurrently --kill-others \"npm run build:functions --watch\" \"firebase serve --only functions\"",
     "firebase:shell": "concurrently --kill-others \"npm run build:functions --watch\" \"firebase functions:shell\" --raw",


### PR DESCRIPTION
This PR implement the missing code so that:
- [x] users can find their organization on the account creation funnel with algolia
- [x] back and forth with email and invitation update when a user requests to join an org
- [x] back and forth with email and invitation update when an org invites a user

Fixes #577 #575 #576 

This PR includes the code from: 
https://github.com/blockframes/blockframes/pull/727

Later (once we QA the wole flow):
- [ ] we need a way to split the case "user waits for org to accept them" and "org waits to be accepted after creation" in the account creation funnel

Testing the whole flow triggered a bunch of issues, listed here:
https://github.com/blockframes/blockframes/issues/738