### PR TITLE
improve flow & meeting prototype

### DIFF
--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -27,6 +27,7 @@
           </ng-template>
         </mat-card>
       </ng-container>
+
       <!-- Meeting -->
       <ng-container *ngSwitchCase="'meeting'">
         <h2>Meeting</h2>
@@ -50,6 +51,13 @@
             <mat-label>Description</mat-label>
             <textarea matInput placeholder="Add a message" formControlName="description"></textarea>
           </mat-form-field>
+          <h6>Files</h6>
+          <p>
+            Select files you want to share during the meeting.
+            Every member of the meeting will be able to see and download the selected files.
+          </p>
+          <p>TODO FILE SELECTOR issue#3672</p>
+          <!-- TODO FILE SELECTOR COMPONENT #3672 -->
         </mat-card>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.html
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.html
@@ -36,20 +36,18 @@
     <!-- MEETING TYPE -->
     <section *ngSwitchCase="'meeting'" fxLayout="column" fxLayoutAlign="space-between center">
 
-      <article class="dark-contrast-theme screen" bgAsset="meeting.webp">
-        <div class="overlay" fxLayout="column" fxLayoutAlign="center center">
-          <span class="mat-display-2">{{ event.title }}</span>
-          <span class="mat-caption">Meeting now</span>
-          <a *ngIf="event.meta.callUrl" mat-flat-button color="accent" [href]="event.meta.callUrl" target="_blank">
-            <mat-icon svgIcon="play"></mat-icon>
-            <span>Join the meeting</span>
-          </a>
-          <p *ngIf="!event.meta.callUrl">
-            Contact <a [href]="'mailto:' + event.organizedBy.email">{{ event.organizedBy | displayName }}</a> to provide a link for the meeting
-          </p>
+      <h3 *ngIf="event.isOwner">You are the owner of this meeting</h3>
+
+      <!-- WORK IN PROGRESS -->
+      <article fxLayout="column" class="meeting">
+        <div fxLayout="row" class="meeting-container">
+          <div [fxFlex]="mediaContainerSize">MEDIA</div>
+          <div [fxFlex]="visioContainerSize">VISIO</div>
         </div>
+        <div fxFlex="15%" *ngIf="event.isOwner">CURRENT MEDIA CONTROL</div>
+        <div fxFlex="35%" *ngIf="event.isOwner">MEDIA LIST</div>
       </article>
-      <!-- TODO update the picture here with Mathilde's picture, she needs to validate with Marie to create it -->
+
       <img asset="meeting.webp" alt="Meeting room">
 
     </section>

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.html
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.html
@@ -42,10 +42,12 @@
       <article fxLayout="column" class="meeting">
         <div fxLayout="row" class="meeting-container">
           <div [fxFlex]="mediaContainerSize">MEDIA</div>
-          <div [fxFlex]="visioContainerSize">VISIO</div>
+          <div [fxFlex]="visioContainerSize">VIDEO CONFERENCE</div>
         </div>
-        <div fxFlex="15%" *ngIf="event.isOwner">CURRENT MEDIA CONTROL</div>
-        <div fxFlex="35%" *ngIf="event.isOwner">MEDIA LIST</div>
+        <ng-container *ngIf="event.isOwner">
+          <div fxFlex="15%">CURRENT MEDIA CONTROL</div>
+          <div fxFlex="35%">MEDIA LIST</div>
+        </ng-container>
       </article>
 
       <img asset="meeting.webp" alt="Meeting room">

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.scss
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.scss
@@ -58,6 +58,18 @@ section {
   }
 }
 
