### PR TITLE
Move end date with changing start date

### DIFF
--- a/libs/event/src/lib/layout/edit/edit.component.html
+++ b/libs/event/src/lib/layout/edit/edit.component.html
@@ -28,12 +28,12 @@
       <div fxLayout fxLayoutAlign="space-between center" fxLayoutGap="24px">
         <mat-form-field fxFlex appearance="outline" test-id="event-start">
           <mat-label>Start</mat-label>
-          <time-picker formControlName="start" [allDay]="form.value.allDay" (ngModelChange)="onStartChange($event)"></time-picker>
+          <time-picker formControlName="start" [allDay]="form.value.allDay" (change)="onEventChange('start')"></time-picker>
         </mat-form-field>
         <span>to</span>
         <mat-form-field fxFlex  appearance="outline" test-id="event-end">
           <mat-label>End</mat-label>
-          <time-picker formControlName="end" [allDay]="form.value.allDay" (ngModelChange)="onEndChange($event)"></time-picker>
+          <time-picker formControlName="end" [allDay]="form.value.allDay" (change)="onEventChange('end')"></time-picker>
         </mat-form-field>
       </div>
 

--- a/libs/event/src/lib/layout/edit/edit.component.html
+++ b/libs/event/src/lib/layout/edit/edit.component.html
@@ -28,12 +28,12 @@
       <div fxLayout fxLayoutAlign="space-between center" fxLayoutGap="24px">
         <mat-form-field fxFlex appearance="outline" test-id="event-start">
           <mat-label>Start</mat-label>
-          <time-picker formControlName="start" [allDay]="form.value.allDay"></time-picker>
+          <time-picker formControlName="start" [allDay]="form.value.allDay" (ngModelChange)="onStartChange($event)"></time-picker>
         </mat-form-field>
         <span>to</span>
         <mat-form-field fxFlex  appearance="outline" test-id="event-end">
           <mat-label>End</mat-label>
