### PR TITLE
Navigate to event immediately when its already running

### DIFF
--- a/libs/event/src/lib/layout/view/view.component.html
+++ b/libs/event/src/lib/layout/view/view.component.html
@@ -23,12 +23,10 @@
         <ng-container *ngSwitchCase="'onTime'">
           <h6>{{event.isPrivate ? 'Private' : 'Public'}} {{ event.type }}</h6>
           <pre class="mat-body-1">{{ event | eventRange }}</pre>
-          <ng-container *ngIf="(invitation$ | async)?.status === 'accepted' || event.isOwner; else noAccess">
+          <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
+          <ng-container *ngIf="(invitation$ | async)?.status === 'accepted' || event.isOwner">
             <a test-id="event-room" mat-flat-button routerLink="./session" color="accent">Access {{ event.type | titlecase }} Room</a>
           </ng-container>
-          <ng-template #noAccess>
-            <invitation-action [invitation]="invitation$ | async" [event]="event"></invitation-action>
-          </ng-template>
         </ng-container>
 
         <ng-container *ngSwitchCase="'late'">

--- a/libs/event/src/lib/layout/view/view.component.scss
+++ b/libs/event/src/lib/layout/view/view.component.scss
@@ -8,6 +8,10 @@ header {
   }
 }
 
+h1 {
+  text-align: center;
+}
+
 h6 {
   text-transform: uppercase;
 }

--- a/libs/event/src/lib/layout/view/view.component.ts
+++ b/libs/event/src/lib/layout/view/view.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core
 import { Event } from '../../+state/event.model';
 import { InvitationService, Invitation, InvitationQuery } from '@blockframes/invitation/+state';
 import { Observable, BehaviorSubject } from 'rxjs';
