### PR TITLE
Check security

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -303,7 +303,7 @@ service cloud.firestore {
 
     // We check that the field is not sent or if field sent is equal to actual
     function isNotUpdatingField(fieldName) {
-			return !incomingData().keys().hasAll([fieldName]) || (existingData.keys().hasAll([fieldName]) && incomingData()[fieldName] == existingData[fieldName]);
+			return !incomingData().keys().hasAll([fieldName]) || (existingData().keys().hasAll([fieldName]) && incomingData()[fieldName] == existingData()[fieldName]);
     }
   }
 }

--- a/libs/notification/src/lib/invitation/guard/invitations.guard.ts
+++ b/libs/notification/src/lib/invitation/guard/invitations.guard.ts
@@ -6,12 +6,33 @@ import { InvitationService } from '../+state/invitation.service';
 import { switchMap } from 'rxjs/operators';
 import { combineLatest } from 'rxjs';
 
+const testData = (query, name) => {
+  query.get().then(data => {
+    console.info(name, 'success!', data.docs.map(x => x.data()))
+  }).catch(err => {
+    console.error(name, 'failed!', err)
+  })
+}
+
 @Injectable({ providedIn: 'root' })
 @CollectionGuardConfig({ awaitSync: false })
 export class InvitationGuard extends CollectionGuard<InvitationState> {
   constructor(service: InvitationService, private authQuery: AuthQuery) {
     super(service);
-  }
+    // @ts-ignore
+    window.service = service;
+    // @ts-ignore
+    window.db = service.db.firestore;
+    //@ts-ignore
+    testData(service.db.collection('invitations').ref.where('fromOrg.id', '==', 'jnbHKBP5YLvRQGcyQ8In'), 'query my org')
+    //@ts-ignore
+    testData(service.db.collection('invitations').ref.where('fromUser.uid', '==', '1M9DUDBATqayXXaXMYThZGtE9up1'), 'query my user')
+    //@ts-ignore
+    testData(service.db.collection('invitations').ref, 'query all')
+    //@ts-ignore
+    testData(service.db.collection('invitations').ref.where('fromOrg.id', '==', 'XXX'), 'query another org')
+    //@ts-ignore
+    testData(service.db.collection('invitations').ref.where('fromUser.uid', '==', 'jnbHKBP5YLvRQGcyQ8In'), 'query another user')  }
 
   /** This sync on invitations where userId is the same as the connected user id */
   sync() {


### PR DESCRIPTION
login with `david.ewing@gillespie-lawrence.fake.cascade8.com`
check the logs.

query works when the correct filters are applied:

<img width="928" alt="Screenshot 2020-04-24 at 15 22 30" src="https://user-images.githubusercontent.com/1136669/80217665-5d537180-8640-11ea-8912-bf1cd71637d3.png">

(in the demo I added a fromOrg: id: JNxxxx, on ci database you'll see 2 empty arrays, no error)