### PR TITLE
With errors

### DIFF
--- a/apps/catalog/catalog/src/app/app.module.ts
+++ b/apps/catalog/catalog/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { intercomId } from '@env';
 // Analytics
 import { FireAnalytics } from '@blockframes/utils/analytics/app-analytics';
 import { AnalyticsEvents } from '@blockframes/utils/analytics/analyticsEvents';
+import { ErrorLoggerModule } from '@blockframes/utils/error-logger.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -66,7 +67,7 @@ import { AnalyticsEvents } from '@blockframes/utils/analytics/analyticsEvents';
     AngularFireStorageModule,
     AngularFireAnalyticsModule,
     // Analytics
-    sentryDsn ? SentryModule : [],
+    sentryDsn ? SentryModule : ErrorLoggerModule,
 
     // Akita
     AkitaNgRouterStoreModule,

--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -5,15 +5,20 @@
  * This ErrorLoggerHandler is a hack to make sure we are actually logging the error.
  */
 import { ErrorHandler, Injectable, NgModule } from '@angular/core';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
 @Injectable()
 export class ErrorLoggerHandler implements ErrorHandler {
+  constructor(private snackBar: MatSnackBar) {}
+
   handleError(error) {
     console.error(error);
+    this.snackBar.open(`${error}`.substring(0, 100));
   }
 }
 
 @NgModule({
+  imports: [MatSnackBarModule],
   providers: [
     {
       provide: ErrorHandler,

--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -11,7 +11,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 export class ErrorLoggerHandler implements ErrorHandler {
   constructor(private snackBar: MatSnackBar) {}
 
-  handleError(error) {
+  handleError(error: any) {
     console.error(error);
     this.snackBar.open(`${error}`.substring(0, 100));
   }

--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -1,0 +1,24 @@
+/**
+ * At some point our frontend started capturing errors and made them impossible to
+ * detect at dev time (we had to use sentry on our dev machine to see errors).
+ *
+ * This ErrorLoggerHandler is a hack to make sure we are actually logging the error.
+ */
+import { ErrorHandler, Injectable, NgModule } from '@angular/core';
+
+@Injectable()
+export class ErrorLoggerHandler implements ErrorHandler {
+  handleError(error) {
+    console.error(error);
+  }
+}
+
+@NgModule({
+  providers: [
+    {
+      provide: ErrorHandler,
+      useClass: ErrorLoggerHandler
+    }
+  ]
+})
+export class ErrorLoggerModule {}

--- a/libs/utils/src/lib/sentry.module.ts
+++ b/libs/utils/src/lib/sentry.module.ts
@@ -3,9 +3,6 @@ import { sentryDsn } from '@env';
 import * as Sentry from '@sentry/browser';
 import { AuthQuery } from '@blockframes/auth/+state/auth.query';
 
-// Analytics
-const providers: any[] = [];
-
 @Injectable()
 export class SentryErrorHandler implements ErrorHandler {
   constructor(private authQuery: AuthQuery) {
@@ -35,10 +32,8 @@ export class SentryErrorHandler implements ErrorHandler {
 Sentry.init({
   dsn: sentryDsn
 });
-providers.push({ provide: ErrorHandler, useClass: SentryErrorHandler });
-
 
 @NgModule({
-  providers
+  providers: [{ provide: ErrorHandler, useClass: SentryErrorHandler }]
 })
 export class SentryModule {}


### PR DESCRIPTION
At some point we lost errors in the front, this PR adds an error handler that make sure we log the errors!
Only in cases where there are no sentry (we'll keep sentry in prod).

- [x] figure out what's the correct way to display a toast with our frameworks 