### PR TITLE
Added user and organization name to email data

### DIFF
--- a/apps/backend-functions/src/internals/invitations/organizations.ts
+++ b/apps/backend-functions/src/internals/invitations/organizations.ts
@@ -145,7 +145,7 @@ async function onRequestFromUserToJoinOrgAccept({
   await addUserToOrg(fromUser.uid, toOrg.id);
   const urlToUse = await getAppUrl(toOrg.id);
   const from = await getFromEmail(toOrg.id);
-  const template = userJoinedAnOrganization(fromUser.email, urlToUse);
+  const template = userJoinedAnOrganization(fromUser.email, urlToUse, toOrg.denomination.full, fromUser.firstName!);
   await sendMailFromTemplate(template, from);
   return mailOnInvitationAccept(fromUser.uid, toOrg.id);
 }

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -93,9 +93,11 @@ export function organizationAppAccessChanged(admin: PublicUser, appLabel: string
 }
 
 /** Send email to a user to inform him that he joined an org */
-export function userJoinedAnOrganization(userEmail: string, url: string = appUrl.market): EmailTemplateRequest {
+export function userJoinedAnOrganization(userEmail: string, url: string = appUrl.market, orgName: string, userFirstName: string): EmailTemplateRequest {
   const data = {
-    pageURL: `${url}/c/o`
+    pageURL: `${url}/c/o`,
+    userFirstName,
+    orgName
   };
   return { to: userEmail, templateId: templateIds.request.joinOrganization.accepted, data };
 }


### PR DESCRIPTION
Fix to do in issue #3412 
"Acceptation to an org email doesn't display org name properly; it's working as intended when sending the request"
