### PR TITLE
Updating file explorer ui 2 

### DIFF
--- a/libs/media/src/lib/components/dialog/file/file.component.html
+++ b/libs/media/src/lib/components/dialog/file/file.component.html
@@ -11,7 +11,7 @@
 
   <ng-container *ngIf="!!hostedMediaWithMetadataForm">
     <mat-form-field appearance="outline">
-      <mat-label>Note title</mat-label>
+      <mat-label>File title</mat-label>
       <input matInput formControlName="title">
     </mat-form-field>
   </ng-container>

--- a/libs/media/src/lib/components/dialog/image/image.component.html
+++ b/libs/media/src/lib/components/dialog/image/image.component.html
@@ -2,7 +2,7 @@
 <mat-divider></mat-divider>
 <form [formGroup]="data.form" fxLayout="column" fxLayoutGap="24px">
   <drop-cropper [ratio]="data.ratio" [storagePath]="data.storagePath" [form]="data.form">
-    <h3 title>Logo</h3>
+    <h3 title>Image</h3>
   </drop-cropper>
   <section fxLayout="column" fxLayoutAlign="center center">
     <button mat-flat-button color="primary" (click)="upload()" [disabled]="!data.form.valid">

--- a/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.html
+++ b/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.html
@@ -11,7 +11,7 @@
       [storagePath]="activeDirectory.storagePath"
       [allowedFileType]="activeDirectory.acceptedFileType"
       [filePrivacy]="activeDirectory.privacy">
-      <h3 title>Upload File</h3>
+      <h3 title>Upload {{ activeDirectory.name }}</h3>
     </file-upload>
   </ng-container>
   <div fxLayout="column" fxLayoutAlign="center center">

--- a/libs/media/src/lib/components/file-explorer/file-explorer.component.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.component.ts
@@ -12,6 +12,7 @@ import { OrganizationForm } from '@blockframes/organization/forms/organization.f
 import { MovieForm } from '@blockframes/movie/form/movie.form';
 import { MediaService } from '@blockframes/media/+state/media.service';
 import { extractMediaFromDocumentBeforeUpdate } from '@blockframes/media/+state/media.model';
+import { sortMovieBy } from '@blockframes/utils/akita-helper/sort-movie-by';
 
 // Material
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -75,6 +76,7 @@ export class FileExplorerComponent implements OnInit, OnDestroy {
     this.movieService.getValue(fromOrg(this.org.id)).then(titlesRaw => {
       const currentApp: App = this.routerQuery.getData('app');
       const titles = titlesRaw.filter(movie => !!movie).filter(movie => movie.storeConfig.appAccess[currentApp]);
+      titles.sort((a, b) => sortMovieBy(a, b, 'Title'));
 
       titles.forEach((title, index) =>
         this.directories.push(createMovieFileStructure(title.id, title.title.international, index + 1)) // we do `index + 1` because `[0]` is the org

--- a/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
@@ -189,7 +189,7 @@ export function createMovieFileStructure(titleId: string, titleName: string, ind
             path: [index, 1, 2],
           },
           {
-            name: 'Still Photo',
+            name: 'Images',
             type: 'image',
             multiple: true,
             docNameField: '',

--- a/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
@@ -122,7 +122,7 @@ export function createMovieFileStructure(titleId: string, titleName: string, ind
     path: [index],
     directories: [
       {
-        name: 'Main information',
+        name: 'Poster & Banner',
         type: 'directory',
         path: [index, 0],
         directories: [

--- a/libs/movie/src/lib/movie/form/media-files/media-files.component.html
+++ b/libs/movie/src/lib/movie/form/media-files/media-files.component.html
@@ -23,7 +23,7 @@
       <h3>Moodboard / Artistic Deck</h3>
       <file-upload test-id="moodboard" [form]="form.promotional.get('moodboard')" [storagePath]="getPath('moodboard')"
         allowedFileType="pdf">
-        <h3 title>Upload File</h3>
+        <h3 title>Upload Moodboard / Artistic Deck</h3>
       </file-upload>
       <span class="mat-caption">Please note that this document will be available for download on the marketplace.</span>
     </section>


### PR DESCRIPTION
To do's in issue #4290
- [x] Sort movies by international title by default
- [x] Rename Still Photo « Images » 
- [x] In title files, change "Main information" for "Poster & Banner" (if possible)
- [x] Upload box on org docs, change label for « File title » 
- [x] Upload box on Still Photo is the one from logo and not stills
- [x] Upload box titles should take the same titles as in the movie form
- [x] Update upload box title for Moodboard / Artistic Deck > "Upload Moodboard / Artistic Deck"
