### PR TITLE
Fix clear button on budget filter

### DIFF
--- a/libs/movie/src/lib/movie/form/search.form.ts
+++ b/libs/movie/src/lib/movie/form/search.form.ts
@@ -142,7 +142,7 @@ export class MovieSearchForm extends FormEntity<MovieSearchControl> {
         this.storeConfig.value.map(config => `storeConfig:${config}`),
         this.appAccess.value.map(access => `appAccess:${access}`)
       ],
-      filters: `budget >= ${this.minBudget.value}`,
+      filters: `budget >= ${this.minBudget.value ?? 0}`,
     });
   }
 }


### PR DESCRIPTION
Fix for clear button for budget filter on movie list page causing the search to crash