### PR TITLE
Fixing permissions creation / Update services

### DIFF
--- a/libs/contract/src/lib/contract/+state/contract.service.ts
+++ b/libs/contract/src/lib/contract/+state/contract.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ContractStore, ContractState } from './contract.store';
-import { CollectionConfig, CollectionService, awaitSyncQuery, Query, WriteOptions } from 'akita-ng-fire';
+import { CollectionConfig, CollectionService, awaitSyncQuery, Query } from 'akita-ng-fire';
 import { Contract, ContractPartyDetail, convertToContractDocument, createContractPartyDetail, initContractWithVersion, ContractWithLastVersion } from './contract.model';
 import orderBy from 'lodash/orderBy';
 import { OrganizationQuery } from '@blockframes/organization/+state/organization.query';
@@ -12,7 +12,6 @@ import { cleanModel } from '@blockframes/utils';
 import { ContractDocumentWithDates } from './contract.firestore';
 import { VersionMeta } from '@blockframes/contract/version/+state/contract-version.model';
 import { PermissionsService } from '@blockframes/organization';
-import { firestore } from 'firebase';
 
 /**
  * Get all the contracts where user organization is party.
@@ -124,9 +123,10 @@ export class ContractService extends CollectionService<ContractState> {
       const contractWithVersion = initContractWithVersion();
 
       for (const contract of contracts) {
-        this.contractVersionService.setContractId(contract.id);
+
         const contractVersions = await this.contractVersionService.getValue(ref =>
-          ref.where(`titles.${movieId}.distributionDealIds`, 'array-contains', distributionDealId)
+          ref.where(`titles.${movieId}.distributionDealIds`, 'array-contains', distributionDealId),
+          { params: { contractId: contract.id } }
         );
         if (contractVersions.length) {
           const sortedContractVersions = orderBy(contractVersions, 'id', 'desc');

--- a/libs/contract/src/lib/version/+state/contract-version.model.ts
+++ b/libs/contract/src/lib/version/+state/contract-version.model.ts
@@ -10,6 +10,7 @@ export interface VersionMeta extends ContractVersion {
 
 export function createVersionMeta(params: Partial<VersionMeta>): VersionMeta {
   return {
+    id: '_meta',
     count: params && params.count || 0,
   } as VersionMeta;
 }

--- a/libs/contract/src/lib/version/+state/contract-version.service.ts
+++ b/libs/contract/src/lib/version/+state/contract-version.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
-import { CollectionService } from 'akita-ng-fire';
+import { CollectionService, CollectionConfig } from 'akita-ng-fire';
 import { ContractVersionState, ContractVersionStore } from './contract-version.store';
 import { VersionMeta, createVersionMeta, ContractVersion } from './contract-version.model';
 import { ContractQuery } from '../../contract/+state/contract.query';
 import { ContractWithLastVersion } from '../../contract/+state/contract.model';
 
 @Injectable({ providedIn: 'root' })
+@CollectionConfig({ path: 'contracts/:contractId/versions' })
 export class ContractVersionService extends CollectionService<ContractVersionState> {
-  private contractId: string;
 
   constructor(private contractQuery: ContractQuery, store: ContractVersionStore) {
     super(store);
@@ -26,36 +26,21 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
     })
   }
 
-  get path() {
-    if (!this.contractId) {
-      this.contractId = this.contractQuery.getActiveId();
-    }
-    return `contracts/${this.contractId}/versions`;
-  }
-
-  /**
-   * @dev when we are out the scope of a guard to set the contractId
-   * @param contractId 
-   * @todo #1644 remove this and find a workaround
-   */
-  public setContractId(contractId: string) {
-    this.contractId = contractId;
-  }
-
   /**
    * Add a new version of the contract.
    * @param contractId
    * @param contractWithLastVersion
    */
   public async addContractVersion(contractWithLastVersion: ContractWithLastVersion): Promise<string> {
-    this.contractId = contractWithLastVersion.doc.id;
     await this.db.firestore.runTransaction(async tx => {
+      const contractId = contractWithLastVersion.doc.id;
+      const lastVersionId = contractWithLastVersion.last.id;
       // Get the _meta document from versions subcollection.
-      const _metaSnap = await tx.get(this.db.doc(`${this.path}/_meta`).ref);
+      const _metaSnap = await tx.get(this.db.doc(`contracts/${contractId}/versions/_meta`).ref);
       const _meta = createVersionMeta(_metaSnap.data());
       // Increment count and then assign it to contractVersion id.
       contractWithLastVersion.last.id = (++_meta.count).toString();
-      const versionRef = this.db.collection(`${this.path}`).doc(contractWithLastVersion.last.id).ref;
+      const versionRef = this.db.doc(`contracts/${contractId}/versions/${lastVersionId}`).ref;
 
       // Update/create _meta and add the version.
       tx.set(_metaSnap.ref, _meta);
@@ -68,14 +53,11 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
    * Returns last contract version.
    * @param contractId if not provided, get the last version of active contract.
    */
-  public async getLastVersionContract(contractId?: string): Promise<ContractVersion> {
+  public async getLastVersionContract(contractId: string): Promise<ContractVersion> {
 
-    if (contractId) {
-      this.contractId = contractId;
-    }
-    const { count } = await this.getValue('_meta') as VersionMeta;
+    const { count } = await this.getValue('_meta', { params: { contractId } }) as VersionMeta;
     if (!!count) {
-      const lastVersion = await this.getValue(count.toString());
+      const lastVersion = await this.getValue(count.toString(), { params: { contractId } });
       return lastVersion;
     }
   }
@@ -84,9 +66,8 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
    * Returns the creation date of the contract.
    * @param contractId if not provided, get the last version of active contract.
    */
-  public async getContractInitialCreationDate(contractId?: string): Promise<Date> {
-    const documentPath = contractId ? `contracts/${contractId}/versions/` : '';
-    const firstVersion = await this.getValue(documentPath + '1');
+  public async getContractInitialCreationDate(contractId: string): Promise<Date> {
+    const firstVersion = await this.getValue('1', { params: { contractId } });
 
     return firstVersion.creationDate;
   }

--- a/libs/contract/src/lib/version/+state/contract-version.service.ts
+++ b/libs/contract/src/lib/version/+state/contract-version.service.ts
@@ -3,7 +3,7 @@ import { CollectionService, CollectionConfig } from 'akita-ng-fire';
 import { ContractVersionState, ContractVersionStore } from './contract-version.store';
 import { VersionMeta, createVersionMeta, ContractVersion } from './contract-version.model';
 import { ContractQuery } from '../../contract/+state/contract.query';
-import { ContractWithLastVersion } from '../../contract/+state/contract.model';
+import { ContractWithLastVersion, Contract } from '../../contract/+state/contract.model';
 
 @Injectable({ providedIn: 'root' })
 @CollectionConfig({ path: 'contracts/:contractId/versions' })
@@ -51,7 +51,7 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
 
   /**
    * Returns last contract version.
-   * @param contractId if not provided, get the last version of active contract.
+   * @param contractId
    */
   public async getLastVersionContract(contractId: string): Promise<ContractVersion> {
 
@@ -64,11 +64,10 @@ export class ContractVersionService extends CollectionService<ContractVersionSta
 
   /**
    * Returns the creation date of the contract.
-   * @param contractId if not provided, get the last version of active contract.
+   * @param contract
    */
-  public async getContractInitialCreationDate(contractId: string): Promise<Date> {
-    const firstVersion = await this.getValue('1', { params: { contractId } });
-
-    return firstVersion.creationDate;
+  public getContractInitialCreationDate(contract: Contract): Date {
+    const firstContract = contract.versions.find(version => version.id === '1');
+    return firstContract.creationDate;
   }
 }

--- a/libs/organization/src/lib/permissions/+state/permissions.service.ts
+++ b/libs/organization/src/lib/permissions/+state/permissions.service.ts
@@ -1,17 +1,24 @@
 import { Injectable } from '@angular/core';
 import { PermissionsQuery } from './permissions.query';
 import { OrganizationMember } from '../../member/+state/member.model';
-import { UserRole } from './permissions.firestore';
+import { UserRole, createDocPermissions } from './permissions.firestore';
 import { PermissionsState, PermissionsStore } from './permissions.store';
 import { CollectionService, CollectionConfig } from 'akita-ng-fire';
+import { BFDoc } from '@blockframes/utils/firequery/types';
+import { firestore } from 'firebase';
+import { OrganizationQuery } from '@blockframes/organization/+state/organization.query';
 
 @Injectable({
   providedIn: 'root'
 })
-@CollectionConfig({ path: 'permissions'})
+@CollectionConfig({ path: 'permissions' })
 export class PermissionsService extends CollectionService<PermissionsState> {
-  constructor(private query: PermissionsQuery, store: PermissionsStore) {
-    super(store)
+  constructor(
+    private query: PermissionsQuery,
+    private organizationQuery: OrganizationQuery,
+    store: PermissionsStore
+  ) {
+    super(store);
   }
 
   /** Update roles of members of the organization */
@@ -20,7 +27,7 @@ export class PermissionsService extends CollectionService<PermissionsState> {
     const permissions = await this.getValue(orgId);
 
     organizationMembers.forEach(({ uid, role }) => {
-      switch(role) {
+      switch (role) {
         case UserRole.superAdmin:
           delete permissions.roles[uid];
           permissions.roles[uid] = UserRole.superAdmin;
@@ -38,6 +45,19 @@ export class PermissionsService extends CollectionService<PermissionsState> {
       }
     });
 
-    return this.update(orgId, { roles: permissions.roles })
+    return this.update(orgId, { roles: permissions.roles });
+  }
+
+  /**
+   * Takes a document (movie or delivery), create relative permissions
+   * and add them to documentPermissions subcollection.
+   * @param doc
+   * @param write
+   */
+  public addDocumentPermissions(doc: BFDoc, write: firestore.WriteBatch) {
+    const organizationId = this.organizationQuery.getActiveId();
+    const documentPermissions = createDocPermissions({ id: doc.id, ownerId: organizationId });
+    const documentPermissionsRef = this.db.doc(`permissions/${organizationId}/documentPermissions/${documentPermissions.id}`).ref;
+    write.set(documentPermissionsRef, documentPermissions);
   }
 }


### PR DESCRIPTION
- Add onCreate hooks for Movie, Delivery and Contract document => related permissions are created when a document is added to firestore.
- Update services with CollectionService methods. (fix #1644 )