### PR TITLE
💣 reset code hack 💣

### DIFF
--- a/apps/backend-functions/src/assets/mail-templates.ts
+++ b/apps/backend-functions/src/assets/mail-templates.ts
@@ -10,6 +10,7 @@ const USER_ORG_INVITATION = '/layout/organization/home';
 export const ADMIN_ACCEPT_ORG_PATH = '/admin/acceptOrganization';
 export const ADMIN_ACCESS_TO_APP_PATH = '/admin/allowAccessToApp';
 export const ADMIN_DATA_PATH = '/admin/data'; // backup / restore
+export const RESET_PASSWORD = '/auth/password-reset?oobCode='
 
 // ------------------------- //
 //   FOR BLOCKFRAMES USERS   //
@@ -27,9 +28,9 @@ export function userVerifyEmail(email: string, link: string): EmailTemplateReque
   return { to: email, templateId: templateIds.userVerifyEmail, data };
 }
 
-export function userResetPassword(email: string, link: string): EmailTemplateRequest {
+export function userResetPassword(email: string, resetCode: string): EmailTemplateRequest {
   const data = {
-    pageURL: link
+    pageURL: `${appUrl}${RESET_PASSWORD}${resetCode}`
   };
   return { to: email, templateId: templateIds.resetPassword, data };
 }

--- a/apps/backend-functions/src/users.ts
+++ b/apps/backend-functions/src/users.ts
@@ -37,7 +37,12 @@ export const startResetPasswordEmailFlow = async (data: any, context: CallableCo
   }
 
   const resetLink = await admin.auth().generatePasswordResetLink(email);
-  await sendMailFromTemplate(userResetPassword(email, resetLink));
+  const resetUrl = new URL(resetLink);
+  const resetCode = resetUrl.searchParams.get('oobCode');
+  if (!resetCode) {
+    throw new Error('Generate Password Link has failed !');
+  }
+  await sendMailFromTemplate(userResetPassword(email, resetCode));
 };
 
 export const startWishlistEmailsFlow = async (data: any, context: CallableContext) => {

--- a/libs/auth/src/lib/pages/password-reset/password-reset.component.ts
+++ b/libs/auth/src/lib/pages/password-reset/password-reset.component.ts
@@ -37,6 +37,8 @@ export class PasswordResetComponent implements OnInit, OnDestroy {
         if (!params) this.router.navigate(['/layout']);
         this.actionCode = params['oobCode'];
 
+        console.log('action code', this.actionCode);
+
         // Verify the password reset code is valid.
         try {
           this.service.checkResetCode(this.actionCode);


### PR DESCRIPTION
this a quick hack to solve the reset code issue, @vincent decided to not use this solution, however I open this PR to have the code shared just in case.

- in the frontend we need a reset *code*
- in the backend I manage to generate a reset *link* but not a *code* (I search the various firebase docs, but didn't find how to do that)
- fortunately the reset *code* is included in the reset *link*, so I just extract this *code* and reconstruct our url

reset link :
`https://blockframes-pl-2.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=<CODE>&apiKey=<REDACTED>&lang=en`

the code is the `oobCode` parameter, the requested url is :
`https://BLOCKFRAME_DOMAIN/auth/password-reset?oobCode=<CODE>`