### PR TITLE
Maintenance App

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - checkout_project
       - run: echo "${FIREBASE_CI_SERVICE_ACCOUNT}" > creds.json
       - run: cp env/env.prod.ts env/env.ts # required for the typechecking & file rewrite to work
-      - run: npm run build:all
+      - run: npm run build:maintenance
       - slack/notify:
           message: '🧹 Deploying to maintenance production...'
       - do-exclusively/do-exclusively:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,7 @@ jobs:
       - run: npm run build:maintenance
       - slack/notify:
           message: '🧹 Deploying to maintenance production...'
-      - do-exclusively/do-exclusively:
-          # Note: right now do-exclusively excludes cross-jobs (staging & prod).
-          token: $CIRCLE_TOKEN
+      - run:
           command: |
             npx firebase use prod &&
             npx firebase deploy --only hosting:blockframes-maintenance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ references:
       name: start firestore emulator in background
       command: npm run firebase:emulator
       background: true
+  maintenance_only: &maintenance_only
+    filters:
+      branches:
+        only:
+          - maintenance
   production_only: &production_only
     filters:
       branches:
@@ -207,6 +212,25 @@ jobs:
             npx firebase deploy --only firestore:rules
           when: always
       - slack/status
+  deploy-to-maintenance:
+    executor: blockframes-ci
+    environment:
+      - ENV: production
+      - NODE_OPTIONS: '--max_old_space_size=4096'
+    steps:
+      - checkout_project
+      - run: echo "${FIREBASE_CI_SERVICE_ACCOUNT}" > creds.json
+      - run: cp env/env.prod.ts env/env.ts # required for the typechecking & file rewrite to work
+      - run: npm run build:all
+      - slack/notify:
+          message: '🧹 Deploying to maintenance production...'
+      - do-exclusively/do-exclusively:
+          # Note: right now do-exclusively excludes cross-jobs (staging & prod).
+          token: $CIRCLE_TOKEN
+          command: |
+            npx firebase use prod &&
+            npx firebase deploy --only hosting:blockframes-maintenance
+      - slack/status
   deploy-to-staging:
     executor: blockframes-ci
     environment:
@@ -267,6 +291,8 @@ workflows:
             - build-and-test-all
       - deploy-to-staging:
           <<: *staging_only
+      - deploy-to-maintenance:
+          <<: *maintenance_only
   nightly-e2e:
     triggers:
       - schedule:

--- a/apps/main/main/src/app/app-routing-module.ts
+++ b/apps/main/main/src/app/app-routing-module.ts
@@ -6,10 +6,12 @@ import { LayoutComponent } from './layout/layout.component';
 import { AppGridComponent } from './app-grid/app-grid.component';
 // Routes utils
 import { App } from '@blockframes/utils';
