### PR TITLE
Fix UI issue for Safari

### DIFF
--- a/libs/movie/src/lib/movie/components/card/card.component.scss
+++ b/libs/movie/src/lib/movie/components/card/card.component.scss
@@ -6,7 +6,6 @@
 
 figure {
   position: relative;
-  display: flex;
   margin: 0;
 }
 


### PR DESCRIPTION
To do in issue #3674 

- [ ] Still image issues on Safari... These are screenshots from a user:
<img width="1440" alt="Capture d’écran 2020-09-24 à 14 50 03" src="https://user-images.githubusercontent.com/14964443/94532163-cd909f80-023d-11eb-972c-46335a4c3485.png">
<img width="1440" alt="Capture d’écran 2020-09-24 à 14 49 55" src="https://user-images.githubusercontent.com/14964443/94532168-cf5a6300-023d-11eb-8069-15478e59e698.png">