### PR TITLE
Catch error thrown on upload cancel

### DIFF
--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.html
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.html
@@ -64,7 +64,7 @@
                 <button mat-icon-button (click)="task$.resume()">
                   <mat-icon svgIcon="play_circle"></mat-icon>
                 </button>
-                <button mat-icon-button (click)="task$.cancel()">
+                <button mat-icon-button (click)="cancel(task$)">
                   <mat-icon svgIcon="cross_circle"></mat-icon>
                 </button>
               </ng-template>

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
@@ -32,4 +32,9 @@ export class UploadWidgetComponent {
     }
   }
 
+  cancel(task: AngularFireUploadTask) {
+    task.resume();
+    task.cancel();
+  }
+
 }

--- a/libs/media/src/lib/pipes/task-progress.pipe.ts
+++ b/libs/media/src/lib/pipes/task-progress.pipe.ts
@@ -2,15 +2,18 @@ import { Pipe, PipeTransform, NgModule } from '@angular/core';
 import { AngularFireUploadTask } from '@angular/fire/storage';
 
 // Rxjs
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { CommonModule } from '@angular/common';
+import { catchError } from 'rxjs/operators';
 
 @Pipe({
   name: 'progress'
 })
 export class TaskProgressPipe implements PipeTransform {
   transform(task: AngularFireUploadTask): Observable<number> {
-    return task.percentageChanges();
+    return task.percentageChanges().pipe(
+      catchError(err => of(0))
+    );
   }
 }
 


### PR DESCRIPTION
issue #3267

- [x] If the state of the uploadTask is "paused" then the cancel button in the UploadWidgetComponent doesn't work
- [x] Canceling an upload in the UploadWidgetComponent while it's state is "running" shows an error but at least the cancel button does work (catch error).