### PR TITLE
Fix movie counts indicators

### DIFF
--- a/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
@@ -1,4 +1,4 @@
-<title-list [titles]="movieSearchResults$ | async">
+<title-list [titles]="movieSearchResults$ | async" [totalCount]="nbHits">
 
   <!-- App Bar Search -->
   <ng-template titleAppBarSearch>

--- a/apps/festival/festival/src/app/marketplace/title/list/list.component.html
+++ b/apps/festival/festival/src/app/marketplace/title/list/list.component.html
@@ -1,4 +1,4 @@
-<title-list [titles]="movieSearchResults$ | async">
+<title-list [titles]="movieSearchResults$ | async" [totalCount]="nbHits"> 
 
   <!-- App Bar Search -->
   <ng-template titleAppBarSearch>

--- a/apps/festival/festival/src/app/marketplace/title/list/list.component.ts
+++ b/apps/festival/festival/src/app/marketplace/title/list/list.component.ts
@@ -60,16 +60,17 @@ export class ListComponent implements OnInit, OnDestroy {
       switchMap(() => this.filterForm.search()),
       tap(res => this.nbHits = res.nbHits),
       pluck('hits'),
-      tap(movies => this.hitsViewed = this.hitsViewed + movies.length),
       map(result => result.map(movie => movie.objectID)),
       switchMap(ids => ids.length ? this.movieService.valueChanges(ids) : of([])),
       // map(movies => movies.sort((a, b) => sortMovieBy(a, b, this.sortByControl.value))), // TODO issue #3584
       tap(movies => {
         if (this.loadingMore) {
           this.movieSearchResultsState.next(this.movieSearchResultsState.value.concat(movies));
+          this.hitsViewed += movies.length;
           this.loadingMore = false;
         } else {
           this.movieSearchResultsState.next(movies);
+          this.hitsViewed = movies.length;
         }
       }),
       tap(_ => setTimeout(() => this.scrollToScrollOffset(), 0))

--- a/libs/movie/src/lib/movie/layout/list/title-list.component.html
+++ b/libs/movie/src/lib/movie/layout/list/title-list.component.html
@@ -45,7 +45,7 @@
   <ng-container *ngIf="titles; else loading">
     <ng-container *ngIf="titles.length else empty">
       <div fxLayout="row" fxLayoutAlign="end start">
-        <span i18n *ngIf="titles.length as count" class="mat-body-2">
+        <span i18n *ngIf="totalCount as count" class="mat-body-2">
           There {count, plural, =0 {} =1 {is} other {are}} {{ count }} title{count, plural, =0 {} =1 {} other {s}}
           available.
         </span>

--- a/libs/movie/src/lib/movie/layout/list/title-list.component.ts
+++ b/libs/movie/src/lib/movie/layout/list/title-list.component.ts
@@ -37,6 +37,7 @@ export class TitleListComponent implements AfterContentInit {
   @ContentChild(TitleProgressDirective, { read: TemplateRef }) titleProgressTemplate: TitleProgressDirective;
 
   @Input() titles: Movie[];
+  @Input() totalCount: number;
 
   @Input() titleType = 'title'; // only for display purpose
 


### PR DESCRIPTION
To do issue #3674 

- [x] On top of the page, display all the titles count (same as the one displayed before the load more button)
- [x] Film count before the load more button is bugged after applying a filter