+.meeting {
+  border: solid 1px black;
+  width: 100%;
+  height: 70vh;
+  div {
+    border: solid 1px black;
+  }
+  .meeting-container {
+    height: 100%;
+  }
+}
+
 @include layout-bp(lt-md) {
   .screen {
     width: 100%;

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.ts
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { EventService, Event } from '@blockframes/event/+state';
-import { pluck, switchMap } from 'rxjs/operators';
+import { pluck, switchMap, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 
@@ -15,6 +15,8 @@ export class SessionComponent implements OnInit {
 
   public event$: Observable<Event>;
   public showSession = true;
+  public mediaContainerSize: string;
+  public visioContainerSize: string;
 
   constructor(
     private service: EventService,
@@ -24,7 +26,16 @@ export class SessionComponent implements OnInit {
   ngOnInit(): void {
     this.event$ = this.route.params.pipe(
       pluck('eventId'),
-      switchMap((eventId: string) => this.service.queryDocs(eventId))
+      switchMap((eventId: string) => this.service.queryDocs(eventId)),
+      tap(event => {
+        if (event.isOwner) {
+          this.mediaContainerSize = '40%';
+          this.visioContainerSize = '60%';
+        } else {
+          this.mediaContainerSize = '60%';
+          this.visioContainerSize = '40%';
+        }
+      }),
     );
   }
 }

--- a/libs/event/src/lib/guard/session.guard.ts
+++ b/libs/event/src/lib/guard/session.guard.ts
@@ -1,23 +1,25 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, UrlTree } from '@angular/router';
 import { InvitationQuery, Invitation } from '@blockframes/invitation/+state';
-import { EventService } from '../+state';
+import { EventService, EventQuery } from '../+state';
 import { eventTime } from '../pipes/event-time.pipe';
 
 @Injectable({ providedIn: 'root' })
 export class SessionGuard implements CanActivate {
   constructor(
     private invitationQuery: InvitationQuery,
+    private eventQuery: EventQuery,
     private service: EventService,
     private router: Router
   ) {}
 
   async canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean | UrlTree> {
     const eventId: string = next.params.eventId;
-    const canNavigate = this.invitationQuery.hasEntity((invitation: Invitation) => {
+    const hasUserAccepted = this.invitationQuery.hasEntity((invitation: Invitation) => {
       return invitation.docId === eventId && invitation.status === 'accepted';
     });
-    if (!canNavigate) {
+    const { isOwner } = this.eventQuery.getActive();
+    if (!isOwner && !hasUserAccepted) {
       return this.router.parseUrl(`/c/o/marketplace/event/${eventId}`);
     }
     const event = await this.service.getValue(eventId);

--- a/libs/event/src/lib/layout/edit/edit.component.html
+++ b/libs/event/src/lib/layout/edit/edit.component.html
@@ -17,6 +17,7 @@
 
 <form [formGroup]="form">
   <section fxLayout="column" fxLayoutGap="24px">
+    <a fxFlexAlign="center" mat-stroked-button color="primary" [routerLink]="eventLink">Go to the event page</a>
     <h2>Details</h2>
     <mat-card class="details" fxLayout="column" fxFlex="65">
       <mat-form-field appearance="outline">

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { EventForm } from '../../form/event.form';
 import { EventService } from '../../+state/event.service';
@@ -12,19 +12,24 @@ import { Observable, BehaviorSubject } from 'rxjs';
   styleUrls: ['./edit.component.scss'],
   changeDetection: ChangeDetectionStrategy.Default  // required for changes on "pristine" for the save button
 })
-export class EventEditComponent {
+export class EventEditComponent implements OnInit {
 
   @Input() form = new EventForm();
   @Input() invitations: Invitation[] = [];
   invitationForm = createAlgoliaUserForm();
   progress: Observable<number>;
   sending = new BehaviorSubject(false);
+  eventLink: string;
 
   constructor(
     private service: EventService,
     private router: Router,
     private route: ActivatedRoute,
   ) { }
+
+  ngOnInit() {
+    this.eventLink = `/c/o/marketplace/event/${this.form.value.id}/session`;
+  }
 
   get meta() {
     return this.form.get('meta');

--- a/libs/event/src/lib/layout/view/view.component.html
+++ b/libs/event/src/lib/layout/view/view.component.html
@@ -10,16 +10,25 @@
         <ng-container *ngSwitchCase="'early'">
           <h6>{{event.isPrivate ? 'Private' : 'Public'}} {{ event.type }}</h6>
           <pre class="mat-body-1">{{ event | eventRange }}</pre>
-          <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
+          <ng-container *ngIf="event.isOwner; else notOwner">
+            <h3>You are the owner of this event</h3>
+            <p>You can invite members and edit the event config in your dashboard</p>
+            <a mat-stroked-button color="primary" [routerLink]="editMeeting">Edit Event</a>
+          </ng-container>
+          <ng-template #notOwner>
+            <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
+          </ng-template>
         </ng-container>
 
         <ng-container *ngSwitchCase="'onTime'">
           <h6>{{event.isPrivate ? 'Private' : 'Public'}} {{ event.type }}</h6>
           <pre class="mat-body-1">{{ event | eventRange }}</pre>
-          <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
-          <ng-container *ngIf="(invitation$ | async)?.status === 'accepted'">
+          <ng-container *ngIf="(invitation$ | async)?.status === 'accepted' || event.isOwner; else noAccess">
             <a test-id="event-room" mat-flat-button routerLink="./session" color="accent">Access {{ event.type | titlecase }} Room</a>
           </ng-container>
+          <ng-template #noAccess>
+            <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
+          </ng-template>
         </ng-container>
 
         <ng-container *ngSwitchCase="'late'">

--- a/libs/event/src/lib/layout/view/view.component.ts
+++ b/libs/event/src/lib/layout/view/view.component.ts
@@ -15,6 +15,7 @@ export class EventViewComponent implements OnInit {
   private _event = new BehaviorSubject<Event>(null);
   event$ = this._event.asObservable();
   invitation$: Observable<Invitation>;
+  editMeeting: string;
 
   @Input()
   get event() {
@@ -31,6 +32,9 @@ export class EventViewComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+
+    this.editMeeting = `/c/o/dashboard/event/${this.event.id}/edit`;
+
     this.invitation$ = this.event$.pipe(
       switchMap(event => this.invitationQuery.selectByDocId(event.id)),
       shareReplay(1)


### PR DESCRIPTION
fix #3671 
- [x] check dashboard edit meeting page
- [x] check marketplace meeting page
- [x] add a link to the marketplace event page from the dashboard edit page
- [x] if the user is the owner of an event add a link from the marketplace to the dashboard edit page
- [x] allow owner of the event to access it without invitation
- [x] replace old meeting page by a prototype of the new page