-import { switchMap, shareReplay } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Location } from '@angular/common';
 
 @Component({
@@ -35,9 +35,8 @@ export class EventViewComponent implements OnInit {
 
     this.editMeeting = `/c/o/dashboard/event/${this.event.id}/edit`;
 
-    this.invitation$ = this.event$.pipe(
-      switchMap(event => this.invitationQuery.selectByDocId(event.id)),
-      shareReplay(1)
+    this.invitation$ = this.invitationQuery.selectAll().pipe(
+      map(invits => invits.find(e => e.docId === this.event.id))
     );
   }
 

--- a/libs/event/src/lib/pipes/event-range.pipe.ts
+++ b/libs/event/src/lib/pipes/event-range.pipe.ts
@@ -6,20 +6,22 @@ import { isSameMonth, isSameDay, isSameYear } from 'date-fns';
 @Pipe({ name: 'eventRange', pure: true })
 export class EventRangePipe implements PipeTransform {
   transform({ start, end }: Event) {
+    const from = formatDate(start, 'h:mm a', 'en');
+    const to = formatDate(end, 'h:mm a', 'en');
+    const gmt = formatDate(start, 'O', 'en');
+
+    const time = `\n${from} - ${to} (${gmt})`; // Use <pre>{{ | eventRange }}</pre> to take advantage of \n
+
     if (isSameDay(start, end)) {
-      const day = formatDate(start, 'EEEE, MMMM d, y', 'en');
-      const from = formatDate(start, 'h:mm a', 'en');
-      const to = formatDate(end, 'h:mm a', 'en');
-      const gmt = formatDate(start, 'O', 'en');
-      return `${day} \n${from} - ${to} (${gmt})`; // Use <pre>{{ | eventRange }}</pre> to take advantage of \n
+      return `${formatDate(start, 'EEEE, MMMM d, y', 'en')} ${time}`;
     }
     if (isSameMonth(start, end)) {
-      return `${start.getDate()} - ${formatDate(end, 'd MMMM, y','en')}`;
+      return `${start.getDate()} - ${formatDate(end, 'd MMMM, y','en')} ${time}`;
     }
     if (isSameYear(start, end)) {
-      return `${formatDate(start, 'MMMM d', 'en')} - ${formatDate(end, 'MMMM d', 'en')}, ${end.getFullYear()}`;
+      return `${formatDate(start, 'MMMM d', 'en')} - ${formatDate(end, 'MMMM d', 'en')}, ${end.getFullYear()} ${time}`;
     }
-    return `${formatDate(start, 'MMMM d y', 'en')} - ${formatDate(start, 'MMMM d y', 'en')}`;
+    return `${formatDate(start, 'MMMM d y', 'en')} - ${formatDate(start, 'MMMM d y', 'en')} ${time}`;
   }
 }
 

--- a/libs/invitation/src/lib/components/action/action.component.html
+++ b/libs/invitation/src/lib/components/action/action.component.html
@@ -33,7 +33,7 @@
         <span *ngIf="!event.isPrivate">Add to my calendar</span>
       </ng-container>
       <ng-container *ngSwitchCase="'onTime'">
-        <span>Session has already started, request access</span>
+        <span>Access event</span>
       </ng-container>
     </ng-container>
   </button>

--- a/libs/invitation/src/lib/components/action/action.component.ts
+++ b/libs/invitation/src/lib/components/action/action.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Router } from '@angular/router';
 import { Event } from '@blockframes/event/+state';
 import { Invitation, InvitationService } from '../../+state';
 
@@ -15,9 +16,17 @@ export class ActionComponent {
 
   @Input() set invitation(invit: Invitation) {
     this.invit= invit;
+
+    if (this.requestPending && invit.status === 'accepted') {
+      this.router.navigate(['/c/o/marketplace/event', invit.docId, 'session']);
+      this.requestPending = false;
+    }
   }
 
+  private requestPending: boolean = false;
+
   constructor(
+    private router: Router,
     private service: InvitationService
   ) {}
 
@@ -30,8 +39,10 @@ export class ActionComponent {
   }
 
   /** Request the owner to accept invitation (automatically accepted if event is public) */
-  request(event: Event) {
+  async request(event: Event) {
     const { ownerId, id } = event;
-    this.service.request('org', ownerId).from('user').to('attendEvent', id);
+    await this.service.request('org', ownerId).from('user').to('attendEvent', id);
+
+    this.requestPending = true;
   }
 }

--- a/libs/invitation/src/lib/components/action/action.component.ts
+++ b/libs/invitation/src/lib/components/action/action.component.ts
@@ -39,10 +39,9 @@ export class ActionComponent {
   }
 
   /** Request the owner to accept invitation (automatically accepted if event is public) */
-  async request(event: Event) {
+  request(event: Event) {
     const { ownerId, id } = event;
-    await this.service.request('org', ownerId).from('user').to('attendEvent', id);
-
+    this.service.request('org', ownerId).from('user').to('attendEvent', id);
     this.requestPending = true;
   }
 }


### PR DESCRIPTION
To do in issue #3674 

"When the event is public and the user not invited, the CTA button should be "Access event" > this would create the request and automatically accept it as it does already + leading to the event page so the user can access the screening

On the marketplace event view, if the user is not invited, the CTA should also be "Access event"
![image](https://user-images.githubusercontent.com/14964443/94543304-2b2ae900-024a-11eb-8b5c-83d9e1ace81c.png)
Also, here we would need an observable so after clicking on "Access event" the "accepted" state + "Access Screening Room" should appear without the user reloading the page
![image](https://user-images.githubusercontent.com/14964443/94543443-5f9ea500-024a-11eb-86b4-e73d51e7d20c.png)
"

-- and --

"-When a user creates a multiple day event, it should automatically starts from 00:00 AM on the first day to 11:59PM last day and this info should be displayed on the time of the event, same as the all day event (already implemented) 
![image](https://user-images.githubusercontent.com/14964443/94546480-397b0400-024e-11eb-9f6b-f2b4a0a2c584.png)"

-- and --

"When event title is too long and has to go on 2 lines, it is not centered anymore. Should stay centered."