### PR TITLE
Polyfill Intersection Observer

### DIFF
--- a/libs/ui/src/lib/app-bar.ts
+++ b/libs/ui/src/lib/app-bar.ts
@@ -82,13 +82,15 @@ export class AppContainerDirective {
   ) {
     this.container = ref.nativeElement;
 
-    zone.runOutsideAngular(() => {
+    zone.runOutsideAngular(async () => {
       const heightSize = 80;
       const options = {
         root: this.container,
         rootMargin: `-${heightSize}px 0px 0px 0px`,
         threshold: 0
       }
+
+      if (!('IntersectionObserver' in window)) await import('intersection-observer');
       this.observer = new IntersectionObserver(([entry]) => {
         // First entry artifact (not sure what happens)
         const {x, y, width, height} = entry.rootBounds;

--- a/libs/ui/src/lib/app-bar.ts
+++ b/libs/ui/src/lib/app-bar.ts
@@ -90,7 +90,9 @@ export class AppContainerDirective {
         threshold: 0
       }
 
-      if (!('IntersectionObserver' in window)) await import('intersection-observer'); // IntersectionObserver doesnt work in Safari older than 12.2
+      // IntersectionObserver isn't supported on Safari older than version 12.2
+      if (!('IntersectionObserver' in window)) await import('intersection-observer');
+
       this.observer = new IntersectionObserver(([entry]) => {
         // First entry artifact (not sure what happens)
         const {x, y, width, height} = entry.rootBounds;

--- a/libs/ui/src/lib/app-bar.ts
+++ b/libs/ui/src/lib/app-bar.ts
@@ -90,7 +90,7 @@ export class AppContainerDirective {
         threshold: 0
       }
 
-      if (!('IntersectionObserver' in window)) await import('intersection-observer');
+      if (!('IntersectionObserver' in window)) await import('intersection-observer'); // IntersectionObserver doesnt work in Safari older than 12.2
       this.observer = new IntersectionObserver(([entry]) => {
         // First entry artifact (not sure what happens)
         const {x, y, width, height} = entry.rootBounds;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22350,6 +22350,11 @@
       "integrity": "sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==",
       "dev": true
     },
+    "intersection-observer": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.11.0.tgz",
+      "integrity": "sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ=="
+    },
     "intl": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "fs-extra": "^8.1.0",
     "generate-password": "^1.4.2",
     "handlebars": "^4.5.3",
+    "intersection-observer": "^0.11.0",
     "jwplatform": "0.0.5",
     "leaflet": "^1.6.0",
     "line-reader": "^0.4.0",


### PR DESCRIPTION
To do in issue #3412 

Intersection Observer is not supported for Safari version lower than 12.2. Therefore it needs to be polyfilled.