### PR TITLE
Order movies by release year

### DIFF
--- a/apps/festival/festival/src/app/marketplace/home/home.component.ts
+++ b/apps/festival/festival/src/app/marketplace/home/home.component.ts
@@ -4,6 +4,7 @@ import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/
 // Blockframes
 import { MovieQuery, MovieService, Movie } from '@blockframes/movie/+state';
 import { OrganizationService, Organization } from '@blockframes/organization/+state';
+import { sortMovieBy } from '@blockframes/utils/akita-helper/sort-movie-by';
 
 // RxJs
 import { Observable, Subscription } from 'rxjs';
@@ -53,7 +54,9 @@ export class HomeComponent implements OnInit, OnDestroy {
       {
         title: 'New films',
         movieCount$: this.movieQuery.selectAll({ filterBy: movie => movie.storeConfig?.status === 'accepted' && movie.storeConfig.appAccess.festival }).pipe(map(movies => movies.length)),
-        movies$: this.movieQuery.selectAll({ filterBy: movie => movie.storeConfig?.status === 'accepted' && movie.storeConfig.appAccess.festival })
+        movies$: this.movieQuery.selectAll({ filterBy: movie => movie.storeConfig?.status === 'accepted' && movie.storeConfig.appAccess.festival }).pipe(
+          map(movies => movies.sort((a, b) => sortMovieBy(a, b, 'Production Year'))),
+        )
       },
       {
         title: 'In production',

--- a/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
+++ b/apps/festival/festival/src/app/marketplace/organization/title/title.component.ts
@@ -4,6 +4,7 @@ import { ViewComponent } from '../view/view.component';
 import { MovieService, MovieQuery } from '@blockframes/movie/+state';
 import { scaleIn } from '@blockframes/utils/animations/fade';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
+import { sortMovieBy } from '@blockframes/utils/akita-helper/sort-movie-by';
 
 @Component({
   selector: 'festival-marketplace-organization-title',
@@ -29,6 +30,7 @@ export class TitleComponent implements OnInit {
       map(org => org.movieIds),
       switchMap(movieIds => this.service.valueChanges(movieIds)),
       map(movies => movies.filter(movie => movie.storeConfig.status === 'accepted' && movie.storeConfig.appAccess.festival)),
+      map(movies => movies.sort((a, b) => sortMovieBy(a, b, 'Production Year')))
     ); // TODO query can be improved after issue #3498
   }
 


### PR DESCRIPTION
To do in issue #3674 
"`/c/o/marketplace/home` Change the New films carousel on marketplace homepage to really display new films, i.e. sort films by creation dates and display them from the newest to oldest"

"Same sort by should be use for films in `c/o/marketplace/organization/orgId/title` > newest to oldest"