### PR TITLE
Fix backgound image bug

### DIFF
--- a/libs/media/src/lib/directives/image-reference/background-reference.directive.ts
+++ b/libs/media/src/lib/directives/image-reference/background-reference.directive.ts
@@ -77,10 +77,10 @@ export class BackgroundReferenceDirective implements OnInit, OnDestroy {
       this.assetUrl$
     ]).subscribe(([ref, assetUrl]) => {
       if (ref) {
-        this.src = this.sanitazier.bypassSecurityTrustStyle(`url(${ref}), url(${assetUrl})`);
+        this.src = this.sanitazier.bypassSecurityTrustStyle(`url("${ref}"), url("${assetUrl}")`);
         this.cdr.markForCheck();
       } else if (assetUrl) {
-        this.src = this.sanitazier.bypassSecurityTrustStyle(`url(${assetUrl})`);
+        this.src = this.sanitazier.bypassSecurityTrustStyle(`url("${assetUrl}")`);
         this.cdr.markForCheck();
       }
     })


### PR DESCRIPTION
it's a problem with file names, it has some `()` , in the code the background directive do this to the element css
```
background-image: url(https://....../myFile(1).png), url(assets/fallback.png)
```
☝️  here the `()`  in the file name are messing with the first `url()`  so the browser simply ignore it, thus displaying the fallback

I have fixed it by putting `""` around the `url` so that the parenthesis are preserved.
