### PR TITLE
Update translateSlug pipe for null/undefined values

### DIFF
--- a/libs/utils/src/lib/pipes/translate-slug.pipe.ts
+++ b/libs/utils/src/lib/pipes/translate-slug.pipe.ts
@@ -7,7 +7,7 @@ import { getLabelBySlug, Scope } from '@blockframes/utils/static-model/staticMod
 export class TranslateSlugPipe implements PipeTransform {
   transform(value: string | string[], property: Scope, language?: string): string {
     // TODO(MF, BD): add language parameter, when translation exist
-    const formatSlug = (slug: string) => getLabelBySlug(property, slug.trim().toLocaleLowerCase());
+    const formatSlug = (slug: string) => slug ? getLabelBySlug(property, slug.trim().toLocaleLowerCase()) : '';
     if (Array.isArray(value)) {
       return value.map(formatSlug).join(', ');
     } else {


### PR DESCRIPTION
Inner function `formatSlug` now returns an empty string if slug is undefined or null to avoid errors.

close #2121 