### PR TITLE
Fix upload cancel and updatable items in UploadWidgetComponent

### DIFF
--- a/libs/media/src/lib/+state/media.service.ts
+++ b/libs/media/src/lib/+state/media.service.ts
@@ -51,7 +51,9 @@ export class MediaService {
     const files = Array.isArray(uploadFiles) ? uploadFiles : [uploadFiles];
     const tasks = files.map(file => this.storage.upload(`${file.path}${file.fileName}`, file.data));
     this.addTasks(tasks);
-    (Promise as any).allSettled(tasks as AngularFireUploadTask[]).then(() => delay(5000).then(() => this.detachWidget()));
+    (Promise as any).allSettled(tasks)
+      .then(() => delay(5000))
+      .then(() => this.detachWidget());
     this.showWidget();
   }
 
@@ -72,7 +74,9 @@ export class MediaService {
     }
 
     this.addTasks(tasks);
-    (Promise as any).allSettled(tasks as AngularFireUploadTask[]).then(() => delay(5000).then(() => this.detachWidget()));
+    (Promise as any).allSettled(tasks)
+      .then(() => delay(5000))
+      .then(() => this.detachWidget());
     this.showWidget();
   }
 
@@ -100,19 +104,12 @@ export class MediaService {
   private detachWidget() {
     if (!this.overlayRef) return;
 
-    let canClose: boolean = true;
-    const tasks = this._tasks.getValue();
-    for (const task of tasks) {
-      const state = task.task.snapshot.state
-      if (state !== 'success') {
-        canClose = false;
-        break;
-      }
-    }
-
+    const canClose = this._tasks.getValue().every(task => task.task.snapshot.state === 'success');
     if (canClose) {
       this.overlayRef.detach();
       delete this.overlayRef;
+      const tasks = this._tasks.getValue().filter(task => task.task.snapshot.state !== 'success');
+      this._tasks.next(tasks);
     }
   }
 

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.html
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.html
@@ -47,7 +47,7 @@
                 <button mat-icon-button (click)="task$.pause()">
                   <mat-icon svgIcon="pause_circle"></mat-icon>
                 </button>
-                <button mat-icon-button (click)="cancel(task$, i)">
+                <button mat-icon-button (click)="task$.cancel()">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>
@@ -64,7 +64,7 @@
                 <button mat-icon-button (click)="task$.resume()">
                   <mat-icon svgIcon="play_circle"></mat-icon>
                 </button>
-                <button mat-icon-button (click)="cancel(task$, i)">
+                <button mat-icon-button (click)="cancel(task$)">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.html
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.html
@@ -1,4 +1,4 @@
-<mat-accordion *ngIf="tasklist.length as itemCount" class="mat-card">
+<mat-accordion *ngIf="(tasklist$ | async)?.length as itemCount" class="mat-card">
   <mat-expansion-panel expanded>
     <mat-expansion-panel-header i18n>Uploading {{ itemCount }} item{ itemCount,
       plural, =1 {} other {s} }
@@ -11,7 +11,7 @@
         thank you for your patience! You can continue using the platform</caption>
 
       <div fxLayout="column-reverse" fxLayoutGap="24px">
-        <ng-container *ngFor="let task$ of tasklist; let i = index">
+        <ng-container *ngFor="let task$ of tasklist$ | async; let i = index">
           <ng-container [ngSwitch]="task$ | state | async">
             <div fxLayout="row" fxLayoutGap="8px">
               <img [src]="getFileType(task$.task.snapshot.ref.name)">
@@ -47,14 +47,14 @@
                 <button mat-icon-button (click)="task$.pause()">
                   <mat-icon svgIcon="pause_circle"></mat-icon>
                 </button>
-                <button mat-icon-button (click)="task$.cancel()">
+                <button mat-icon-button (click)="cancel(task$, i)">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>
 
               <!-- Error -->
               <ng-template ngSwitchCase="canceled">
-                <button mat-icon-button (click)="tasklist.splice(i, 1)">
+                <button mat-icon-button (click)="remove(i)">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>
@@ -64,14 +64,14 @@
                 <button mat-icon-button (click)="task$.resume()">
                   <mat-icon svgIcon="play_circle"></mat-icon>
                 </button>
-                <button mat-icon-button (click)="task$.cancel()">
+                <button mat-icon-button (click)="cancel(task$, i)">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>
 
               <!-- Finished -->
               <ng-template ngSwitchCase="success">
-                <button mat-icon-button (click)="tasklist.splice(i, 1)">
+                <button mat-icon-button (click)="remove(i)">
                   <mat-icon svgIcon="check_circle"></mat-icon>
                 </button>
               </ng-template>

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
@@ -37,9 +37,9 @@ export class UploadWidgetComponent {
     }
   }
 
