### PR TITLE
Issue#1568 contract list query

### DIFF
--- a/apps/catalog/catalog/src/app/dashboard/dashboard.module.ts
+++ b/apps/catalog/catalog/src/app/dashboard/dashboard.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LayoutModule } from './layout/layout.module';
 import { LayoutComponent } from './layout/layout.component';
+import { ActiveOrganizationContractsGuard } from '@blockframes/contract/guards/active-organization-contracts.guard'
 
 const routes: Routes = [
   {
@@ -28,6 +29,7 @@ const routes: Routes = [
       },
       {
         path: 'titles',
+        canActivate: [ActiveOrganizationContractsGuard],
         children: [{
           path: '',
           loadChildren: () => import('./title/list/list.module').then(m => m.TitleListModule)

--- a/apps/catalog/catalog/src/app/marketplace/movie/search/search.component.ts
+++ b/apps/catalog/catalog/src/app/marketplace/movie/search/search.component.ts
@@ -213,7 +213,7 @@ export class MarketplaceSearchComponent implements OnInit {
         if (AFM_DISABLE) {
           //TODO #1146
           return movies.filter(async movie => {
-            const deals = await this.distributionDealService.getDistributionDeals(movie.id);
+            const deals = await this.distributionDealService.getMovieDistributionDeals(movie.id);
             return filterMovie(movie, filterOptions, deals);
           });
         } else {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2,7 +2,7 @@
   "indexes": [],
   "fieldOverrides": [
     {
-      "collectionGroup": "distributiondeals",
+      "collectionGroup": "distributionDeals",
       "fieldPath": "licensor.orgId",
       "indexes": [
         {

--- a/firestore.rules
+++ b/firestore.rules
@@ -134,7 +134,7 @@ service cloud.firestore {
 
     /// DISTRIBUTION DEALS RULES ///
 
-    match /{path=**}/distributiondeals/{dealId} {
+    match /{path=**}/distributionDeals/{dealId} {
     	allow write: if true; // @TODO #1388 Only if contract.status  === 'unknown' ?
       allow read: if true; // @TODO #1388 Only if licensee.orgId == currentUser.orgId || if licensor.orgId == currentUser.orgId
     }

--- a/libs/contract/src/lib/+state/contract.service.ts
+++ b/libs/contract/src/lib/+state/contract.service.ts
@@ -76,7 +76,6 @@ export class ContractService extends CollectionService<ContractState> {
    */
   public async getContractWithLastVersion(contractOrId: Contract | string): Promise<ContractWithLastVersion> {
     try {
-
       const contractWithVersion = initContractWithVersion()
       const contract = typeof contractOrId === 'string'
         ? await this.getValue(contractOrId)
@@ -87,7 +86,7 @@ export class ContractService extends CollectionService<ContractState> {
 
       return contractWithVersion;
     } catch (error) {
-      console.log(`Contract ${contractOrId} not found`);
+      console.error('Contract not found');
     }
   }
 

--- a/libs/contract/src/lib/+state/contract.store.ts
+++ b/libs/contract/src/lib/+state/contract.store.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Contract } from './contract.model';
+import { ContractWithLastVersion } from './contract.model';
 import { EntityState, ActiveState, EntityStore, StoreConfig } from '@datorama/akita';
 
-export interface ContractState extends EntityState<Contract, string>, ActiveState<string> {}
+export interface ContractState extends EntityState<ContractWithLastVersion, string>, ActiveState<string> {}
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'contracts' })

--- a/libs/contract/src/lib/+state/contract.store.ts
+++ b/libs/contract/src/lib/+state/contract.store.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { ContractWithLastVersion } from './contract.model';
+import { Contract } from './contract.model';
 import { EntityState, ActiveState, EntityStore, StoreConfig } from '@datorama/akita';
 
-export interface ContractState extends EntityState<ContractWithLastVersion, string>, ActiveState<string> {}
+export interface ContractState extends EntityState<Contract, string>, ActiveState<string> {}
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'contracts' })

--- a/libs/contract/src/lib/version/+state/contract-version.service.ts
+++ b/libs/contract/src/lib/version/+state/contract-version.service.ts
@@ -76,7 +76,7 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
    * Returns the creation date of the contract.
    * @param contractId if not provided, get the last version of active contract.
    */
-  public async getContractCreationDate(contractId?: string): Promise<Date> {
+  public async getContractInitialCreationDate(contractId?: string): Promise<Date> {
     const documentPath = contractId ? `contracts/${contractId}/versions/` : '';
     const firstVersion = await this.getValue(documentPath + '1');
 

--- a/libs/contract/src/lib/version/+state/contract-version.service.ts
+++ b/libs/contract/src/lib/version/+state/contract-version.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
-import { CollectionConfig, CollectionService } from 'akita-ng-fire';
+import { CollectionService } from 'akita-ng-fire';
 import { ContractVersionState, ContractVersionStore } from './contract-version.store';
 import { ContractVersion, ContractWithLastVersion, VersionMeta } from './contract-version.model';
 import { ContractQuery } from '../../+state/contract.query';
 
 @Injectable({ providedIn: 'root' })
-@CollectionConfig({ path: 'contracts/:contractId/versions' })
 export class ContractVersionService extends CollectionService<ContractVersionState> {
   constructor(private contractQuery: ContractQuery, store: ContractVersionStore) {
     super(store);
@@ -71,5 +70,16 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
     const lastVersion = this.getValue(subCollectionPath + count.toString());
 
     return lastVersion;
+  }
+
+  /**
+   * Returns the creation date of the contract.
+   * @param contractId if not provided, get the last version of active contract.
+   */
+  public async getContractCreationDate(contractId?: string): Promise<Date> {
+    const documentPath = contractId ? `contracts/${contractId}/versions/` : '';
+    const firstVersion = await this.getValue(documentPath + '1');
+
+    return firstVersion.creationDate;
   }
 }

--- a/libs/movie/src/lib/distribution-deals/+state/distribution-deal.service.ts
+++ b/libs/movie/src/lib/distribution-deals/+state/distribution-deal.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import objectHash from 'object-hash';
 import { firestore } from 'firebase';
-import { CollectionConfig, CollectionService } from 'akita-ng-fire';
+import { CollectionService } from 'akita-ng-fire';
 import { DistributionDealState, DistributionDealStore } from './distribution-deal.store';
 import { OrganizationQuery } from '@blockframes/organization/+state/organization.query';
 import { MovieQuery } from '../../movie/+state/movie.query';
@@ -12,7 +12,6 @@ import { ContractWithLastVersion } from '@blockframes/contract/version/+state/co
 import { ContractService } from '@blockframes/contract/+state/contract.service';
 
 @Injectable({ providedIn: 'root' })
-@CollectionConfig({ path: 'movies/:movieId/distributiondeals' })
 export class DistributionDealService extends CollectionService<DistributionDealState> {
   constructor(
     private movieQuery: MovieQuery,
@@ -25,7 +24,7 @@ export class DistributionDealService extends CollectionService<DistributionDealS
   }
 
   get path() {
-    return `movies/${this.movieQuery.getActiveId()}/distributiondeals`;
+    return `movies/${this.movieQuery.getActiveId()}/distributionDeals`;
   }
 
   /**
@@ -54,7 +53,7 @@ export class DistributionDealService extends CollectionService<DistributionDealS
       // @todo #1397 change this price calculus
       contract.last.titles[movieId].price = contract.last.price;
 
-      const contractId = await this.contractVersionService.addContractAndVersion(contract)
+      const contractId = await this.contractVersionService.addContractAndVersion(contract);
 
       // Link distributiondeal with contract
       distributionDeal.contractId = contractId;
@@ -64,7 +63,7 @@ export class DistributionDealService extends CollectionService<DistributionDealS
       // Contract may have been updated along with the distribution deal, we update it
       await this.contractService.add(contract.doc);
       await this.contractVersionService.add(contract.last);
-      return distributionDeal.id ;
+      return distributionDeal.id;
     }
   }
 
@@ -85,18 +84,48 @@ export class DistributionDealService extends CollectionService<DistributionDealS
    * @param type  licensee | licensor
    */
   public async getMyDeals(type: string = 'licensor'): Promise<DistributionDeal[]> {
-    const myDeals = await this.getValue(ref =>
-      ref.where(`${type}.orgId`, '==', this.organizationQuery.getActiveId())
-    );
-    return myDeals.map(deal => this.formatDistributionDeal(deal));
+    const myDealsSnap = await this.db
+      .collectionGroup('distributionDeals', ref => ref.where(`${type}.orgId`, '==', this.organizationQuery.getActiveId()))
+      .get()
+      .toPromise();
+    const myDeals = myDealsSnap.docs.map(deal => this.formatDistributionDeal(deal.data()));
+    return myDeals;
   }
 
   /**
    * Get distributionDeals from a specific movie.
    * @param movieId
    */
-  public async getDistributionDeals(movieId: string) {
-    const distributionDealsSnap = await this.db.collection(`movies/${movieId}/distributiondeals`).get().toPromise();
-    return distributionDealsSnap.docs.map(deal => deal.data() as DistributionDeal);
+  public async getMovieDistributionDeals(movieId: string): Promise<DistributionDeal[]> {
+    const distributionDealsSnap = await this.db
+      .collection(`movies/${movieId}/distributionDeals`)
+      .get()
+      .toPromise();
+    const distributionDeals = distributionDealsSnap.docs.map(deal => this.formatDistributionDeal(deal.data()));
+    return distributionDeals;
+  }
+
+  /**
+   * Get distributionDeals from a specific contract.
+   * @param contractId
+   */
+  public async getContractDistributionDeals(contractId: string): Promise<DistributionDeal[]> {
+    const distributionDealsSnap = await this.db
+      .collectionGroup('distributionDeals', ref => ref.where('contractId', '==', contractId))
+      .get()
+      .toPromise();
+    const distributionDeals = distributionDealsSnap.docs.map(deal => this.formatDistributionDeal(deal.data()));
+    return distributionDeals;
+  }
+
+  /**
+   * Get all the territories from a list of deals and
+   * return them into an array of string
+   * @param deals
+   */
+  public getDistributionDealsTerritories(deals: DistributionDeal[]): string[] {
+    const territories = deals.map(deal => deal.territory.map(territory => territory));
+    const flattenedTerritories = territories.reduce((acc, nestedArray) => acc.concat(nestedArray));
+    return flattenedTerritories;
   }
 }

--- a/libs/movie/src/lib/movie/+state/movie.service.ts
+++ b/libs/movie/src/lib/movie/+state/movie.service.ts
@@ -15,13 +15,14 @@ import { createImgRef } from '@blockframes/utils/image-uploader';
 import { ContractQuery } from '@blockframes/contract/+state/contract.query';
 import { Contract } from '@blockframes/contract/+state/contract.model';
 import { cleanModel } from '@blockframes/utils/helpers';
+import { Organization } from '@blockframes/organization/+state/organization.model';
 
 /** Query movies from the contract with distributions deals from the last version. */
 const movieListContractQuery = (contract: Contract, movieIds: string[]): Query<Movie[]> => ({
   path: 'movies',
   queryFn: ref => ref.where('id', 'in', movieIds),
   distributionDeals: (movie: Movie) => ({
-    path: `movies/${movie.id}/distributiondeals`,
+    path: `movies/${movie.id}/distributionDeals`,
     queryFn: ref => ref.where('id', 'in', contract.lastVersion.titles[movie.id].distributionDealIds)
   })
 });


### PR DESCRIPTION
- Update contract list query to avoid  fetching unwanted contracts.
- Add new functions to get contracts information when they are displayed as a list.
- Rename `distributiondeals` sub-collection into `distributionDeals`.
- Remove useless `@CollectionConfig` from subcollection services. 
