### PR TITLE
Navigate user to dashboard event

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -162,8 +162,9 @@ service cloud.firestore {
     }
 
     function isInvitationRecepient() {
-      return isOrgAdmin(existingData().toOrg.id)
-        || userId() == existingData().toUser.uid;
+      return userId() == existingData().toUser.uid
+        || (existingData().type == 'joinOrganization' && isOrgAdmin(existingData().toOrg.id))
+        || (existingData().type == 'attendEvent' && isOrgMember(existingData().toOrg.id));
     }
 
     function isOnlyChangingInvitationStatus() {

--- a/libs/invitation/src/lib/components/item/item.component.ts
+++ b/libs/invitation/src/lib/components/item/item.component.ts
@@ -16,7 +16,7 @@ export class ItemComponent {
   get eventLink() {
     if (this.invitation.type === 'attendEvent') {
       if (this.invitation.mode === 'request') {
-        return `../event/${this.invitation.docId}/edit`;
+        return `/c/o/dashboard/event/${this.invitation.docId}/edit`;
       } else {
         return `/c/o/marketplace/event/${this.invitation.docId}`;
       }


### PR DESCRIPTION
To do issue #3674 

"Invitations: can't accept a request to attend an event, it goes back to pending right after I click on accept (currently with dev+crystel-fhw@cascade8.com)"

""More details" on the action list for that same invitation (request to attend to an event) links to a dead url https://staging.archipelmarket.com/c/o/marketplace/event/4MeCa9BVCC7lkSCih9T8/edit > it's not marketplace but dashboard (for the owner of the event)
[Update: url marketplace in fact depends on the user being already in the marketplace or dashboard; sellers being able to be on both apps, the link should be agnostic of that and always redirect to dashboard when the org is owner of the event ]"