### PR TITLE
feat(backend-ops): disable maintenance mode with --skipMaintenance flag

### DIFF
--- a/apps/backend-ops/src/main.ts
+++ b/apps/backend-ops/src/main.ts
@@ -12,7 +12,7 @@ import { clearUsers, createUsers, printUsers, generateWatermarks, syncUsers } fr
 import { generateFixtures } from './generate-fixtures';
 
 const args = process.argv.slice(2);
-const [cmd, ...rest] = args;
+const [cmd, ...flags] = args;
 
 async function runCommand() {
   if (cmd === 'prepareForTesting') {
@@ -49,6 +49,15 @@ async function runCommand() {
     showHelp();
     return Promise.reject('Command not recognised');
   }
+}
+
+function flagExists(compare: string) {
+  return flags.find(flag => flag === compare)
+}
+
+if (flagExists('--skipMaintenance') || flagExists('skipMaintenance')) {
+  process.env.BLOCKFRAMES_MAINTENANCE_DISABLED = 'CLI flag';
+  console.warn('WARNING! BLOCKFRAMES_MAINTENANCE_DISABLED is set to true, meaning maintenance mode is disabled!')
 }
 
 const consoleMsg = `Time running command "${cmd}"`;

--- a/apps/backend-ops/src/main.ts
+++ b/apps/backend-ops/src/main.ts
@@ -51,12 +51,12 @@ async function runCommand() {
   }
 }
 
-function flagExists(compare: string) {
-  return flags.find(flag => flag === compare)
+function hasFlag(compare: string) {
+  return flags.some(flag => flag === compare) || flags.some(flag => flag === `--${compare}`)
 }
 
-if (flagExists('--skipMaintenance') || flagExists('skipMaintenance')) {
-  process.env.BLOCKFRAMES_MAINTENANCE_DISABLED = 'CLI flag';
+if (hasFlag('skipMaintenance')) {
+  process.env.BLOCKFRAMES_MAINTENANCE_DISABLED = 'true';
   console.warn('WARNING! BLOCKFRAMES_MAINTENANCE_DISABLED is set to true, meaning maintenance mode is disabled!')
 }
 

--- a/libs/firebase-utils/src/lib/maintenance.ts
+++ b/libs/firebase-utils/src/lib/maintenance.ts
@@ -17,7 +17,10 @@ const maintenanceRef = () => {
 };
 
 export async function startMaintenance() {
-  if (process.env.BLOCKFRAMES_MAINTENANCE_DISABLED) return;
+  if (process.env.BLOCKFRAMES_MAINTENANCE_DISABLED) {
+    console.warn('Warning: startMaintenance() called but BLOCKFRAMES_MAINTENANCE_DISABLED is set to true. Maintenance mode is disabled...');
+    return;
+  }
   return maintenanceRef().set({ startedAt: admin.firestore.FieldValue.serverTimestamp(), endedAt: null });
 }
 

--- a/libs/firebase-utils/src/lib/maintenance.ts
+++ b/libs/firebase-utils/src/lib/maintenance.ts
@@ -17,10 +17,12 @@ const maintenanceRef = () => {
 };
 
 export async function startMaintenance() {
+  if (process.env.BLOCKFRAMES_MAINTENANCE_DISABLED) return;
   return maintenanceRef().set({ startedAt: admin.firestore.FieldValue.serverTimestamp(), endedAt: null });
 }
 
 export async function endMaintenance() {
+  if (process.env.BLOCKFRAMES_MAINTENANCE_DISABLED) return;
   return maintenanceRef().set({
     endedAt: admin.firestore.FieldValue.serverTimestamp(),
     startedAt: null


### PR DESCRIPTION
- added guard clause to maintenance methods if maintenance is disabled
- backend-ops which is what CI runs when making a release, will check for this flag
- even without the flag, maintenance mode can be disabled with an environment variable
- `BLOCKFRAMES_MAINTENANCE_DISABLED`
- Pros: freedom to disable it from environment, in CI setup, in terminal, in .env, and also via flag
- cons: maybe add a `console.warn` in `startMaintenance` if it's disabled