### PR TITLE
Fix invitation links and text

### DIFF
--- a/libs/invitation/src/lib/components/item/item.component.html
+++ b/libs/invitation/src/lib/components/item/item.component.html
@@ -10,7 +10,7 @@
           <!-- Invited to attendEvent -->
           <ng-container *ngIf="invitation.mode === 'invitation'; else request">
             {{ invitation.fromOrg | orgName }} invited you to 
-            <a [routerLink]="['/c/o/marketplace/event', invitation.id]" id="link">{{ event.title }}</a>.
+            <a [routerLink]="['/c/o/marketplace/event', invitation.docId]" id="link">{{ event.title }}</a>.
             {{event | eventRange }}
           </ng-container>
           <!-- Request to attendEvent -->
@@ -43,7 +43,7 @@
   </button>
 </mat-list-item>
 <mat-menu #menu="matMenu">
-  <a test-id="go-to-event" mat-menu-item [routerLink]="eventLink">Go to event</a>
+  <a test-id="go-to-event" mat-menu-item [routerLink]="eventLink">More details</a>
   <ng-container [ngSwitch]="invitation.status">
     <ng-container *ngSwitchCase="'pending'">
       <span test-id="accept-invitation" mat-menu-item (click)="handleInvitation(invitation, 'acceptInvitation')">

--- a/libs/invitation/src/lib/components/item/item.component.ts
+++ b/libs/invitation/src/lib/components/item/item.component.ts
@@ -14,7 +14,15 @@ export class ItemComponent {
   constructor(private invitationService: InvitationService) { }
 
   get eventLink() {
-    return `../event/${this.invitation.docId}`;
+    if (this.invitation.type === 'attendEvent') {
+      if (this.invitation.mode === 'request') {
+        return `../event/${this.invitation.docId}/edit`;
+      } else {
+        return `/c/o/marketplace/event/${this.invitation.docId}`;
+      }
+    } else if (this.invitation.type === 'joinOrganization') {
+      return `/c/o/organization/${this.invitation.fromOrg.id}/view/members`;  
+    }
   }
 
   handleInvitation(invitation: Invitation, action: 'acceptInvitation' | 'declineInvitation') {


### PR DESCRIPTION
Fix multiple to do's from issue #3412 
1. "Wrong invitation when a user request to join an organization:
"Go to event" action should be renamed "More details" to be generic
"Go to event" action should redirect to https://staging.archipelmarket.com/c/o/organization/e1VXeusNJK6pb8kmVnUn/view/members when it's an invitation for organization and to https://staging.archipelmarket.com/c/o/dashboard/event/gST9ZDOPoWoYBuXUeVEW/edit when it's an event (and you are the organizer receiving a request)"

2. "On dashboard, when you receive an invitation to an event which is not yours and click on the more details button, the user is redirected to the dashboard view of the event as it was his/her own. It should redirect to the marketplace event view instead.
To avoid too many use cases every invitations (even for your events) should redirect to the marketplace view of the event.
Here the dashboard event view:"