### PR TITLE
Fixing permissions again

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,6 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-
     ///////////////////
     /// COLLECTIONS ///
     ///////////////////
@@ -67,16 +66,17 @@ service cloud.firestore {
 
     match /permissions/{orgId} {
     	allow read: if isOrgMember(userId(), orgId);
-      allow create: if isOrgAdmin(userId(), orgId)
+      allow create: if (isOrgAdmin(userId(), orgId)
       	&& incomingData().id == orgId
-        && documentIdChecked(orgId, 'permissions');
+        && documentIdChecked(orgId, 'permissions'))
+        || isCreatingOrganization(orgId);
 			allow update: if isOrgAdmin(userId(), orgId)
       	&& incomingData().id == orgId
         && documentIdChecked(orgId, 'permissions')
         && incomingData().id == existingData().id;
 
       match /documentPermissions/{docId} {
-        allow read: if isOrgMember(orgId);
+        allow read: if isOrgMember(userId(), orgId);
         allow create: if isOrgMember(userId(), orgId)
           && incomingData().id == docId;
         allow update: if isOrgAdmin(userId(), orgId)
@@ -147,7 +147,7 @@ service cloud.firestore {
 
     match /contracts/{contractId} {
     	allow read: if userHasValidOrg(); // allow read: if isParty(userOrgId()) || isBlockframesAdmin(userId()); => ISSUE#1619
-      allow create: if userHasValidOrg();
+      allow create: if canCreateNewPermissions(userOrgId(), contractId);
       allow update: if orgCan('canUpdate', userOrgId(), contractId);
       allow delete: if orgCan('canDelete', userOrgId(), contractId);
 
@@ -231,6 +231,11 @@ service cloud.firestore {
 
     function canCreateNewPermissions(orgId, docId) {
     	return getAfter(/databases/$(database)/documents/permissions/$(orgId)/documentPermissions/$(docId)).data.canCreate == true;
+    }
+
+    function isCreatingOrganization(orgId) {
+			return userId() in getAfter(/databases/$(database)/documents/orgs/$(orgId)).data.userIds
+      	&& exists(/databases/$(database)/documents/orgs/$(orgId)) == false;
     }
 
     function getOrgPermissions(orgId) {

--- a/libs/organization/src/lib/+state/organization.service.ts
+++ b/libs/organization/src/lib/+state/organization.service.ts
@@ -76,16 +76,9 @@ export class OrganizationService extends CollectionService<OrganizationState> {
     });
     const permissionsDoc = this.db.doc(`permissions/${orgId}`);
     const userDoc = this.db.doc(`users/${user.uid}`);
-    const apps: App[] = [App.mediaDelivering, App.mediaFinanciers, App.storiesAndMore];
 
     // Set the new organization in permissions collection.
     (write as firestore.WriteBatch).set(permissionsDoc.ref, permissions);
-    // Initialize apps permissions documents in permissions apps sub-collection.
-    apps.map(app => {
-      const newApp = this.db.doc(`permissions/${orgId}/userAppsPermissions/${app}`);
-      const appPermissions = createAppPermissions(app);
-      return (write as firestore.WriteBatch).set(newApp.ref, appPermissions);
-    })
 
     // Update user with orgId.
     return write.update(userDoc.ref, { orgId });


### PR DESCRIPTION
- Remove unused appsPermissions subcollection (until we meet again)
- Add new rule in permissions collection when creating an organization (checks that organization document doesn't exist and checks that userId will be in the organization document to be created).