### PR TITLE
Fix deleting other media values when uploading new image

### DIFF
--- a/libs/media/src/lib/+state/media.firestore.ts
+++ b/libs/media/src/lib/+state/media.firestore.ts
@@ -1,7 +1,7 @@
 export type ImgSizeDirectory = 'lg' | 'md' | 'xs' | 'original';
 export const imgSizeDirectory: ImgSizeDirectory[] = ['lg', 'md', 'xs', 'original'];
 
-// TODO(#3088) blob, delete and newRef shouldnt be in firestore; these values are only used to determine what to do with the image on update of Form
+// TODO(#3088) blob, delete and path shouldnt be in firestore; these values are only used to determine what to do with the image on update of Form
 export interface ImgRef {
   ref: string;
   urls: {
@@ -12,7 +12,8 @@ export interface ImgRef {
   };
   blob?: any;
   delete?: boolean;
-  newRef?: string;
+  path?: string;
+  fileName?: string;
 }
 
 // @todo(#3063) remove this interface
@@ -52,7 +53,7 @@ export function getImgSize(url: string) {
 }
 
 export interface UploadFile {
-  ref: string,
+  path: string,
   data: Blob,
   fileName: string,
 }

--- a/libs/media/src/lib/+state/media.model.ts
+++ b/libs/media/src/lib/+state/media.model.ts
@@ -2,20 +2,20 @@ import { ImgRef, OldImgRef } from './media.firestore';
 
 export * from './media.firestore';
 
-export function extractMedia(origin: any) {
+export function extractToBeUpdatedMedia(origin: any) {
   const value = Object.assign({}, origin);
-  const media = extractMediaValue(value);
+  const media = extractToBeUpdatedMediaValue(value);
   return [value, media];
 }
 
-function extractMediaValue(value: any) {
+function extractToBeUpdatedMediaValue(value: any) {
   let media: ImgRef[] = [];
   for (const key in value) {
-    if (isMedia(value[key])) {
+    if (isMedia(value[key]) && mediaNeedsUpdate(value[key])) {
       media.push(value[key]);
       delete value[key];
     } else if (typeof value[key] === 'object' && !!value[key]) {
-      const childMedia = extractMediaValue(value[key]);
+      const childMedia = extractToBeUpdatedMediaValue(value[key]);
       media = media.concat(childMedia);
     }
   }
@@ -26,6 +26,9 @@ function isMedia(obj: any): boolean {
   return typeof obj === 'object' && !!obj && 'ref' in obj && 'urls' in obj;
 }
 
+function mediaNeedsUpdate(obj: ImgRef): boolean {
+  return obj.delete || (obj.path && obj.blob);
+} 
 
 const formats = {
   avatar: {

--- a/libs/media/src/lib/+state/media.model.ts
+++ b/libs/media/src/lib/+state/media.model.ts
@@ -27,7 +27,7 @@ function isMedia(obj: any): boolean {
 }
 
 function mediaNeedsUpdate(obj: ImgRef): boolean {
-  return obj.delete || (obj.path && obj.blob);
+  return obj.delete || (!!obj.path && !!obj.blob);
 } 
 
 const formats = {

--- a/libs/media/src/lib/+state/media.service.ts
+++ b/libs/media/src/lib/+state/media.service.ts
@@ -11,6 +11,7 @@ import { UploadFile, ImgRef } from "./media.firestore";
 
 // Blockframes
 import { UploadWidgetComponent } from '../components/upload/widget/upload-widget.component';
+import { sanitizeFileName } from '@blockframes/utils/file-sanitizer';
 
 @Injectable({ providedIn: 'root' })
 export class MediaService {
@@ -43,7 +44,7 @@ export class MediaService {
     if (Array.isArray(uploadFiles)) {
       uploadFiles.forEach(uploadFile => this.uploadBlob(uploadFile));
     } else {
-      this.upload(uploadFiles.ref, uploadFiles.data, uploadFiles.fileName);
+      this.upload(uploadFiles.path, uploadFiles.data, uploadFiles.fileName);
     }
   }
   /**
@@ -59,7 +60,7 @@ export class MediaService {
     } else {
       const promises = [];
       for (let index = 0; index < file.length; index++) {
-        promises.push(this.upload(path, file.item(index), file.item(index).name))
+        promises.push(this.upload(path, file.item(index), file.item(index).name));
       }
       Promise.all(promises);
     }
@@ -73,11 +74,13 @@ export class MediaService {
  * @param fileName
  */
   private async upload(path: string, fileOrBlob: Blob | File, fileName: string) {
-    const exists = await this.exists(path.concat(fileName));
+    const sanitizedFileName: string = sanitizeFileName(fileName);
+    const exists = await this.exists(path.concat(sanitizedFileName));
+
     this.showWidget();
 
     if (exists) {
-      throw new Error(`Upload Error : there is already a file @ ${path}, please delete it before uploading a new file!`);
+      throw new Error(`Upload Error : there is already a file @ ${sanitizedFileName}, please delete it before uploading a new file!`);
     }
 
     const uploading = this.query.isUploading(fileName);
@@ -165,11 +168,10 @@ export class MediaService {
         if (imgRef.ref !== '') {
           this.removeFile(imgRef.ref);
         }
-        const fileName = imgRef.newRef.substr(imgRef.newRef.lastIndexOf('/') + 1);
         const file: UploadFile = {
-          ref: imgRef.newRef,
+          path: imgRef.path,
           data: imgRef.blob,
-          fileName: fileName
+          fileName: imgRef.fileName
         }
         this.uploadBlob(file);
       }

--- a/libs/media/src/lib/components/cropper/cropper.component.ts
+++ b/libs/media/src/lib/components/cropper/cropper.component.ts
@@ -59,7 +59,6 @@ export class CropperComponent implements OnInit, OnDestroy {
   //////////////////////
 
   private ref: AngularFireStorageReference;
-  private fileName: string;
   private step: BehaviorSubject<CropStep> = new BehaviorSubject('drop');
   private sub = new Subscription;
 
@@ -122,21 +121,21 @@ export class CropperComponent implements OnInit, OnDestroy {
         throw new Error('No image cropped yet');
       }
 
-      this.fileName = sanitizeFileName(this.file.name).replace(/(\.[\w\d_-]+)$/i, '.webp');
       const blob = b64toBlob(this.croppedImage);
 
       this.nextStep('show');
 
+      // regexp selects part of string after the last . in the string (which is always the file extension) and replaces this by '.webp'
+      const fileName = this.file.name.replace(/(\.[\w\d_-]+)$/i, '.webp');
+
       this.form.patchValue({
-        newRef: `${this.storagePath}/original/${this.fileName}`,
+        path: `${this.storagePath}/original/${fileName}`,
         blob: blob,
-        delete: false
+        delete: false,
+        fileName: fileName
       })
       this.form.markAsDirty();
 
-      this.form.newRef.setValue(`${this.storagePath}/original/${this.fileName}`);
-      this.form.blob.setValue(blob);
-      this.form.delete.setValue(false);
     } catch (err) {
       console.error(err);
     }
@@ -153,8 +152,9 @@ export class CropperComponent implements OnInit, OnDestroy {
     }
 
     this.form.patchValue({
-      newRef: '',
+      path: '',
       blob: '',
+      fileName:'',
       delete: true
     })
     this.form.markAsDirty();

--- a/libs/media/src/lib/directives/image-reference/image-reference.form.ts
+++ b/libs/media/src/lib/directives/image-reference/image-reference.form.ts
@@ -13,8 +13,9 @@ function createImgRefControl(reference: ImgRef) {
       lg: new FormControl(urls.lg)
     }),
     blob: new FormControl(),
-    newRef: new FormControl(''),
-    delete: new FormControl(false)
+    path: new FormControl(''),
+    delete: new FormControl(false),
+    fileName: new FormControl('')
   }
 }
 
@@ -30,6 +31,6 @@ export class ImgRefForm extends FormEntity<ImgRefControl> {
   get ref() { return this.get('ref') }
   get urls() { return this.get('urls') }
   get blob() { return this.get('blob') }
-  get newRef() { return this.get('newRef') }
+  get path() { return this.get('path') }
   get delete() { return this.get('delete') }
 }

--- a/libs/movie/src/lib/movie/+state/movie.service.ts
+++ b/libs/movie/src/lib/movie/+state/movie.service.ts
@@ -56,7 +56,7 @@ export class MovieService extends CollectionService<MovieState> {
 
   save(movie: Movie) {
     return this.runTransaction(async write => {
-      const [ value, media ] = extractMedia(movie);
+      const [ value, media ] = extractToBeUpdatedMedia(movie);
       this.mediaService.uploadOrDeleteMedia(media);
       return this.update(value, { write });
     });

--- a/libs/movie/src/lib/movie/+state/movie.service.ts
+++ b/libs/movie/src/lib/movie/+state/movie.service.ts
@@ -15,7 +15,7 @@ import { RouterQuery } from '@datorama/akita-ng-router-store';
 import { OrganizationService } from '@blockframes/organization/+state/organization.service';
 import { UserService } from '@blockframes/user/+state/user.service';
 import { MediaService } from '@blockframes/media/+state/media.service';
-import { extractMedia } from '@blockframes/media/+state/media.model';
+import { extractToBeUpdatedMedia } from '@blockframes/media/+state/media.model';
 import { firestore } from 'firebase/app';
 import { createMovieAppAccess, getCurrentApp } from '@blockframes/utils/apps';
 

--- a/libs/organization/src/lib/organization/pages/organization/organization.component.ts
+++ b/libs/organization/src/lib/organization/pages/organization/organization.component.ts
@@ -3,7 +3,7 @@ import { OrganizationForm } from '@blockframes/organization/forms/organization.f
 import { OrganizationQuery } from '@blockframes/organization/+state/organization.query';
 import { OrganizationService } from '@blockframes/organization/+state/organization.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { extractMedia } from '@blockframes/media/+state/media.model';
+import { extractToBeUpdatedMedia } from '@blockframes/media/+state/media.model';
 import { MediaService } from '@blockframes/media/+state/media.service';
 
 @Component({

--- a/libs/organization/src/lib/organization/pages/organization/organization.component.ts
+++ b/libs/organization/src/lib/organization/pages/organization/organization.component.ts
@@ -33,7 +33,7 @@ export class OrganizationComponent implements OnInit {
         if (this.organizationForm.invalid) {
           throw new Error('Your organization profile informations are not valid');
         }
-        const [ org, media ] = extractMedia(this.organizationForm.value);
+        const [ org, media ] = extractToBeUpdatedMedia(this.organizationForm.value);
         this.media.uploadOrDeleteMedia(media);
         this.service.update(this.query.getActiveId(), org);
         this.snackBar.open('Organization profile was successfully changed', 'close', { duration: 2000 });

--- a/libs/user/src/lib/auth/pages/profile-view/profile-view.component.ts
+++ b/libs/user/src/lib/auth/pages/profile-view/profile-view.component.ts
@@ -10,7 +10,7 @@ import { ProfileForm } from '@blockframes/auth/forms/profile-edit.form';
 import { EditPasswordForm } from '@blockframes/utils/form/controls/password.control';
 import { User } from '@blockframes/auth/+state/auth.store';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
-import { extractMedia } from '@blockframes/media/+state/media.model';
+import { extractToBeUpdatedMedia } from '@blockframes/media/+state/media.model';
 import { MediaService } from '@blockframes/media/+state/media.service';
 
 @Component({

--- a/libs/user/src/lib/auth/pages/profile-view/profile-view.component.ts
+++ b/libs/user/src/lib/auth/pages/profile-view/profile-view.component.ts
@@ -56,7 +56,7 @@ export class ProfileViewComponent implements OnInit {
         throw new Error('Your profile informations are not valid.')
       } else {
         const uid = this.authQuery.userId;
-        const [ user, media ] = extractMedia(this.profileForm.value);
+        const [ user, media ] = extractToBeUpdatedMedia(this.profileForm.value);
         this.mediaService.uploadOrDeleteMedia(media);
         this.authService.update({ uid, ...user });
         this.snackBar.open('Profile updated.', 'close', { duration: 2000 });


### PR DESCRIPTION
- [x] Uploading new image on MovieForm deletes the other images on the form
- [ ] The "Delete" button of a Still Photo on the MovieForm doesn't delete it from the array in the database and therefore it is shown again when the page is refreshed.
- [ ]  The "Delete" button of a Still Photo empties the Still Photo Array on the database and doesn't delete any image from the storage.
- [ ] Last Still Photo doesn't have a delete button