### PR TITLE
Remove accidental arrows on organization card

### DIFF
--- a/libs/organization/src/lib/organization/components/card/card.component.html
+++ b/libs/organization/src/lib/organization/components/card/card.component.html
@@ -5,7 +5,7 @@
   <h5>{{ org | orgName }}</h5>
   <span class="mat-body-2">{{ (org.activity | toLabel: 'orgActivity') || "-" }}</span>
 </div>
-<mat-tab-group headerPosition="below" mat-align-tabs="center">
+<mat-tab-group headerPosition="below" mat-align-tabs="center" [disablePagination]="true">
   <mat-tab>
     <ng-template mat-tab-label>
       <mat-icon svgIcon="profile"></mat-icon>


### PR DESCRIPTION
To do in issue #3674

"Seller org list (`/c/o/marketplace/organization`), don't know what are the arrows for at the bottom of the org card but they're not working, we should remove it
![image](https://user-images.githubusercontent.com/14964443/95102773-16f85780-0734-11eb-8d2c-7ca64662830c.png)"