### PR TITLE
Tiny ui fixes

### DIFF
--- a/apps/festival/festival/src/app/marketplace/home/home.component.html
+++ b/apps/festival/festival/src/app/marketplace/home/home.component.html
@@ -2,6 +2,7 @@
   <header fxLayout="column" fxLayoutAlign="center start" fxLayoutAlign.xs="center center" class="dark-contrast-theme">
     <h4>Welcome to Archipel Market</h4>
     <h1 class="mat-display-2">The ongoing<br/> film market</h1>
+    <p>Check out our <a routerLink="/c/o/marketplace/event">Upcoming screenings</a>  or discover the platform’s projects or companies:</p>
     <div fxLayout="row" fxLayoutGap="24px">
       <a mat-flat-button color="accent" test-id="library" routerLink="../title">What's on the market today</a>
       <a mat-stroked-button test-id="sales agent" routerLink="../organization">Who's on the market today</a>

--- a/apps/festival/festival/src/app/marketplace/home/home.component.scss
+++ b/apps/festival/festival/src/app/marketplace/home/home.component.scss
@@ -13,7 +13,16 @@ header {
   border: none;
 
   h1.mat-display-2 {
-    margin-bottom: 80px;
+    margin-bottom: 30px;
+  }
+
+  p {
+    margin-bottom: 30px;
+    margin-left: 12px;
+    a {
+      border-bottom: 2px solid;
+      font-weight: bolder;
+    }
   }
   h4 {
     text-transform: uppercase;

--- a/libs/movie/src/lib/movie/components/credit-card/credit-card.component.html
+++ b/libs/movie/src/lib/movie/components/credit-card/credit-card.component.html
@@ -11,7 +11,7 @@
           {{ credit.role ? (credit.role | translateSlug:'CREW_ROLES') : 'Crew' }}
         </ng-container>
         <ng-container *ngSwitchCase="'cast'">
-          Comedian
+          Actor
         </ng-container>
       </ng-container>
     </p>

--- a/libs/movie/src/lib/movie/components/upcoming-screenings/upcoming-screenings.component.html
+++ b/libs/movie/src/lib/movie/components/upcoming-screenings/upcoming-screenings.component.html
@@ -35,9 +35,9 @@
 </ng-container>
 <ng-template #noScreenings>
   <ng-container *ngIf="org | async as org">
-    <span class="mat-body-1">There are no screenings scheduled at the moment. You can contact
+    <span class="mat-body-1">There is no screening scheduled at the moment. You can contact
       {{ org[0].denomination?.public || 'the organization' }} for any
-      questions</span>
-    <a mat-flat-button color="accent" [href]="'mailto:'+ org[0].email">Contact Seller</a>
+      questions.</span>
+    <a mat-flat-button color="accent" [href]="'mailto:'+ org[0].email">Contact Sales Agent</a>
   </ng-container>
 </ng-template> 


### PR DESCRIPTION
To do issue #3674 

"Person Card: 
- add a tooltip for the no status icon: "Status is not provided" 
![image](https://user-images.githubusercontent.com/14964443/94837647-d25b7c00-0414-11eb-9679-60e227a2cf76.png)
- for cast card, change "Comedian" for "Actor"
![image](https://user-images.githubusercontent.com/14964443/94838177-80ffbc80-0415-11eb-9ba7-6fe77ef70a44.png)"

-- and --

"Screening banner:
- change text for "There are no screening scheduled at the moment. You can contact {{orgName}} for any questions." 
- screening CTA button text is: "Contact Sales Agent"
![image](https://user-images.githubusercontent.com/14964443/94836495-56146900-0413-11eb-8ac0-4220e73065fe.png)"

-- and --
Move upward "check out upcoming screenings" banner on homepage so it's just before the top banner "the ongoing film market" this is to help the users find their screening more easily. Mb good to check quickly with @stephanie-cascade8 if there should be some margin between the 2 banners but the goal is to see the screenings banner without scrolling."

