### PR TITLE
Removed reload on signout

### DIFF
--- a/libs/user/src/lib/auth/+state/auth.service.ts
+++ b/libs/user/src/lib/auth/+state/auth.service.ts
@@ -86,7 +86,6 @@ export class AuthService extends FireAuthService<AuthState> {
 
     this.ngIntercom.shutdown();
     sessionStorage.clear();
-    window.location.reload();
   }
 
   /**


### PR DESCRIPTION
Fix issue #3929 

Reload page on sign out didn't seem to be needed.

The issue was first mentioned 4 months ago in [issue#2782](https://github.com/blockframes/blockframes/issues/2782) and fixed in [PR #3214](https://github.com/blockframes/blockframes/pull/3214). I removed the reload page part and tested on Firefox, Chrome and Safari and all tabs logged out and navigated to the home page.