### PR TITLE
Get api over https instead of http

### DIFF
--- a/libs/user/src/lib/auth/+state/auth.service.ts
+++ b/libs/user/src/lib/auth/+state/auth.service.ts
@@ -135,7 +135,7 @@ export class AuthService extends FireAuthService<AuthState> {
   }
 
   public async getPrivacyPolicy() {
-    const { ip } = await this.http.get<{ip: string}>(`http://api.ipify.org/?format=json`).toPromise();
+    const { ip } = await this.http.get<{ip: string}>(`https://api.ipify.org/?format=json`).toPromise();
     return {
       date: new Date(),
       ip: ip


### PR DESCRIPTION
Fix error "zone.js:3324 Mixed Content: The page at 'https://staging.archipelmarket.com/auth/connexion#login' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.ipify.org/?format=json'. This request has been blocked; the content must be served over HTTPS."