### PR TITLE
Status canceled support

### DIFF
--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="active$ | async | deepKey:getDeepPath(activeDirectory.storagePath) as data">
-  <bf-table-filter [source]="data | toArray" [columns]="columns" [initialColumns]="initialColumns">
+  <bf-table-filter [source]="data | toArray" [columns]="columns" [initialColumns]="initialColumns" (rowClick)="previewFile(getFileRef($event))">
     <ng-template colRef="ref" let-item="item">
       <img [asset]="getFileRef(item) | fileTypeImage">
     </ng-template>
@@ -9,13 +9,13 @@
       </span>
     </ng-template>
     <ng-template colRef="actions" let-item="item">
-      <button mat-button (click)="downloadFile(item)">
+      <button mat-button (click)="downloadFile(item, $event)">
         <mat-icon svgIcon="download"></mat-icon>
       </button>
-      <button mat-button (click)="editFile.emit(item)">
+      <button mat-button (click)="edit(item, $event)">
         <mat-icon svgIcon="pencil"></mat-icon>
       </button>
-      <button mat-button (click)="deleteFile(item)">
+      <button mat-button (click)="deleteFile(item, $event)">
         <mat-icon svgIcon="trash"></mat-icon>
       </button>
     </ng-template>

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -69,7 +69,13 @@ export class MultipleFilesViewComponent implements OnInit {
     }
   }
 
-  public deleteFile(row: HostedMediaWithMetadata | MovieNote | string) {
+  edit(row: HostedMediaWithMetadata | MovieNote | string, event: Event) {
+    event.stopPropagation();
+    this.editFile.emit(row);
+  }
+
+  public deleteFile(row: HostedMediaWithMetadata | MovieNote | string, event: Event) {
+    event.stopPropagation();
     this.dialog.open(ConfirmComponent, {
       data: {
         title: 'Are you sure you want to delete this file?',
@@ -117,7 +123,8 @@ export class MultipleFilesViewComponent implements OnInit {
     });
   }
 
-  public async downloadFile(item: Partial<HostedMediaWithMetadata | OrganizationDocumentWithDates>) {
+  public async downloadFile(item: Partial<HostedMediaWithMetadata | OrganizationDocumentWithDates>, event: Event) {
+    event.stopPropagation();
     const ref = item[this.activeDirectory.fileRefField];
     const url = await this.mediaService.generateImgIxUrl(ref);
     window.open(url);

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.html
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.html
@@ -36,9 +36,14 @@
                   <caption class="mat-caption"><em>Uploading</em></caption>
                 </ng-template>
 
-                <!-- Error -->
+                <!-- Canceled -->
                 <ng-template ngSwitchCase="canceled">
-                  <caption class="mat-caption canceled"><em>A problem has occurred!</em></caption>
+                  <caption class="mat-caption"><em>Upload canceled</em></caption>
+                </ng-template>
+
+                <!-- Error -->
+                <ng-template ngSwitchCase="error">
+                  <caption class="mat-caption error"><em>An error occured!</em></caption>
                 </ng-template>
               </div>
 

--- a/libs/media/src/lib/components/upload/widget/upload-widget.component.scss
+++ b/libs/media/src/lib/components/upload/widget/upload-widget.component.scss
@@ -45,6 +45,6 @@ mat-icon {
   color: var(--primary);
 }
 
-.canceled {
+.error {
   color: var(--warn);
 }

--- a/libs/media/src/lib/pipes/task-state.pipe.ts
+++ b/libs/media/src/lib/pipes/task-state.pipe.ts
@@ -24,7 +24,7 @@ export class TaskStatePipe implements PipeTransform {
         }
       }
       const error = () => {
-        subscriber.next('canceled');
+        subscriber.next('error');
         subscriber.complete();
       }
       task.task.on('state_changed', progress, error);


### PR DESCRIPTION
To do in issue #4290  NOT FIXED
There is an issue in AngularFire where cancelling results in an error response. This should be fixed in AngularFire 6.1.1
https://github.com/angular/angularfire/issues/1805

This PR doesn't change anything in the current UI, but does support cancel status once AngularFire has fixed the issue and we've updated our packages.

Accidently added commit:
To do issue #4290 
- [x] row click in file explorer for file preview