### PR TITLE
Fix upload cancel and updatable items in UploadWidgetComponent v2

### DIFF
--- a/libs/media/src/lib/+state/media.firestore.ts
+++ b/libs/media/src/lib/+state/media.firestore.ts
@@ -82,13 +82,13 @@ export function getImgSize(url: string): ImageSizes {
   }
 }
 
-export interface UploadFile {
+export interface UploadData {
   /**
   * firebase storage upload path *(or ref)*,
   * @note **Make sure that the path param does not include the filename.**
   * @note **Make sure that the path ends with a `/`.**
   */
   path: string,
-  data: Blob,
+  data: Blob | File,
   fileName: string,
 }

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.html
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.html
@@ -1,4 +1,4 @@
-<mat-accordion *ngIf="(tasklist$ | async)?.length as itemCount" class="surface">
+<mat-accordion *ngIf="(tasks.$ | async)?.length as itemCount" class="mat-card">
   <mat-expansion-panel expanded>
     <mat-expansion-panel-header i18n>Uploading {{ itemCount }} item{ itemCount,
       plural, =1 {} other {s} }
@@ -11,7 +11,7 @@
         thank you for your patience! You can continue using the platform</caption>
 
       <div fxLayout="column-reverse" fxLayoutGap="24px">
-        <ng-container *ngFor="let task$ of tasklist$ | async; let i = index">
+        <ng-container *ngFor="let task$ of tasks.$ | async; let i = index">
           <ng-container [ngSwitch]="task$ | state | async">
             <div fxLayout="row" fxLayoutGap="8px">
               <img [src]="getFileType(task$.task.snapshot.ref.name)">

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.ts
@@ -2,8 +2,8 @@
 import { Component, ChangeDetectionStrategy, Inject } from '@angular/core';
 import { AngularFireUploadTask } from '@angular/fire/storage';
 
-// RxJs
-import { BehaviorSubject, Observable } from 'rxjs';
+// Blockframes
+import { BehaviorStore } from '@blockframes/utils/helpers';
 
 @Component({
   selector: 'bf-upload-widget',
@@ -13,13 +13,10 @@ import { BehaviorSubject, Observable } from 'rxjs';
 })
 export class UploadWidgetComponent {
 
-  tasklist$: Observable<AngularFireUploadTask[]>;
 
   constructor(
-    @Inject('tasks') public tasks: BehaviorSubject<AngularFireUploadTask[]>,
-  ) {
-    this.tasklist$ = this.tasks.asObservable();
-  }
+    @Inject('tasks') public tasks: BehaviorStore<AngularFireUploadTask[]>,
+  ) {}
 
   getFileType(file: string) {
     const type = file.split('.').pop();
@@ -43,9 +40,9 @@ export class UploadWidgetComponent {
   }
 
   remove(index: number) {
-    const tasks = this.tasks.getValue();
+    const tasks = this.tasks.value;
     tasks.splice(index, 1);
-    this.tasks.next(tasks);
+    this.tasks.value = tasks;
   }
 
 }

--- a/libs/utils/src/lib/helpers.ts
+++ b/libs/utils/src/lib/helpers.ts
@@ -1,4 +1,5 @@
 import { firestore } from "firebase/app";
+import { BehaviorSubject, Observable } from "rxjs";
 
 /**
  * @see #483
@@ -142,4 +143,23 @@ export function downloadCsvFromJson(data: any[], fileName = 'my-file') {
   a.click();
   window.URL.revokeObjectURL(url);
   a.remove();
+}
+
+/**
+ * Default structure for BehaviorSubject
+ * includes an observable, getter and setter
+ */
+export class BehaviorStore<T> {
+  private state: BehaviorSubject<T>;
+  $: Observable<T>;
+  constructor(initial: T) {
+    this.state = new BehaviorSubject<T>(initial);
+    this.$ = this.state.asObservable();
+  }
+  get value(): T {
+    return this.state.getValue();
+  }
+  set value(value: T) {
+    this.state.next(value);
+  }
 }


### PR DESCRIPTION
issue #3267

- [x] If the state of the uploadTask is "paused" then the cancel button in the UploadWidgetComponent doesn't work
- [x] Canceling an upload in the UploadWidgetComponent while it's state is "running" shows an error but at least the cancel button does work (catch error).
- [x] If the UploadWidgetComponent is already open and a new file needs to be uploaded, this task isn't added to the component.