### PR TITLE
Fix attendEvent permission and link on invitation

### DIFF
--- a/libs/invitation/src/lib/components/item/item.component.html
+++ b/libs/invitation/src/lib/components/item/item.component.html
@@ -16,7 +16,7 @@
           <!-- Request to attendEvent -->
           <ng-template #request>
             {{ invitation.fromUser | displayName }} would like to attend event 
-            <a [routerLink]="['/c/o/marketplace/event', invitation.id]" id="link">{{ event.title }}</a>.
+            <a [routerLink]="['/c/o/marketplace/event', invitation.docId]" id="link">{{ event.title }}</a>.
             {{ event | eventRange }}
           </ng-template>
         </ng-container>

--- a/libs/invitation/src/lib/guard/invitations.guard.ts
+++ b/libs/invitation/src/lib/guard/invitations.guard.ts
@@ -48,6 +48,9 @@ export class InvitationGuard extends CollectionGuard<InvitationState> {
           return combineLatest([
             this.service.syncCollection(ref => ref.where('fromUser.uid', '==', user.uid)),
             this.service.syncCollection(ref => ref.where('toUser.uid', '==', user.uid)),
+
+            this.service.syncCollection(ref => ref.where('type', '==', 'attendEvent').where('fromOrg.id', '==', orgId)),
+            this.service.syncCollection(ref => ref.where('type', '==', 'attendEvent').where('toOrg.id', '==', orgId)),
           ])
         }
       })


### PR DESCRIPTION
To do in issue #3674 

"Request to access a screening from buyer to seller has a wrong link id, it uses the invitation id instead of the event id"

Also, users that are not an admin didn't have access to requests to attend the event. Now they do.