### PR TITLE
Remove upcoming screening component for now

### DIFF
--- a/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
+++ b/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
@@ -33,7 +33,8 @@
   </section>
 
   <!-- Footer -->
-  <movie-screening></movie-screening>
+  <!-- TODO issue#3674 https://github.com/blockframes/blockframes/issues/3674#issuecomment-703626090 -->
+  <!-- <movie-screening></movie-screening> -->
   <ng-container *ngIf="movie.promotional.still_photo.length">
     <h2 flex>Images</h2>
     <bf-carousel flex [min]="4">


### PR DESCRIPTION
Upcoming screening banner needs some more bug fixes. Therefore we chose to disable it for now and fix it for the next release.