### PR TITLE
ci: tweak test to run all in a bash

### DIFF
--- a/.circleci/deploy-and-test-e2e.sh
+++ b/.circleci/deploy-and-test-e2e.sh
@@ -28,5 +28,7 @@ npm run build:backend-ops && node dist/apps/backend-ops/main.js prepareForTestin
 echo "wait for maintenance mode to end (slightly more than 8 minutes)"
 sleep 500
 
-npm run e2e:catalog
-npm run e2e:festival
+npm run e2e:catalog && test1=$? || test1=$?
+npm run e2e:festival && test2=$? || test2=$?
+
+exit $(($test1 + $test2)) # we want to exit on error if any test exit is non-zero => sum the exit codes

--- a/env/demo/env.demo1.ts
+++ b/env/demo/env.demo1.ts
@@ -22,12 +22,14 @@ export const appUrlContent = 'https://demo1.archipelcontent.com';
 export const appUrlMarket = 'https://demo1.archipelmarket.com';
 
 export const firebase = {
-  apiKey: 'AIzaSyBu86_wOPRjXyR-wVXq4FLkQ0GZrcgWTsM',
-  authDomain: 'blockframes-demo-1.firebaseapp.com',
-  databaseURL: 'https://blockframes-demo-1.firebaseio.com',
-  projectId: 'blockframes-demo-1',
-  storageBucket: 'blockframes-demo-1.appspot.com',
-  messagingSenderId: '11685432883'
+  apiKey: "AIzaSyBu86_wOPRjXyR-wVXq4FLkQ0GZrcgWTsM",
+  authDomain: "blockframes-demo-1.firebaseapp.com",
+  databaseURL: "https://blockframes-demo-1.firebaseio.com",
+  projectId: "blockframes-demo-1",
+  storageBucket: "blockframes-demo-1.appspot.com",
+  messagingSenderId: "11685432883",
+  appId: "1:11685432883:web:bedc809872148fcde49d46",
+  measurementId: "G-ZQHCHN67GF"
 };
 
 // Algolia
@@ -81,7 +83,7 @@ export const templateIds = {
   // At this step, we can not use links into emails
   welcomeMessage: 'd-eb8e1eb7c5a24eb8af1d2d32539ad714',
 
-  // Template for sending the verify email 
+  // Template for sending the verify email
   // Internal to firebase, no link needed here
   userVerifyEmail: 'd-81438bdf511b43cfa866ca63a45a02ae',
 
@@ -102,7 +104,8 @@ export const templateIds = {
   wishlistPending: 'd-e0cd8970d19346eea499a81f67f1a557',
   invitationToMeetingFromUser: 'd-b40ccbd91c2f4d6599be56ab1f8e6631',
   invitationToScreeningFromOrg: 'd-1a7cc9ca846c4ae1b4e8cf8a76455cc5',
-  requestToAttendEventFromUser: 'd-07f5e3cc6796455097b6082c22568d9e'
+  requestToAttendEventFromUser: 'd-07f5e3cc6796455097b6082c22568d9e',
+  newAppAccessForOrg: 'd-274b8b8370b44dc2984273d28970a06d'
 }
 
 // Yandex Metrika Id
@@ -137,7 +140,7 @@ export const quorum = {
 
 // BigQuery
 // ========
-export const bigQueryAnalyticsTable = 'blockframes-staging.analytics_194475853.events_';
+export const bigQueryAnalyticsTable = 'blockframes-demo1.analytics_200039147.events_';
 
 // Archipel Content OrgId
 // ======================


### PR DESCRIPTION
Running e2e tests in a serialized queue relies on do-exclusively orb, we can't use the "always" option from circleci.

This tweaks the e2e testing to run all tests and gather their result to fail or succeed the test.

piggyback Vincent's demo1 config with this PR