### PR TITLE
Migrate still_photo

### DIFF
--- a/apps/backend-ops/src/firestoreMigrations/temporary-0028.ts
+++ b/apps/backend-ops/src/firestoreMigrations/temporary-0028.ts
@@ -99,6 +99,15 @@ async function updateMovies(db: Firestore, movies: Movie[]) {
       }
     });
 
+    // update still photos from an array with old ImgRef to a record with new ImgRef
+    const still_photo = {};
+    let index = 0;
+    for (const still of movie.promotionalElements.still_photo as any) {
+      still_photo[index] = updateImgRef(still, 'media') as PromotionalImage;
+      index++;
+    }
+    movie.promotionalElements.still_photo = still_photo;
+
     db.doc(`movies/${movie.id}`).set(movie);
   }
 }


### PR DESCRIPTION
- [x] `movie.promotionalElements`
  - [x] `still_photo.media`  : Record migration, then ImgRef migration [@RemcoSimonides ]
  

### Records migration
Transform every `movie.promotionalElements` arrays into `Record<string, ...>`.
You should not change the inner elements, this will be done later depending on their types.
You can use the index teh string key of the record :
```TypeScript
still_photo: [
  { poster0 },
  { poster1 },
  { poster2 },
  // ...
]
```
Should become :
```TypeScript
still_photo: {
  '0': { poster0 },
  '1': { poster1 },
  '2': { poster2 },
  // ...
}
```
