### PR TITLE
Added delay to prevent the bug from happening

### DIFF
--- a/libs/ui/src/lib/app-bar.ts
+++ b/libs/ui/src/lib/app-bar.ts
@@ -5,7 +5,6 @@ import { trigger, style, transition, animate, query } from '@angular/animations'
 import { Easing } from '@blockframes/utils/animations/animation-easing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { delay } from '@blockframes/utils/helpers';
 
 @Component({
   selector: 'app-bar',
@@ -79,11 +78,11 @@ export class AppContainerDirective {
   constructor(
     @Inject(DOCUMENT) private document: Document,
     ref: ElementRef,
-    private zone: NgZone
+    zone: NgZone
   ) {
     this.container = ref.nativeElement;
 
-    this.zone.runOutsideAngular(() => {
+    zone.runOutsideAngular(() => {
       const heightSize = 80;
       const options = {
         root: this.container,
@@ -99,9 +98,9 @@ export class AppContainerDirective {
         const isLeavingTop = !entry.isIntersecting && entry.boundingClientRect.top <= heightSize;
         const isEnteringTop = !this.appBar.isApp && entry.isIntersecting;
         if (isLeavingTop) {
-          this.zone.run(() => this.appBar.isApp = false);
+          zone.run(() => this.appBar.isApp = false);
         } else if (isEnteringTop) {
-          this.zone.run(() => this.appBar.isApp = true);
+          zone.run(() => this.appBar.isApp = true);
         }
       }, options);
     });

--- a/libs/ui/src/lib/app-bar.ts
+++ b/libs/ui/src/lib/app-bar.ts
@@ -3,9 +3,9 @@ import { PortalModule, TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule, DOCUMENT } from '@angular/common';
 import { trigger, style, transition, animate, query } from '@angular/animations';
 import { Easing } from '@blockframes/utils/animations/animation-easing';
-import { Observable } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { delay } from '@blockframes/utils/helpers';
 
 @Component({
   selector: 'app-bar',
@@ -84,7 +84,6 @@ export class AppContainerDirective {
 @Directive({ selector: '[pageBar]' })
 export class PageBarDirective implements AfterViewInit, OnDestroy {
   private observer: IntersectionObserver;
-  public isVisible$: Observable<boolean>;
   @Input() targetId: string;
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -93,7 +92,8 @@ export class PageBarDirective implements AfterViewInit, OnDestroy {
     private zone: NgZone,
   ) {}
 
-  ngAfterViewInit() {
+  async ngAfterViewInit() {
+    await delay(500); // prevents sizes in entry.rootBounds to not be 0
     this.appContainer.appBar.attach(this.template)
     if (this.targetId) {
       this.zone.runOutsideAngular(() => {


### PR DESCRIPTION
Fix to do from issue #3412 

"On top of #3355, top search bar that should appear when you scroll down doesn't appear if you do this flow:
1. go on all films
2. go on a public org page (e.g. `c/o/marketplace/organization/GdFUevWIifjk6VEYgfCT/title`)
3. go back on the page all films. Don't know why but the 2 look linked..."

Actually this bug happens on all pages which use the pageBar directive. This is caused by the values in `entry.rootBounds` to be all 0. After a small delay the `entry.rootBounds` do have the values they should have.

I expected animations to be the cause of this issue, but even when disabling animations this bug still happens...