-          <time-picker formControlName="end" [allDay]="form.value.allDay"></time-picker>
+          <time-picker formControlName="end" [allDay]="form.value.allDay" (ngModelChange)="onEndChange($event)"></time-picker>
         </mat-form-field>
       </div>
 

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -1,11 +1,11 @@
-import { Component, ChangeDetectionStrategy, Input, OnInit, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { EventForm } from '../../form/event.form';
 import { EventService } from '../../+state/event.service';
 import { MEETING_MAX_INVITATIONS_NUMBER } from '../../+state/event.firestore';
 import { Invitation }  from '@blockframes/invitation/+state/invitation.model';
 import { createAlgoliaUserForm } from '@blockframes/utils/algolia';
-import { Observable, BehaviorSubject, Subscription } from 'rxjs';
+import { Observable, BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'event-edit',
@@ -22,7 +22,6 @@ export class EventEditComponent implements OnInit {
   sending = new BehaviorSubject(false);
   eventLink: string;
   limit = Infinity;
-  sub: Subscription;
 
   private _previousStartValue: Date;
   private _previousEndValue: Date;

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -23,8 +23,8 @@ export class EventEditComponent implements OnInit {
   eventLink: string;
   limit = Infinity;
 
-  private _previousStartValue: Date;
-  private _previousEndValue: Date;
+  private previousStartValue: Date;
+  private previousEndValue: Date;
 
   constructor(
     private service: EventService,
@@ -38,8 +38,8 @@ export class EventEditComponent implements OnInit {
     }
     this.eventLink = `/c/o/marketplace/event/${this.form.value.id}/session`;
 
-    this._previousStartValue = new Date(this.form.get('start').value);
-    this._previousEndValue = new Date(this.form.get('end').value);
+    this.previousStartValue = new Date(this.form.get('start').value);
+    this.previousEndValue = new Date(this.form.get('end').value);
   }
 
   get meta() {
@@ -64,20 +64,20 @@ export class EventEditComponent implements OnInit {
   }
 
   onStartChange(start: Date) {
-    if (start >= this._previousEndValue) {
-      const diff = Math.abs(this._previousStartValue.getTime() - start.getTime());
-      const newDate = new Date(this._previousEndValue.getTime() + diff);
+    if (start >= this.previousEndValue) {
+      const diff = Math.abs(this.previousStartValue.getTime() - start.getTime());
+      const newDate = new Date(this.previousEndValue.getTime() + diff);
       this.form.get('end').setValue(newDate);
     }
-    this._previousStartValue = new Date(start);
+    this.previousStartValue = new Date(start);
   }
 
   onEndChange(end: Date) {
-    if (end <= this._previousStartValue) {
-      const diff = Math.abs(this._previousEndValue.getTime() - end.getTime());
-      const newDate = new Date(this._previousStartValue.getTime() - diff);
+    if (end <= this.previousStartValue) {
+      const diff = Math.abs(this.previousEndValue.getTime() - end.getTime());
+      const newDate = new Date(this.previousStartValue.getTime() - diff);
       this.form.get('start').setValue(newDate);
     }
-    this._previousEndValue = new Date(this.form.get('end').value);
+    this.previousEndValue = new Date(this.form.get('end').value);
   }
 }

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -70,7 +70,6 @@ export class EventEditComponent implements OnInit {
       const date = new Date(key === 'start' ? time + this.duration : time - this.duration);
       this.form.get(keyToUpdate).setValue(date);
     } else {
-      // Don't reuse the start & end here because value might have changed
       this.duration = end.getTime() - start.getTime();
     }
   }

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -1,11 +1,11 @@
-import { Component, ChangeDetectionStrategy, Input, OnInit } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, OnInit, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { EventForm } from '../../form/event.form';
 import { EventService } from '../../+state/event.service';
 import { MEETING_MAX_INVITATIONS_NUMBER } from '../../+state/event.firestore';
 import { Invitation }  from '@blockframes/invitation/+state/invitation.model';
 import { createAlgoliaUserForm } from '@blockframes/utils/algolia';
-import { Observable, BehaviorSubject } from 'rxjs';
+import { Observable, BehaviorSubject, Subscription } from 'rxjs';
 
 @Component({
   selector: 'event-edit',
@@ -13,7 +13,7 @@ import { Observable, BehaviorSubject } from 'rxjs';
   styleUrls: ['./edit.component.scss'],
   changeDetection: ChangeDetectionStrategy.Default  // required for changes on "pristine" for the save button
 })
-export class EventEditComponent implements OnInit {
+export class EventEditComponent implements OnInit, OnDestroy {
 
   @Input() form = new EventForm();
   @Input() invitations: Invitation[] = [];
@@ -22,6 +22,9 @@ export class EventEditComponent implements OnInit {
   sending = new BehaviorSubject(false);
   eventLink: string;
   limit = Infinity;
+  sub: Subscription;
+
+  private _previousStartValue: Date;
 
   constructor(
     private service: EventService,
@@ -34,6 +37,21 @@ export class EventEditComponent implements OnInit {
       this.limit = MEETING_MAX_INVITATIONS_NUMBER;
     }
     this.eventLink = `/c/o/marketplace/event/${this.form.value.id}/session`;
+
+    this._previousStartValue = new Date(this.form.get('start').value);
+    this.sub = this.form.get('start').valueChanges.subscribe(start => {
+      const end = this.form.get('end').value as Date;
+      if (start >= end) {
+        var diff = Math.abs(this._previousStartValue.getTime() - start.getTime());
+        const newEndDate = new Date(end.setTime(end.getTime() + diff));
+        this.form.get('end').setValue(newEndDate);
+        this._previousStartValue = new Date(this.form.get('start').value);
+      }
+    })
+  }
+
+  ngOnDestroy() {
+    this.sub.unsubscribe();
   }
 
   get meta() {

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -13,7 +13,7 @@ import { Observable, BehaviorSubject, Subscription } from 'rxjs';
   styleUrls: ['./edit.component.scss'],
   changeDetection: ChangeDetectionStrategy.Default  // required for changes on "pristine" for the save button
 })
-export class EventEditComponent implements OnInit, OnDestroy {
+export class EventEditComponent implements OnInit {
 
   @Input() form = new EventForm();
   @Input() invitations: Invitation[] = [];
@@ -41,28 +41,6 @@ export class EventEditComponent implements OnInit, OnDestroy {
 
     this._previousStartValue = new Date(this.form.get('start').value);
     this._previousEndValue = new Date(this.form.get('end').value);
-
-    this.sub = this.form.valueChanges.subscribe(value => {
-      if (value.start >= this._previousEndValue) {
-        const diff = Math.abs(this._previousStartValue.getTime() - value.start.getTime());
-        const movedDate = new Date(this._previousEndValue.getTime() + diff);
-        this.form.get('end').setValue(movedDate, { emitEvent: false });
-      }
-
-      if (value.end <= this._previousStartValue) {
-        const diff = Math.abs(this._previousEndValue.getTime() - value.end.getTime());
-        const movedDate = new Date(this._previousStartValue.getTime() - diff);
-        this.form.get('start').setValue(movedDate, { emitEvent: false });
-      }
-
-      this._previousStartValue = new Date(this.form.get('start').value);
-      this._previousEndValue = new Date(this.form.get('end').value);
-    });
-
-  }
-
-  ngOnDestroy() {
-    this.sub.unsubscribe();
   }
 
   get meta() {
@@ -86,4 +64,21 @@ export class EventEditComponent implements OnInit, OnDestroy {
     this.service.remove(this.form.value.id);
   }
 
+  onStartChange(start: Date) {
+    if (start >= this._previousEndValue) {
+      const diff = Math.abs(this._previousStartValue.getTime() - start.getTime());
+      const newDate = new Date(this._previousEndValue.getTime() + diff);
+      this.form.get('end').setValue(newDate);
+    }
+    this._previousStartValue = new Date(start);
+  }
+
+  onEndChange(end: Date) {
+    if (end <= this._previousStartValue) {
+      const diff = Math.abs(this._previousEndValue.getTime() - end.getTime());
+      const newDate = new Date(this._previousStartValue.getTime() - diff);
+      this.form.get('start').setValue(newDate);
+    }
+    this._previousEndValue = new Date(this.form.get('end').value);
+  }
 }

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -25,6 +25,7 @@ export class EventEditComponent implements OnInit, OnDestroy {
   sub: Subscription;
 
   private _previousStartValue: Date;
+  private _previousEndValue: Date;
 
   constructor(
     private service: EventService,
@@ -39,15 +40,25 @@ export class EventEditComponent implements OnInit, OnDestroy {
     this.eventLink = `/c/o/marketplace/event/${this.form.value.id}/session`;
 
     this._previousStartValue = new Date(this.form.get('start').value);
-    this.sub = this.form.get('start').valueChanges.subscribe(start => {
-      const end = this.form.get('end').value as Date;
-      if (start >= end) {
-        var diff = Math.abs(this._previousStartValue.getTime() - start.getTime());
-        const newEndDate = new Date(end.setTime(end.getTime() + diff));
-        this.form.get('end').setValue(newEndDate);
-        this._previousStartValue = new Date(this.form.get('start').value);
+    this._previousEndValue = new Date(this.form.get('end').value);
+
+    this.sub = this.form.valueChanges.subscribe(value => {
+      if (value.start >= this._previousEndValue) {
+        const diff = Math.abs(this._previousStartValue.getTime() - value.start.getTime());
+        const movedDate = new Date(this._previousEndValue.getTime() + diff);
+        this.form.get('end').setValue(movedDate, { emitEvent: false });
       }
-    })
+
+      if (value.end <= this._previousStartValue) {
+        const diff = Math.abs(this._previousEndValue.getTime() - value.end.getTime());
+        const movedDate = new Date(this._previousStartValue.getTime() - diff);
+        this.form.get('start').setValue(movedDate, { emitEvent: false });
+      }
+
+      this._previousStartValue = new Date(this.form.get('start').value);
+      this._previousEndValue = new Date(this.form.get('end').value);
+    });
+
   }
 
   ngOnDestroy() {

--- a/libs/event/src/lib/layout/edit/edit.component.ts
+++ b/libs/event/src/lib/layout/edit/edit.component.ts
@@ -23,8 +23,7 @@ export class EventEditComponent implements OnInit {
   eventLink: string;
   limit = Infinity;
 
-  private previousStartValue: Date;
-  private previousEndValue: Date;
+  private duration: number;
 
   constructor(
     private service: EventService,
@@ -38,8 +37,8 @@ export class EventEditComponent implements OnInit {
     }
     this.eventLink = `/c/o/marketplace/event/${this.form.value.id}/session`;
 
-    this.previousStartValue = new Date(this.form.get('start').value);
-    this.previousEndValue = new Date(this.form.get('end').value);
+    const { start, end } = this.form.value;
+    this.duration = end.getTime() - start.getTime();
   }
 
   get meta() {
@@ -63,21 +62,16 @@ export class EventEditComponent implements OnInit {
     this.service.remove(this.form.value.id);
   }
 
-  onStartChange(start: Date) {
-    if (start >= this.previousEndValue) {
-      const diff = Math.abs(this.previousStartValue.getTime() - start.getTime());
-      const newDate = new Date(this.previousEndValue.getTime() + diff);
-      this.form.get('end').setValue(newDate);
+  onEventChange(key: 'start' | 'end') {
+    const { start, end } = this.form.value;
+    if (end.getTime() - start.getTime() <= 0) {
+      const keyToUpdate = key === 'start' ? 'end' : 'start';
+      const time = this.form.value[key].getTime();
+      const date = new Date(key === 'start' ? time + this.duration : time - this.duration);
+      this.form.get(keyToUpdate).setValue(date);
+    } else {
+      // Don't reuse the start & end here because value might have changed
+      this.duration = end.getTime() - start.getTime();
     }
-    this.previousStartValue = new Date(start);
-  }
-
-  onEndChange(end: Date) {
-    if (end <= this.previousStartValue) {
-      const diff = Math.abs(this.previousEndValue.getTime() - end.getTime());
-      const newDate = new Date(this.previousStartValue.getTime() - diff);
-      this.form.get('start').setValue(newDate);
-    }
-    this.previousEndValue = new Date(this.form.get('end').value);
   }
 }

--- a/libs/ui/src/lib/form/time-picker/time-picker.component.ts
+++ b/libs/ui/src/lib/form/time-picker/time-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Optional, Self, ElementRef, OnDestroy } from '@angular/core';
+import { Component, Input, Optional, Self, ElementRef, OnDestroy, EventEmitter, Output } from '@angular/core';
 import { FormGroup, FormControl, NgControl, ControlValueAccessor } from '@angular/forms';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Subject } from 'rxjs';
@@ -114,6 +114,8 @@ export class TimePickerComponent implements ControlValueAccessor, MatFormFieldCo
     }
   }
 
+  @Output() change = new EventEmitter()
+
   get empty() {
     const {value: {day, time}} = this.form;
     return !day && !time;
@@ -185,6 +187,7 @@ export class TimePickerComponent implements ControlValueAccessor, MatFormFieldCo
   setDate() {
     const value = createDate(this.form.getRawValue());
     this.onChange(value)
+    this.change.emit(value);
   }
 
 }


### PR DESCRIPTION
To do in issue #3674 

"When we change start date of an event, end date should adapt: event should stay the same duration. E.g. Start date 09/15/20 10:00 am / End date 09/15/20 11:00 am > start date changed to 09/16/20 11:00 am, end date should be automatically updated to 09/16/20 noon"