### PR TITLE
Event analytics hotfix

### DIFF
--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -70,6 +70,6 @@
     </ng-container>
   </event-edit>
   <ng-container *ngIf="isEventStarted()">
-    <festival-event-analytics [eventId]="form.id.value"></festival-event-analytics>
+    <event-analytics [eventId]="form.id.value"></event-analytics>
   </ng-container>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -69,4 +69,7 @@
       </ng-container>
     </ng-container>
   </event-edit>
+  <ng-container *ngIf="isEventStarted()">
+    <festival-event-analytics [eventId]="form.id.value"></festival-event-analytics>
+  </ng-container>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
@@ -1,4 +1,4 @@
-festival-event-analytics {
+event-analytics {
   display: block;
   padding: 24px;
 }

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
@@ -1,0 +1,4 @@
+festival-event-analytics {
+  display: block;
+  padding: 24px;
+}

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
@@ -82,6 +82,12 @@ export class EditComponent implements OnInit, OnDestroy {
     });
   }
 
+  // Will be used to show event statistics only if event started
+  isEventStarted() {
+    const start = this.form.get('start').value as Date;
+    return start.getTime() < Date.now();
+  }
+
   ngOnDestroy() {
     this.sub.unsubscribe();
     this.formSub.unsubscribe();

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.module.ts
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.module.ts
@@ -16,6 +16,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { FileNameModule } from '@blockframes/utils/pipes/fileName.pipe';
+import { EventAnalyticsModule } from '@blockframes/event/components/analytics/analytics.module';
 
 @NgModule({
   declarations: [EditComponent],
@@ -24,6 +25,7 @@ import { FileNameModule } from '@blockframes/utils/pipes/fileName.pipe';
     FlexLayoutModule,
     ReactiveFormsModule,
     LayoutEventEditModule,
+    EventAnalyticsModule,
     DisplayNameModule,
     FileSelectorModule,
     FormListModule,

--- a/apps/festival/festival/src/app/dashboard/event/review/review.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/review/review.component.html
@@ -1,40 +1,4 @@
 <ng-container *ngIf="event$ | async as event">
   <event-review [event]="event"></event-review>
-
-  <h2>Statistics</h2>
-  <ng-container *ngIf="analytics$ | async as analytics; else loading">
-    <ng-container *ngIf="analytics.length else noAnalytics">
-      <section class="analytics">
-        <mat-card class="attendees">
-          <span fxLayout="row" fxLayoutAlign="start center">
-            <mat-icon svgIcon="group"></mat-icon>
-            <span class="mat-body-2">Number of attendees</span>
-          </span>
-          <h2>{{ analytics.length }}</h2>
-        </mat-card>
-        <mat-card>
-          <h3>Attendees</h3>
-          <bf-table-filter
-            showFilter
-            showPaginator
-            [initialColumns]="initialColumns"
-            [columns]="columns"
-            [source]="analytics">
-            <ng-template colRef="name" let-name>{{ name | titlecase }}</ng-template>
-          </bf-table-filter>
-        </mat-card>
-      </section>
-    </ng-container>
-  </ng-container>
-  <ng-template #noAnalytics>
-    <article class="no-analytics" fxLayout="column" fxLayoutAlign="center center">
-      <img asset="wait.webp" alt="waiting">
-      <p class="mat-body-2">There is no statistics available here yet.</p>
-    </article>
-  </ng-template>
-  <ng-template #loading>
-    <article fxLayout="row" fxLayoutAlign="center">
-      <mat-spinner></mat-spinner>
-    </article>
-  </ng-template>
+  <festival-event-analytics [eventId]="event.id"></festival-event-analytics>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/review/review.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/review/review.component.html
@@ -1,4 +1,4 @@
 <ng-container *ngIf="event$ | async as event">
   <event-review [event]="event"></event-review>
-  <festival-event-analytics [eventId]="event.id"></festival-event-analytics>
+  <event-analytics [eventId]="event.id"></event-analytics>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/review/review.component.scss
+++ b/apps/festival/festival/src/app/dashboard/event/review/review.component.scss
@@ -1,37 +1,4 @@
-@import '~@angular/flex-layout/mq';
-
 :host {
   display: block;
   padding: 24px;
-}
-
-img {
-  width: 320px;
-}
-
-.attendees {
-  width: 550px;
-  margin-bottom: 24px;
-  h2 {
-    margin-top: 16px;
-  }
-}
-
-h3 {
-  margin-top: 16px;
-  margin-bottom: 0;
-}
-
-bf-table-filter {
-  height: 100%;
-}
-
-.analytics, .no-analytics {
-  margin-bottom: 300px;
-}
-
-@include layout-bp(xs) {
-  .attendees {
-    width: 300px;
-  }
 }

--- a/apps/festival/festival/src/app/dashboard/event/review/review.component.ts
+++ b/apps/festival/festival/src/app/dashboard/event/review/review.component.ts
@@ -1,16 +1,9 @@
 import { Component, ChangeDetectionStrategy, OnInit } from '@angular/core';
 import { Event } from '@blockframes/event/+state';
-import { Invitation } from '@blockframes/invitation/+state';
 import { EventService } from '@blockframes/event/+state/event.service';
 import { Observable } from 'rxjs';
-import { switchMap, map, filter, pluck } from 'rxjs/operators';
+import { switchMap, pluck } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
-import { EventAnalytics } from '@blockframes/event/+state/event.firestore';
-
-const columns = {
-  name: 'Name',
-  email: 'Email Address'
-};
 
 @Component({
   selector: 'festival-event-review',
@@ -20,12 +13,7 @@ const columns = {
 })
 export class EventReviewComponent implements OnInit {
   event$: Observable<Event>;
-  invitations$: Observable<Invitation[]>;
-  analytics$ : Observable<EventAnalytics[]>;
   eventId$: Observable<string>;
-
-  public columns = columns;
-  public initialColumns = Object.keys(columns);
 
   constructor(
     private service: EventService,
@@ -34,15 +22,6 @@ export class EventReviewComponent implements OnInit {
 
   ngOnInit() {
     this.eventId$ = this.route.params.pipe(pluck('eventId'));
-
-    this.analytics$ = this.eventId$.pipe(
-      switchMap((eventId: string) => this.service.queryAnalytics(eventId)),
-      filter(analytics => !!analytics),
-      map(analytics => {
-        const transformEvent = (event: EventAnalytics) => ({ ...event, name: `${event.firstName} ${event.lastName}` });
-        return analytics.eventUsers.map(transformEvent);
-      })
-    );
 
     this.event$ = this.eventId$.pipe(
       switchMap((eventId: string) => this.service.valueChanges(eventId))

--- a/apps/festival/festival/src/app/dashboard/event/review/review.module.ts
+++ b/apps/festival/festival/src/app/dashboard/event/review/review.module.ts
@@ -1,29 +1,17 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { EventReviewComponent } from './review.component';
 
-import { TableFilterModule } from '@blockframes/ui/list/table-filter/table-filter.module';
 import { LayoutEventReviewModule } from '@blockframes/event/layout/review/review.module';
-import { ImageReferenceModule } from '@blockframes/media/directives/image-reference/image-reference.module';
-
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-
+import { EventAnalyticsModule } from '@blockframes/event/components/analytics/analytics.module';
 
 @NgModule({
   declarations: [EventReviewComponent],
   imports: [
     CommonModule,
     LayoutEventReviewModule,
-    ImageReferenceModule,
-    TableFilterModule,
-    FlexLayoutModule,
-    MatCardModule,
-    MatIconModule,
-    MatProgressSpinnerModule,
+    EventAnalyticsModule,
     RouterModule.forChild([{ path: '', component: EventReviewComponent }])
   ]
 })

--- a/libs/event/src/lib/components/analytics/analytics.component.html
+++ b/libs/event/src/lib/components/analytics/analytics.component.html
@@ -1,0 +1,38 @@
+<ng-container *ngIf="eventId">
+  <h2>Statistics</h2>
+  <ng-container *ngIf="analytics as analytics; else loading">
+    <ng-container *ngIf="analytics.length else noAnalytics">
+      <section class="analytics">
+        <mat-card class="attendees">
+          <span fxLayout="row" fxLayoutAlign="start center">
+            <mat-icon svgIcon="group"></mat-icon>
+            <span class="mat-body-2">Number of attendees</span>
+          </span>
+          <h2>{{ analytics.length }}</h2>
+        </mat-card>
+        <mat-card>
+          <h3>Attendees</h3>
+          <bf-table-filter
+            showFilter
+            showPaginator
+            [initialColumns]="initialColumns"
+            [columns]="columns"
+            [source]="analytics">
+            <ng-template colRef="name" let-name>{{ name | titlecase }}</ng-template>
+          </bf-table-filter>
+        </mat-card>
+      </section>
+    </ng-container>
+  </ng-container>
+  <ng-template #noAnalytics>
+    <article class="no-analytics" fxLayout="column" fxLayoutAlign="center center">
+      <img asset="wait.webp" alt="waiting">
+      <p class="mat-body-2">There is no statistics available here yet.</p>
+    </article>
+  </ng-template>
+  <ng-template #loading>
+    <article fxLayout="row" fxLayoutAlign="center">
+      <mat-spinner></mat-spinner>
+    </article>
+  </ng-template>
+</ng-container>

--- a/libs/event/src/lib/components/analytics/analytics.component.scss
+++ b/libs/event/src/lib/components/analytics/analytics.component.scss
@@ -1,0 +1,32 @@
+@import '~@angular/flex-layout/mq';
+
+img {
+  width: 320px;
+}
+
+.attendees {
+  width: 550px;
+  margin-bottom: 24px;
+  h2 {
+    margin-top: 16px;
+  }
+}
+
+h3 {
+  margin-top: 16px;
+  margin-bottom: 0;
+}
+
+bf-table-filter {
+  height: 100%;
+}
+
+.analytics, .no-analytics {
+  margin-bottom: 300px;
+}
+
+@include layout-bp(xs) {
+  .attendees {
+    width: 300px;
+  }
+}

--- a/libs/event/src/lib/components/analytics/analytics.component.ts
+++ b/libs/event/src/lib/components/analytics/analytics.component.ts
@@ -1,0 +1,36 @@
+import { Component, ChangeDetectionStrategy, OnInit, Input, ChangeDetectorRef } from '@angular/core';;
+import { EventService } from '@blockframes/event/+state/event.service';
+import { EventAnalytics } from '@blockframes/event/+state/event.firestore';
+
+const columns = {
+  name: 'Name',
+  email: 'Email Address'
+};
+
+@Component({
+  selector: 'festival-event-analytics',
+  templateUrl: './analytics.component.html',
+  styleUrls: ['./analytics.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class EventAnalyticsComponent implements OnInit {
+
+  analytics : EventAnalytics[];
+
+  @Input() eventId: string;
+
+  public columns = columns;
+  public initialColumns = Object.keys(columns);
+
+  constructor(
+    private service: EventService,
+    private cdr: ChangeDetectorRef,
+  ) { }
+
+  async ngOnInit() {
+    const transformEvent = (event: EventAnalytics) => ({ ...event, name: `${event.firstName} ${event.lastName}` });
+    const analytics = await this.service.queryAnalytics(this.eventId);
+    this.analytics = analytics.eventUsers.map(transformEvent);
+    this.cdr.markForCheck();
+  }
+}

--- a/libs/event/src/lib/components/analytics/analytics.component.ts
+++ b/libs/event/src/lib/components/analytics/analytics.component.ts
@@ -8,7 +8,7 @@ const columns = {
 };
 
 @Component({
-  selector: 'festival-event-analytics',
+  selector: 'event-analytics',
   templateUrl: './analytics.component.html',
   styleUrls: ['./analytics.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/libs/event/src/lib/components/analytics/analytics.module.ts
+++ b/libs/event/src/lib/components/analytics/analytics.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { EventAnalyticsComponent } from './analytics.component';
+
+import { TableFilterModule } from '@blockframes/ui/list/table-filter/table-filter.module';
+import { ImageReferenceModule } from '@blockframes/media/directives/image-reference/image-reference.module';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@NgModule({
+  declarations: [EventAnalyticsComponent],
+  imports: [
+    CommonModule,
+    ImageReferenceModule,
+    TableFilterModule,
+    FlexLayoutModule,
+    MatCardModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  exports: [EventAnalyticsComponent]
+})
+export class EventAnalyticsModule { }

--- a/libs/event/src/lib/form/event.form.ts
+++ b/libs/event/src/lib/form/event.form.ts
@@ -29,6 +29,10 @@ export class EventForm extends FormEntity<EventControl, Event> {
   get meta() {
     return this.get('meta');
   }
+
+  get id() {
+    return this.get('id');
+  }
 }
 
 // Meta


### PR DESCRIPTION
Display statistics of an event at the end of the event form; same as event dashboard view. For the moment, you can't access the view before the event is finished (or with the direct url) and that's annoying for multiple day screenings since they'd like to have their stats asap