### PR TITLE
Add docId Index

### DIFF
--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -34,6 +34,7 @@ import { onOrganizationCreate, onOrganizationDelete, onOrganizationUpdate } from
 import { adminApp, onRequestAccessToAppWrite } from './admin';
 import { onMovieUpdate, onMovieCreate, onMovieDelete } from './movie';
 import * as bigQuery from './bigQuery';
+import { onDocumentPermissionCreate } from './permissions';
 
 /** Trigger: when eth-events-server pushes contract events. */
 export const onIpHashEvent = functions.pubsub.topic('eth-events.ipHash').onPublish(onIpHash);
@@ -117,6 +118,13 @@ export const onInvitationUpdateEvent = onDocumentWrite(
   'invitations/{invitationID}',
   onInvitationWrite
 );
+
+/** Trigger: when a permission document is created. */
+export const onDocumentPermissionCreateEvent = onDocumentCreate(
+  'permissions/{orgID}/documentPermissions/{docId}',
+  onDocumentPermissionCreate
+);
+
 
 //--------------------------------
 //       Movies Management        //

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -125,9 +125,8 @@ export const onDocumentPermissionCreateEvent = onDocumentCreate(
   onDocumentPermissionCreate
 );
 
-
 //--------------------------------
-//       Movies Management        //
+//       Movies Management      //
 //--------------------------------
 
 /**

--- a/apps/backend-functions/src/permissions.ts
+++ b/apps/backend-functions/src/permissions.ts
@@ -1,0 +1,21 @@
+/**
+ * Manage permission documents
+ */
+import { db, functions } from './internals/firebase';
+
+/**
+ * When a user creates a permisssion for a document we index its id,
+ * this is used in the firestore rules: a user cannot create a document if it already exists
+ * in the index.
+ *
+ * This index might be used for other features, will come later.
+ */
+export async function onDocumentPermissionCreate(
+  snapshot: FirebaseFirestore.DocumentSnapshot,
+  context: functions.EventContext
+) {
+  const { docID, orgID } = context.params;
+
+  // if the permission let you write the document, it means that you are the first owner.
+  return db.doc(`docsIndex/${docID}`).set({ authorOrgId: orgID });
+}

--- a/apps/backend-ops/src/firebaseSetup.ts
+++ b/apps/backend-ops/src/firebaseSetup.ts
@@ -30,7 +30,7 @@ export async function prepareForTesting() {
   process.exit(0);
 }
 
