### PR TITLE
Get accepted movies without resetting the store

### DIFF
--- a/apps/festival/festival/src/app/marketplace/organization/title/title.component.html
+++ b/apps/festival/festival/src/app/marketplace/organization/title/title.component.html
@@ -1,6 +1,6 @@
 <h1>Line-up</h1>
 <section fxLayout="row wrap" fxLayoutGap="24px grid">
-  <ng-container *ngFor="let movie of movies$ | async">
-    <movie-card [movie]="movie" [link]="['../../../title', movie.id]" size="poster"></movie-card>
+  <ng-container *ngFor="let title of titles$ | async">
+    <movie-card [movie]="title" [link]="['../../../title', title.id]" size="poster"></movie-card>
   </ng-container>
 </section>

--- a/apps/festival/festival/src/app/marketplace/organization/title/title.component.html
+++ b/apps/festival/festival/src/app/marketplace/organization/title/title.component.html
@@ -1,6 +1,6 @@
 <h1>Line-up</h1>
 <section fxLayout="row wrap" fxLayoutGap="24px grid">
-  <ng-container *ngFor="let title of titles$ | async">
-    <movie-card [movie]="title" [link]="['../../../title', title.id]" size="poster"></movie-card>
+  <ng-container *ngFor="let movie of movies$ | async">
+    <movie-card [movie]="movie" [link]="['../../../title', movie.id]" size="poster"></movie-card>
   </ng-container>
 </section>

--- a/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
+++ b/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
@@ -15,7 +15,7 @@ import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-ti
 })
 export class TitleComponent implements OnInit {
   @HostBinding('@scaleIn') private animePage;
-  public movies$: Observable<Movie[]>;
+  public titles$: Observable<Movie[]>;
 
   constructor(
     private service: MovieService,
@@ -25,11 +25,11 @@ export class TitleComponent implements OnInit {
 
   ngOnInit() {
     this.dynTitle.setPageTitle('Sales Agent', 'Line-up');
-    this.movies$ = this.parent.org$.pipe(
+    this.titles$ = this.parent.org$.pipe(
       map(org => org.movieIds),
       switchMap(movieIds => this.service.valueChanges(movieIds)),
       map(movies => movies.filter(movie => movie.main.storeConfig.status === 'accepted' && movie.main.storeConfig.appAccess.festival)),
-    );
+    ); // TODO query can be improved after issue #3498
   }
 
 }

--- a/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
+++ b/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, HostBinding } from '@angular/core';
-import { switchMap, map, tap } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { Component, OnInit, ChangeDetectionStrategy, HostBinding } from '@angular/core';
+import { switchMap, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 import { ViewComponent } from '../view/view.component';
-import { MovieService, MovieStore, MovieQuery } from '@blockframes/movie/+state';
+import { MovieService, Movie } from '@blockframes/movie/+state';
 import { scaleIn } from '@blockframes/utils/animations/fade';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
 
@@ -13,30 +13,23 @@ import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-ti
   animations: [scaleIn],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TitleComponent implements OnInit, OnDestroy {
+export class TitleComponent implements OnInit {
   @HostBinding('@scaleIn') private animePage;
-  private sub: Subscription;
-  // Todo Try to filter movie before sync with the store
-  public titles$ = this.query.selectAll({filterBy: movies => movies.main.storeConfig.status === 'accepted' && movies.main.storeConfig.appAccess.festival});
+  public movies$: Observable<Movie[]>;
 
   constructor(
     private service: MovieService,
-    private query: MovieQuery,
-    private store: MovieStore,
     private parent: ViewComponent,
     private dynTitle: DynamicTitleService,
   ) { }
 
-  ngOnInit(): void {
+  ngOnInit() {
     this.dynTitle.setPageTitle('Sales Agent', 'Line-up');
-    this.sub = this.parent.org$.pipe(
+    this.movies$ = this.parent.org$.pipe(
       map(org => org.movieIds),
-      tap(_ => this.store.reset()),
-      switchMap(movieIds => this.service.syncManyDocs(movieIds))
-    ).subscribe();
+      switchMap(movieIds => this.service.valueChanges(movieIds)),
+      map(movies => movies.filter(movie => movie.main.storeConfig.status === 'accepted' && movie.main.storeConfig.appAccess.festival)),
+    );
   }
 
-  ngOnDestroy() {
-    this.sub.unsubscribe();
-  }
 }


### PR DESCRIPTION
Fix to do in issue #3412 

"When you go from org public page on marketplace (e.g. /c/o/marketplace/organization/e1VXeusNJK6pb8kmVnUn/title) and then on wishlist only the films from that sales agents + included in your wishlist are visible."