### PR TITLE
set scrollY to 0 when route change is happening

### DIFF
--- a/apps/catalog/catalog/src/app/dashboard/layout/layout.component.html
+++ b/apps/catalog/catalog/src/app/dashboard/layout/layout.component.html
@@ -28,7 +28,7 @@
   </mat-sidenav>
 
 
-  <mat-sidenav-content>
+  <mat-sidenav-content #content>
     <!-- TOOLBAR -->
     <mat-toolbar fxLayout="row" fxLayoutAlign="space-between center" id="catalog-toolbar">
       <button mat-icon-button (click)="sidenav.toggle()">

--- a/apps/catalog/catalog/src/app/dashboard/layout/layout.component.ts
+++ b/apps/catalog/catalog/src/app/dashboard/layout/layout.component.ts
@@ -1,9 +1,13 @@
 // Angular
 import { FormControl } from '@angular/forms';
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, AfterViewInit, OnDestroy, ViewChild } from '@angular/core';
+import { MatSidenavContent } from '@angular/material/sidenav';
+import { Router, NavigationEnd } from '@angular/router';
 
 import { BreakpointsService } from '@blockframes/utils/breakpoint/breakpoints.service';
 import { algolia } from '@env';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'catalog-layout',
@@ -11,13 +15,30 @@ import { algolia } from '@env';
   styleUrls: ['./layout.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LayoutComponent {
+export class LayoutComponent implements AfterViewInit, OnDestroy {
   searchCtrl: FormControl = new FormControl('');
 
   ltMd$ = this.breakpointsService.ltMd;
-
+  
   public movieIndex = algolia.indexNameMovies
+  
+  private routerSub: Subscription
 
-  constructor(
-    private breakpointsService: BreakpointsService) { }
+  @ViewChild('content') sidenavContent: MatSidenavContent;
+
+  constructor(private breakpointsService: BreakpointsService, private router: Router) { }
+
+    ngAfterViewInit() {
+    // https://github.com/angular/components/issues/4280
+    // TODO #2502
+    this.routerSub = this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.sidenavContent.scrollTo({top: 0});
+      })
+    }
+
+    ngOnDestroy() {
+      if(this.routerSub) { this.routerSub.unsubscribe(); }
+    }
 }

--- a/apps/catalog/catalog/src/app/marketplace/layout/layout.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/layout/layout.component.html
@@ -25,7 +25,7 @@
    </mat-nav-list>
   </mat-sidenav>
 
-  <mat-sidenav-content>
+  <mat-sidenav-content #content>
     <!-- TOOLBAR -->
     <mat-toolbar fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="default center" fxLayoutGap="24px">


### PR DESCRIPTION
close #2123 
now by every forward navigation in dashbord and marketplace we start at the top of the page.
But also on every backward navigation, we start also at the top.
There is a followup issue ref #2502 which explains why we have such behaviour. 
TLDR;
Its because we are in a mat side nav and which has his own scroll container, so the angular router cant access this container and set the position to scrollY position to 0.
Cause we need to go quick for the release 1.3 this is the intermediate solution.