### PR TITLE
Add subtitle to my files page, navigate one back in breadcrumbs

### DIFF
--- a/apps/festival/festival/src/app/dashboard/files/files.component.html
+++ b/apps/festival/festival/src/app/dashboard/files/files.component.html
@@ -1,4 +1,5 @@
 <header>
   <h1>My Files</h1>
+  <p>This is your File Storage. Its structure is predetermined. We trust you to upload the right content in the right place!</p>
 </header>
 <file-explorer [org]="org"></file-explorer>

--- a/libs/media/src/lib/components/file-explorer/file-explorer.component.html
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.component.html
@@ -34,6 +34,12 @@
 
       </header>
 
+      <ng-container *ngIf="breadCrumbs.length > 1">
+        <button mat-icon-button (click)="goTo(breadCrumbs[breadCrumbs.length - 2].path)" matTooltip="Navigate back one step">
+          <mat-icon svgIcon="arrow_back"></mat-icon>
+        </button>
+      </ng-container>
+
       <mat-divider></mat-divider>
 
       <ng-container *ngIf="activeDirectory.type === 'directory' else fileDirectory">

--- a/libs/media/src/lib/components/file-explorer/file-explorer.component.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.component.ts
@@ -65,7 +65,7 @@ export class FileExplorerComponent implements OnInit, OnDestroy {
   ngOnInit() {
 
     // create org's folders & files
-    const orgFileStructure = createOrgFileStructure(this.org.id, this.org.denomination.full)
+    const orgFileStructure = createOrgFileStructure(this.org.id)
     this.directories.push(orgFileStructure);
 
     // set the org folder as active

--- a/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
@@ -83,9 +83,9 @@ export function isHostedMediaWithMetadataForm(form: MovieNotesForm | HostedMedia
   return !!(form as HostedMediaWithMetadataForm).get('title');
 }
 
-export function createOrgFileStructure(orgId: string, orgName: string): Directory {
+export function createOrgFileStructure(orgId: string): Directory {
   return {
-    name: orgName,
+    name: 'Company Files',
     type: 'directory',
     path: [0],
     directories: [

--- a/libs/media/src/lib/components/file-explorer/file-explorer.module.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.module.ts
@@ -20,6 +20,7 @@ import { SingleFileViewModule } from './components/single-file-view/single-file-
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [FileExplorerComponent],
@@ -43,6 +44,7 @@ import { MatButtonModule } from '@angular/material/button';
     MatListModule,
     MatIconModule,
     MatButtonModule,
+    MatTooltipModule
   ],
   exports: [FileExplorerComponent]
 })


### PR DESCRIPTION
To do's in issue #4290
- [x] Add a subtitle below "My Files" title: "This is your File Storage. Its structure is predetermined. We trust you to upload the right content in the right place!"
- [x] Rename the org section "Company Files" 
- [x] Add an arrow below the breadcrumbs and above the files table that goes back to the previous page