### PR TITLE
Show multi day even at every day it is screening

### DIFF
--- a/libs/event/src/lib/components/list/list.component.html
+++ b/libs/event/src/lib/components/list/list.component.html
@@ -1,7 +1,7 @@
 <ul fxLayout="column" fxLayoutGap="16px">
   <ng-container *ngFor="let timeFrame of timeFrames">
     <!-- For a time frame -->
-    <ng-container *ngIf="(events | filterByDate: timeFrame : 'start') as eventList">
+    <ng-container *ngIf="(events | filterByDate: timeFrame : 'start' : 'end') as eventList">
 
       <h2 *ngIf="eventList.length">
         {{ timeFrame | labelByDate }}

--- a/libs/event/src/lib/components/list/list.component.ts
+++ b/libs/event/src/lib/components/list/list.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, TemplateRef, ContentChild, ChangeDetectionStrategy, HostBinding } from '@angular/core';
 import { ascTimeFrames } from '@blockframes/utils/pipes/filter-by-date.pipe';
 import { slideUpList } from '@blockframes/utils/animations/fade';
+import { EventBase } from '@blockframes/event/+state/event.firestore';
 
 @Component({
   selector: 'event-list',
@@ -13,7 +14,7 @@ export class ListComponent {
   @HostBinding('@slideUpList') animation = true;
   timeFrames = ascTimeFrames;
 
-  @Input() events: Event[];
+  @Input() events: EventBase<Date>[];
   @ContentChild(TemplateRef) itemTemplate: TemplateRef<any>;
-  
+
 }

--- a/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
+++ b/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
@@ -34,10 +34,12 @@
 
   <!-- Footer -->
   <movie-screening></movie-screening>
-  <h2 flex>Images</h2>
-  <bf-carousel flex [min]="4">
-    <ng-container *ngFor="let photo of movie.promotional.still_photo">
-      <img carouselItem [col]="3" [ref]="photo" asset="empty_poster.webp" >
-    </ng-container>
-  </bf-carousel>
+  <ng-container *ngIf="movie.promotional.still_photo.length">
+    <h2 flex>Images</h2>
+    <bf-carousel flex [min]="4">
+      <ng-container *ngFor="let photo of movie.promotional.still_photo">
+        <img carouselItem [col]="3" [ref]="photo" asset="empty_poster.webp" >
+      </ng-container>
+    </bf-carousel>
+  </ng-container>
 </ng-container>

--- a/libs/utils/src/lib/pipes/filter-by-date.pipe.ts
+++ b/libs/utils/src/lib/pipes/filter-by-date.pipe.ts
@@ -48,8 +48,9 @@ export class FilterByDatePipe implements PipeTransform {
    * @param value A list to order by date
    * @param timeFrame 
    * @param key The key where to find the date value
+   * @param keyFinish The key where to find the end date value. If used, date found at key is used as starting date.
    */
-  transform(value: any[], timeFrame: TimeFrame, key: string = 'date') {
+  transform(value: any[], timeFrame: TimeFrame, key: string = 'date', keyFinish?: string) {
     if (!Array.isArray(value)) {
       return value;
     }
@@ -57,7 +58,12 @@ export class FilterByDatePipe implements PipeTransform {
     const now = startOfDay(Date.now());
     const fromDate = add({ [type]: from }, now);
     const toDate = add({ [type]: to }, now);
-    return value.filter(v => v[key] >= fromDate && v[key] < toDate);
+    return value.filter(v => {
+      if (!!keyFinish) {
+        return v[key] < toDate && v[keyFinish] >= fromDate;
+      }
+      return v[key] >= fromDate && v[key] < toDate;
+    });
   }
 }
 


### PR DESCRIPTION
To do issue #3674 

"Screening lists (/c/o/marketplace/event + /c/o/marketplace/organization/orgId/screening + /c/o/marketplace/title/movieId/screenings) display events based on their starting date but for multiple day screenings they should appear on every day of the screening.
For example: an event from 10/15 to 10/17 is currently shown only for the 15th while it should be displayed on 15th, 16th and 17th"

-- And --

"Images section title shouldn't be displayed if there is no stills on the film"