-  cancel(task: AngularFireUploadTask, index: number) {
-    task.pause();
-    this.remove(index);
+  cancel(task: AngularFireUploadTask) {
+    task.resume();
+    task.cancel();
   }
 
   remove(index: number) {

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
@@ -1,8 +1,9 @@
 // Angular
 import { Component, ChangeDetectionStrategy, Inject } from '@angular/core';
+import { AngularFireUploadTask } from '@angular/fire/storage';
 
 // RxJs
-import { AngularFireUploadTask } from '@angular/fire/storage';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Component({
   selector: 'bf-upload-widget',
@@ -12,9 +13,13 @@ import { AngularFireUploadTask } from '@angular/fire/storage';
 })
 export class UploadWidgetComponent {
 
+  tasklist$: Observable<AngularFireUploadTask[]>;
+
   constructor(
-    @Inject('tasks') public tasklist: AngularFireUploadTask[],
-  ) {}
+    @Inject('tasks') public tasks: BehaviorSubject<AngularFireUploadTask[]>,
+  ) {
+    this.tasklist$ = this.tasks.asObservable();
+  }
 
   getFileType(file: string) {
     const type = file.split('.').pop();
@@ -30,6 +35,17 @@ export class UploadWidgetComponent {
       default:
         return '/assets/images/dark/image.webp';
     }
+  }
+
+  cancel(task: AngularFireUploadTask, index: number) {
+    task.pause();
+    this.remove(index);
+  }
+
+  remove(index: number) {
+    const tasks = this.tasks.getValue();
+    tasks.splice(index, 1);
+    this.tasks.next(tasks);
   }
 
 }

--- a/libs/media/src/lib/pipes/task-progress.pipe.ts
+++ b/libs/media/src/lib/pipes/task-progress.pipe.ts
@@ -2,15 +2,18 @@ import { Pipe, PipeTransform, NgModule } from '@angular/core';
 import { AngularFireUploadTask } from '@angular/fire/storage';
 
 // Rxjs
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { CommonModule } from '@angular/common';
+import { catchError } from 'rxjs/operators';
 
 @Pipe({
   name: 'progress'
 })
 export class TaskProgressPipe implements PipeTransform {
   transform(task: AngularFireUploadTask): Observable<number> {
-    return task.percentageChanges();
+    return task.percentageChanges().pipe(
+      catchError(err => of(0))
+    );
   }
 }
 

--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -12,10 +12,6 @@ export class ErrorLoggerHandler implements ErrorHandler {
   constructor(private snackBar: MatSnackBar) {}
 
   handleError(error: any) {
-    if (error?.name === 'FirebaseError' && error?.code === 'storage/canceled') {
-      // suppress error issue #3267
-      return;
-    }
     console.error(error);
     this.snackBar.open(`${error}`.substring(0, 100), 'close');
   }

--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -12,6 +12,10 @@ export class ErrorLoggerHandler implements ErrorHandler {
   constructor(private snackBar: MatSnackBar) {}
 
   handleError(error: any) {
+    if (error?.name === 'FirebaseError' && error?.code === 'storage/canceled') {
+      // suppress error issue #3267
+      return;
+    }
     console.error(error);
     this.snackBar.open(`${error}`.substring(0, 100), 'close');
   }


### PR DESCRIPTION
issue #3267

- [x] If the state of the uploadTask is "paused" then the cancel button in the UploadWidgetComponent doesn't work
- [x] Canceling an upload in the UploadWidgetComponent while it's state is "running" shows an error but at least the cancel button does work (catch error).
- [x] If the UploadWidgetComponent is already open and a new file needs to be uploaded, this task isn't added to the component.