-export async function restoreShorcut() {
+export async function restoreShortcut() {
   return restore(appUrl);
 }
 

--- a/apps/backend-ops/src/firebaseSetup.ts
+++ b/apps/backend-ops/src/firebaseSetup.ts
@@ -30,6 +30,10 @@ export async function prepareForTesting() {
   process.exit(0);
 }
 
+export async function restoreShorcut() {
+  return restore(appUrl);
+}
+
 export async function upgrade() {
   console.info('Preparing the database...');
   await migrate(true);

--- a/apps/backend-ops/src/firestoreMigrations/0004.ts
+++ b/apps/backend-ops/src/firestoreMigrations/0004.ts
@@ -1,19 +1,19 @@
 import { Firestore } from '../admin';
 
 const orgAppAccessMapping = {
-  'jnbHKBP5YLvRQGcyQ8In': { catalogDashboard: true, catalogMarketplace: true },
-  'vcyZAPBMZaxyDsszeMZo': { catalogDashboard: true, catalogMarketplace: true },
-  'sLchj1Ib4Cxhwr0ZBW4m': { catalogDashboard: true, catalogMarketplace: false },
-  'B10P335uag5cUsDT1VGk': { catalogDashboard: false, catalogMarketplace: true },
-  'crcwtaCywM09U45evkuA': { catalogDashboard: false, catalogMarketplace: true },
-  'Gmjs8f9vRr68EbbyBSc6': { catalogDashboard: false, catalogMarketplace: true },
-  'SuF2np4mlqpHCmUfj42G': { catalogDashboard: false, catalogMarketplace: true },
-  'MjvTm9y69EPRjZyjsOap': { catalogDashboard: false, catalogMarketplace: true },
-  'J3yEyNgAUaN0wlix84Wk': { catalogDashboard: false, catalogMarketplace: true },
-  'uCkMfQ99t6qQtxfJqdvm': { catalogDashboard: true, catalogMarketplace: true },
-  'e1VXeusNJK6pb8kmVnUn': { catalogDashboard: true, catalogMarketplace: true },
-  'bzyMG1qBpWjkXfTB4F2r': { catalogDashboard: true, catalogMarketplace: false },
-}
+  jnbHKBP5YLvRQGcyQ8In: { catalogDashboard: true, catalogMarketplace: true },
+  vcyZAPBMZaxyDsszeMZo: { catalogDashboard: true, catalogMarketplace: true },
+  sLchj1Ib4Cxhwr0ZBW4m: { catalogDashboard: true, catalogMarketplace: false },
+  B10P335uag5cUsDT1VGk: { catalogDashboard: false, catalogMarketplace: true },
+  crcwtaCywM09U45evkuA: { catalogDashboard: false, catalogMarketplace: true },
+  Gmjs8f9vRr68EbbyBSc6: { catalogDashboard: false, catalogMarketplace: true },
+  SuF2np4mlqpHCmUfj42G: { catalogDashboard: false, catalogMarketplace: true },
+  MjvTm9y69EPRjZyjsOap: { catalogDashboard: false, catalogMarketplace: true },
+  J3yEyNgAUaN0wlix84Wk: { catalogDashboard: false, catalogMarketplace: true },
+  uCkMfQ99t6qQtxfJqdvm: { catalogDashboard: true, catalogMarketplace: true },
+  e1VXeusNJK6pb8kmVnUn: { catalogDashboard: true, catalogMarketplace: true },
+  bzyMG1qBpWjkXfTB4F2r: { catalogDashboard: true, catalogMarketplace: false }
+};
 
 /**
  * Update appAcces in organization documents
@@ -21,21 +21,22 @@ const orgAppAccessMapping = {
 export async function updateOrgStructure(db: Firestore) {
   const orgs = await db.collection('orgs').get();
 
-  const newOrgData = orgs.docs.map(async (orgDocSnapshot: any): Promise<any> => {
-    const orgData = orgDocSnapshot.data();
-    const newData = { ...orgData };
+  const newOrgData = orgs.docs.map(
+    async (orgDocSnapshot: any): Promise<any> => {
+      const orgData = orgDocSnapshot.data();
+      const newData = { ...orgData };
 
-    if (!newData.appAccess) {
-      if (orgAppAccessMapping[orgDocSnapshot.ref.id]) {
-        newData.appAccess = orgAppAccessMapping[orgDocSnapshot.ref.id];
-      } else {
-        newData.appAccess = { catalogDashboard: true, catalogMarketplace: true };
+      if (!newData.appAccess) {
+        if (orgAppAccessMapping[orgDocSnapshot.ref.id]) {
+          newData.appAccess = orgAppAccessMapping[orgDocSnapshot.ref.id];
+        } else {
+          newData.appAccess = { catalogDashboard: true, catalogMarketplace: true };
+        }
+
+        return orgDocSnapshot.ref.set(newData);
       }
-
-      return orgDocSnapshot.ref.set(newData);
     }
-
-  });
+  );
   await Promise.all(newOrgData);
   console.log('Updating appAccess in organization documents done.');
 }
@@ -46,16 +47,17 @@ export async function updateOrgStructure(db: Firestore) {
 export async function updateDistributionDealsStructure(db: Firestore) {
   const deals = await db.collectionGroup('distributionDeals').get();
 
-  const newDealData = deals.docs.map(async (dealDocSnapshot: any): Promise<any> => {
-    const dealData = dealDocSnapshot.data();
-    const newData = { ...dealData };
+  const newDealData = deals.docs.map(
+    async (dealDocSnapshot: any): Promise<any> => {
+      const dealData = dealDocSnapshot.data();
+      const newData = { ...dealData };
 
-    if (!newData.status) {
-      newData.status = 'draft';
-      return dealDocSnapshot.ref.set(newData);
+      if (!newData.status) {
+        newData.status = 'draft';
+        return dealDocSnapshot.ref.set(newData);
+      }
     }
-
-  });
+  );
   await Promise.all(newDealData);
   console.log('Updating status in distributionDeals documents done.');
 }

--- a/apps/backend-ops/src/firestoreMigrations/0005.ts
+++ b/apps/backend-ops/src/firestoreMigrations/0005.ts
@@ -1,5 +1,20 @@
 import { Firestore } from '../admin';
 
+/**
+ * Rename a key in a SIMPLE object. pure function: returns a NEW object,
+ * with SHALLOW cloning.
+ *
+ * @param m: object (mapping)
+ * @param k: old key name
+ * @param newK: new key name
+ */
+const renameKey = (m: { [key: string]: any }, k: string, newK: string) => {
+  const result = { ...m };
+  result[newK] = result[k];
+  delete result[k];
+  return result;
+};
+
 export async function upgrade(db: Firestore) {
   const permissions = await db.collection('permissions').get();
   const batch = db.batch();
@@ -23,7 +38,9 @@ export async function upgrade(db: Firestore) {
       const newRef = permission.ref.collection('documentPermissions').doc(orgDocPerm.id);
 
       const data = orgDocPerm.data();
-      batch.set(newRef, data);
+
+      const newData = renameKey(data, 'owner', 'ownerId');
+      batch.set(newRef, newData);
 
       const { id, owner } = data;
 

--- a/apps/backend-ops/src/firestoreMigrations/0005.ts
+++ b/apps/backend-ops/src/firestoreMigrations/0005.ts
@@ -1,0 +1,43 @@
+import { Firestore } from '../admin';
+
+export async function upgrade(db: Firestore) {
+  const permissions = await db.collection('permissions').get();
+  const batch = db.batch();
+
+  const updates = permissions.docs.map(async permission => {
+    // delete userAppsPermissions
+    const appsPerms = await permission.ref.collection('userAppsPermissions').get();
+    appsPerms.forEach(appPerm => {
+      batch.delete(appPerm.ref);
+    });
+
+    // delete userDocsPermission
+    const userDocPerms = await permission.ref.collection('userDocsPermissions').get();
+    userDocPerms.forEach(userDocPerm => {
+      batch.delete(userDocPerm.ref);
+    });
+
+    // rename orgDocsPermissions
+    const orgDocPerms = await permission.ref.collection('orgDocsPermissions').get();
+    orgDocPerms.forEach(orgDocPerm => {
+      const newRef = permission.ref.collection('documentPermissions').doc(orgDocPerm.id);
+
+      const data = orgDocPerm.data();
+      batch.set(newRef, data);
+
+      const { id, owner } = data;
+
+      if (orgDocPerm.ref.path.includes(owner)) {
+        // there's only one owner for a document, prevents pushing multiple time the same doc.
+        const indexRef = db.collection('docsIndex').doc(id);
+        batch.set(indexRef, { authorOrgId: owner });
+      }
+
+      // and delete!
+      batch.delete(orgDocPerm.ref);
+    });
+  });
+
+  await Promise.all(updates);
+  return batch.commit();
+}

--- a/apps/backend-ops/src/firestoreMigrations/index.ts
+++ b/apps/backend-ops/src/firestoreMigrations/index.ts
@@ -2,6 +2,8 @@ import * as v0001 from './0001';
 import * as v0002 from './0002';
 import * as v0003 from './0003';
 import * as v0004 from './0004';
+import * as v0005 from './0005';
+
 import { Firestore } from '../admin';
 
 export interface IMigration {
@@ -17,6 +19,7 @@ export const MIGRATIONS = {
   2: v0002,
   3: v0003,
   4: v0004,
+  5: v0005
 };
 
 export const VERSIONS_NUMBERS = Object.keys(MIGRATIONS).map(s => parseInt(s, 10));

--- a/apps/backend-ops/src/main.ts
+++ b/apps/backend-ops/src/main.ts
@@ -1,4 +1,4 @@
-import { prepareForTesting, upgrade } from './firebaseSetup';
+import { prepareForTesting, restoreShorcut, upgrade } from './firebaseSetup';
 import { migrate } from './migrations';
 import { exitable, showHelp } from './tools';
 import { upgradeAlgoliaMovies, upgradeAlgoliaOrgs } from './algolia';
@@ -11,6 +11,8 @@ if (cmd === 'prepareForTesting') {
   exitable(prepareForTesting)();
 } else if (cmd === 'upgrade') {
   exitable(upgrade)();
+} else if (cmd === 'restore') {
+  exitable(restoreShorcut)();
 } else if (cmd === 'migrate') {
   exitable(migrate)();
 } else if (cmd === 'syncUsers') {

--- a/apps/backend-ops/src/main.ts
+++ b/apps/backend-ops/src/main.ts
@@ -1,4 +1,4 @@
-import { prepareForTesting, restoreShorcut, upgrade } from './firebaseSetup';
+import { prepareForTesting, restoreShortcut, upgrade } from './firebaseSetup';
 import { migrate } from './migrations';
 import { exitable, showHelp } from './tools';
 import { upgradeAlgoliaMovies, upgradeAlgoliaOrgs } from './algolia';
@@ -12,7 +12,7 @@ if (cmd === 'prepareForTesting') {
 } else if (cmd === 'upgrade') {
   exitable(upgrade)();
 } else if (cmd === 'restore') {
-  exitable(restoreShorcut)();
+  exitable(restoreShortcut)();
 } else if (cmd === 'migrate') {
   exitable(migrate)();
 } else if (cmd === 'syncUsers') {

--- a/apps/backend-ops/src/migrations.ts
+++ b/apps/backend-ops/src/migrations.ts
@@ -82,10 +82,15 @@ export async function migrate(withBackup: boolean = true) {
     await updateDBVersion(db, lastVersion);
   } catch (e) {
     console.error(e);
-    console.error("the migration failed, revert'ing!");
+    console.error('the migration failed, revert\'ing!');
     await restore(appUrl);
     throw e;
   } finally {
+    if (withBackup) {
+      console.info('running a backup post-migration');
+      await backup(appUrl);
+      console.info('done with the backup post-migration');
+    }
     await endMaintenance();
     console.info('end the migration process...');
   }

--- a/apps/main/main/src/test-rules/006-permissions.spec.ts
+++ b/apps/main/main/src/test-rules/006-permissions.spec.ts
@@ -47,7 +47,7 @@ describe('permission table', () => {
     await expect(orgRef.delete()).toDeny();
   });
 
-  test.skip('deny a user from another org to give them auth on something owned by another org', async () => {
+  test('deny a user from another org to give them auth on something owned by another org', async () => {
     // R003: a user can give themselves a permission for a document owned by another org.
     const db = await setup(userTom, mockData);
     const orgRef = db.doc(

--- a/apps/main/main/src/test-rules/006-permissions.spec.ts
+++ b/apps/main/main/src/test-rules/006-permissions.spec.ts
@@ -94,6 +94,17 @@ describe('permission table', () => {
     await expect(permDoc.delete()).toDeny();
   });
 
+  test('disallow users to access the docsIndex', async () => {
+    const db = await setup(userMarie, mockData);
+    const permDoc = db.doc(`docsIndex/${contractAznavour.id}`);
+
+    await expect(permDoc.set({ id: 'wrongId', set: true })).toDeny();
+    await expect(permDoc.set({ id: 'newId', set: true })).toDeny();
+    await expect(permDoc.get()).toDeny();
+    await expect(permDoc.update({ updated: true })).toDeny();
+    await expect(permDoc.delete()).toDeny();
+  });
+
   test('disallow a user not admin to UPDATE a permission document', async () => {
     // they can create!
 

--- a/apps/main/main/src/test-rules/mock.ts
+++ b/apps/main/main/src/test-rules/mock.ts
@@ -196,6 +196,10 @@ export const mockData = [
   },
   // Permissions
   {
+    docPath: `docsIndex/${contractAznavour.id}`,
+    content: { authorOrgId: userGilles.orgId }
+  },
+  {
     docPath: `permissions/${userGilles.orgId}/documentPermissions/${contractAznavour.id}`,
     content: {
       canUpdate: true,

--- a/firestore.rules
+++ b/firestore.rules
@@ -82,6 +82,11 @@ service cloud.firestore {
     }
 
     /// PERMISSIONS RULES ///
+    match /docsIndex/{docId} {
+      // index of every doc create with a permission doc associated:
+      // essential for isBrandNewDocument.
+      allow read, write: if false;
+    }
 
     match /permissions/{orgId} {
     	allow read: if isOrgMember(userId(), orgId);

--- a/firestore.rules
+++ b/firestore.rules
@@ -56,11 +56,29 @@ service cloud.firestore {
     match /invitations/{invitationId} {
     	allow read: if userId() == existingData().user.uid
       	|| userOrgId() == existingData().organization.id;
-    	allow update, create: if userId() == incomingData().user.uid
+
+      allow create: if userId() == incomingData().user.uid
       	|| userOrgId() == incomingData().organization.id
-        || isOwner(userOrgId(), incomingData().docId)
         || orgCan('isAdmin', userOrgId(), incomingData().docId);
-      allow delete: if isOrgAdmin(userId(), orgId) || userId() == existingData().user.uid;
+
+
+    	allow update: if (
+        (
+          (incomingData().user.uid == existingData().user.uid)
+          && (incomingData().organization.id == existingData().organization.id)
+        )
+        &&
+        (
+          (userId() == existingData().user.uid)
+          || (userOrgId() == incomingData().organization.id)
+          || (orgCan('isAdmin', userOrgId(), incomingData().docId))
+        )
+      );
+
+      allow delete: if (
+        isOrgAdmin(userId(), existingData().organization.id)
+        || userId() == existingData().user.uid
+      );
     }
 
     /// ORGANIZATION RULES ///

--- a/firestore.rules
+++ b/firestore.rules
@@ -97,7 +97,8 @@ service cloud.firestore {
       match /documentPermissions/{docId} {
         allow read: if isOrgMember(userId(), orgId);
         allow create: if isOrgMember(userId(), orgId)
-          && incomingData().id == docId;
+          && incomingData().id == docId
+          && isBrandNewDocument(docId);
         allow update: if isOrgAdmin(userId(), orgId)
           && incomingData().id == docId
           && incomingData().id == existingData().id;
@@ -259,6 +260,11 @@ service cloud.firestore {
 
     function getDocumentPermissions(orgId, docId) {
     	return get(/databases/$(database)/documents/permissions/$(orgId)/documentPermissions/$(docId)).data;
+    }
+
+    function isBrandNewDocument(docId) {
+      // check that no corresponding doc exists in the index (you have to get invited to create perm for a document that ALREADY exists)
+      return !exists(/databases/$(database)/documents/docsIndex/$(docId));
     }
 
     function canCreateNewPermissions(orgId, docId) {


### PR DESCRIPTION
Fix "a user can give themselves permission for a document owned by another org (R003)"

When a user creates document permission, we index this document (allDocPermission/{docId}) => now we have ONE location with all the documents ids that have permission attached to them.

In the rules, we forbid the creation of a permission doc if there's already a corresponding document id in the index. => document permission for an object that ALREADY exists is created by the backend as admin.


