### PR TITLE
Disable sorting per column

### DIFF
--- a/apps/festival/festival/src/app/dashboard/title/list/list.component.html
+++ b/apps/festival/festival/src/app/dashboard/title/list/list.component.html
@@ -16,7 +16,7 @@
     <mat-card>
       <bf-table-filter [source]="titles" [columns]="columns" [initialColumns]="initialColumns" showFilter showPaginator clickable
         (rowClick)="goToTitle($event)">
-        <ng-template colRef="title" let-title><b>{{ title.international }}</b></ng-template>
+        <ng-template colRef="title.international" let-title><b>{{ title }}</b></ng-template>
         <ng-template colRef="view" let-movie="item">{{ movie | getViews | async }}</ng-template>
         <ng-template colRef="directors" let-directors>{{ directors | displayName }}</ng-template>
         <ng-template colRef="productionStatus" let-prod>{{ prod | toLabel: 'productionStatus' }}</ng-template>

--- a/apps/festival/festival/src/app/dashboard/title/list/list.component.ts
+++ b/apps/festival/festival/src/app/dashboard/title/list/list.component.ts
@@ -9,7 +9,7 @@ import { OrganizationQuery } from '@blockframes/organization/+state';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
 
 const columns = {
-  title: 'Title',
+  'title.international': 'Title',
   view: '# Views',
   directors: 'Director(s)',
   productionStatus: 'Production Status',
@@ -24,7 +24,7 @@ const columns = {
 })
 export class ListComponent implements OnInit, OnDestroy {
   columns = columns;
-  initialColumns = ['title', 'view', 'directors', 'productionStatus', 'storeConfig.status'];
+  initialColumns = ['title.international', 'view', 'directors', 'productionStatus', 'storeConfig.status'];
   titles$: Observable<Movie[]>;
   filter = new FormControl();
   filter$ = this.filter.valueChanges.pipe(startWith(this.filter.value));

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="active$ | async | deepKey:getDeepPath(activeDirectory.storagePath) as data">
-  <bf-table-filter [source]="data | toArray" [columns]="columns" [initialColumns]="initialColumns" (rowClick)="previewFile(getFileRef($event))">
+  <bf-table-filter [source]="data | toArray" [columns]="columns" [initialColumns]="initialColumns" (rowClick)="previewFile(getFileRef($event))" clickable>
     <ng-template colRef="ref" let-item="item">
       <img [asset]="getFileRef(item) | fileTypeImage">
     </ng-template>

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -27,9 +27,9 @@ import {
 } from '../../file-explorer.model';
 
 const columns = { 
-  ref: 'Type',
-  name: 'Document Name',
-  actions: 'Actions'
+  ref: { value: 'Type', disableSort: true },
+  main: { value: 'Document Name', disableSort: false },
+  actions: { value: 'Actions', disableSort: true } 
 };
 
 @Component({

--- a/libs/ui/src/lib/list/table-filter/table-filter.component.html
+++ b/libs/ui/src/lib/list/table-filter/table-filter.component.html
@@ -14,7 +14,7 @@
 
     <!-- You need to set the matColumnDef on the same ng-container as the ngFor or it fails -->
     <ng-container *ngFor="let column of columns | keyvalue" [matColumnDef]="column.key">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> {{ column.value }} </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="sortColumnDisabled(column.value)"> {{ column.value?.value || column.value }} </th>
       <td [ngClass]="{'clickable': clickable}" mat-cell *matCellDef="let row">
         <ng-container *ngIf="(cols | findColRef:column.key) as col; else default">
           <ng-template
@@ -59,7 +59,7 @@
   <widget-card>
     <mat-selection-list [formControl]="columnFilter" class="mat-elevation-z2">
       <mat-list-option *ngFor="let column of columns | keyvalue" [value]="column.key" color="primary">
-        {{ column.value }}
+        {{ column.value?.value || column.value }}
       </mat-list-option>
     </mat-selection-list>
   </widget-card>

--- a/libs/ui/src/lib/list/table-filter/table-filter.component.ts
+++ b/libs/ui/src/lib/list/table-filter/table-filter.component.ts
@@ -37,7 +37,7 @@ export class TableFilterComponent implements OnInit, AfterViewInit {
   @Input() @boolean clickable: boolean;
 
   // Name of the column headers
-  @Input() columns: Record<string, any>;
+  @Input() columns: Record<string, string | { value: string, disableSort: boolean }>;
   @Input() initialColumns: string[];
   @Input() link: string;
   @Input() showLoader = false;
@@ -92,5 +92,9 @@ export class TableFilterComponent implements OnInit, AfterViewInit {
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+  }
+
+  sortColumnDisabled(value: string | { value: string, disableSort: boolean }) {
+    return typeof value === 'string' ? false : value.disableSort;
   }
 }


### PR DESCRIPTION
To do in issue #4290 
- [x] Table for org docs & still photo: remove the sort by on « Type » & « Actions » as all docs have the same types & actions