+import { MaintenanceGuard } from '@blockframes/ui/maintenance';
 
 const routes = [{
   path: '',
-  component: AppGridComponent
+  component: AppGridComponent,
+  canActivate: [MaintenanceGuard],
 },{
   path: 'catalog',
   loadChildren: () => import('@blockframes/apps/catalog/catalog.module').then(m => m.CatalogModule)

--- a/apps/main/main/src/app/app-routing-module.ts
+++ b/apps/main/main/src/app/app-routing-module.ts
@@ -8,19 +8,18 @@ import { AppGridComponent } from './app-grid/app-grid.component';
 import { App } from '@blockframes/utils';
 import { MaintenanceGuard } from '@blockframes/ui/maintenance';
 
-const routes = [{
-  path: '',
-  component: AppGridComponent,
-  canActivate: [MaintenanceGuard],
-},{
-  path: 'catalog',
-  loadChildren: () => import('@blockframes/apps/catalog/catalog.module').then(m => m.CatalogModule)
-},
-{
-  path: App.mediaDelivering,
-  data: { app: App.mediaDelivering },
-  loadChildren: () => import('@blockframes/apps/delivery/delivery.module').then(m => m.DeliveryModule)
-}]
+const routes = [
+  {
+    path: '',
+    component: AppGridComponent,
+    canActivate: [MaintenanceGuard]
+  },
+  {
+    path: 'maintenance',
+    canActivate: [MaintenanceGuard],
+    loadChildren: () => import('@blockframes/ui/maintenance').then(m => m.MaintenanceModule)
+  }
+];
 
 @NgModule({
   imports: [

--- a/apps/main/main/src/index.html
+++ b/apps/main/main/src/index.html
@@ -12,6 +12,7 @@
   <meta name="theme-color" content="#1976d2">
 
   <!-- issue#1146: Redirect to delivery / catalog / etc app for Berlin, quick hack -->
+  <!--
   <script>
     const hostname = window.location.hostname;
 
@@ -23,6 +24,7 @@
       // skip
     }
   </script>
+  -->
 
 </head>
 <body class="light-theme mat-app-background mat-typography">

--- a/apps/main/main/src/index.html
+++ b/apps/main/main/src/index.html
@@ -8,7 +8,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
-  <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#1976d2">
 
   <!-- issue#1146: Redirect to delivery / catalog / etc app for Berlin, quick hack -->

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "site": "blockframes-maintenance",
     "public": "dist/apps/",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [

--- a/firebase.json
+++ b/firebase.json
@@ -5,26 +5,6 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
-        "source": "/delivery/contract.pdf",
-        "function": "generateDeliveryPDF"
-      },
-      {
-        "source": "/admin{,/**}",
-        "function": "admin"
-      },
-      {
-        "source": "/delivery{,/**}",
-        "destination": "/delivery/index.html"
-      },
-      {
-        "source": "/catalog{,/**}",
-        "destination": "/catalog/index.html"
-      },
-      {
-        "source": "/movie-financing{,/**}",
-        "destination": "/movie-financing/index.html"
-      },
-      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/libs/ui/src/lib/maintenance/maintenance.component.html
+++ b/libs/ui/src/lib/maintenance/maintenance.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="isInMaintenance$ | async; else canRefresh">
   <h1 class="mat-display-1">We are in maintenance</h1>
-  <h3>Please come back on Friday 20th.</h3>
+  <h3>Please come back on Friday 21th.</h3>
 </ng-container>
 
 <ng-template #canRefresh>

--- a/libs/ui/src/lib/maintenance/maintenance.component.html
+++ b/libs/ui/src/lib/maintenance/maintenance.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="isInMaintenance$ | async; else canRefresh">
   <h1 class="mat-display-1">We are in maintenance</h1>
-  <h3>This should take about 20min</h3>
+  <h3>Please come back on Friday 20th.</h3>
 </ng-container>
 
 <ng-template #canRefresh>

--- a/libs/ui/src/lib/maintenance/maintenance.service.ts
+++ b/libs/ui/src/lib/maintenance/maintenance.service.ts
@@ -1,23 +1,20 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
-import { filter, tap, map, first } from 'rxjs/operators';
-import { isInMaintenance, IMaintenanceDoc, maintenancePath } from '@blockframes/utils/maintenance';
+import { filter, first, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class MaintenanceService {
-  
   // if document doesn't exist, we are not in the maintenance
-  isInMaintenance$ = this.db.doc<IMaintenanceDoc>(maintenancePath).valueChanges().pipe(
-    map(maintenanceDoc => maintenanceDoc ? isInMaintenance(maintenanceDoc) : false)
-  );
+  isInMaintenance$ = of(true);
 
   constructor(private db: AngularFirestore) {}
 
   redirectOnMaintenance() {
     return this.isInMaintenance$.pipe(
       filter(isMaintenance => !!isMaintenance),
-      first(),  // Change on maintenance can only happen once during the session
+      first(), // Change on maintenance can only happen once during the session
       tap(_ => window.location.reload())
-    )
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:backend-ops": "npx ng build backend-ops --configuration=\"${ENV:-dev}\"",
     "build:root": "rm -rf ./dist/apps/assets && mv ./dist/apps/main/* ./dist/apps/",
     "build:all": "npm run build:main && npm run build:delivery && npm run build:movie-financing && npm run build:backend-functions && npm run build:backend-ops && npm run build:catalog && npm run build:root",
+    "build:maintenance": "npm run build:main && npm run build:root",
     "firebase:serve": "concurrently --kill-others \"npm run build:functions --watch\" \"firebase serve --only functions\"",
     "firebase:shell": "concurrently --kill-others \"npm run build:functions --watch\" \"firebase functions:shell\" --raw",
     "firebase:emulator": "firebase emulators:start --only firestore",


### PR DESCRIPTION
We want to put the app in maintenance for our users and keep accessing it for our admins,
this enable a permanent maintenance page AND deploy to a maintenance app.

- Missing is the ability to auto-refresh the production app is deployed. Seem's to overcomplicate for low to no value.
- Good news is we now know how to use firebase apps structure for multiple sub applications.