### PR TITLE
Rework create event dialog

### DIFF
--- a/libs/event/src/lib/components/week/week.component.ts
+++ b/libs/event/src/lib/components/week/week.component.ts
@@ -133,7 +133,7 @@ export class CalendarWeekComponent {
 
   /** Open a create dialog and redirect if needed */
   private createEvent(calEvent: CalendarEvent) {
-    const data = { event: { ...calEvent, type: this.eventTypes[0] }, types: this.eventTypes };
+    const data = { event: { ...calEvent, type: '' }, types: this.eventTypes };
     this.dialog.open(EventCreateComponent, { data, width: '650px' }).afterClosed()
       .subscribe(async ({ event } = {}) => {
         if (event) {

--- a/libs/event/src/lib/components/week/week.component.ts
+++ b/libs/event/src/lib/components/week/week.component.ts
@@ -135,12 +135,10 @@ export class CalendarWeekComponent {
   private createEvent(calEvent: CalendarEvent) {
     const data = { event: { ...calEvent, type: this.eventTypes[0] }, types: this.eventTypes };
     this.dialog.open(EventCreateComponent, { data, width: '650px' }).afterClosed()
-      .subscribe(async ({ event, redirect } = {}) => {
+      .subscribe(async ({ event } = {}) => {
         if (event) {
           this.service.add(event);
-          if (redirect) {
-            this.router.navigate([event.id, 'edit'], { relativeTo: this.route });
-          }
+          this.router.navigate([event.id, 'edit'], { relativeTo: this.route });
         } else {
           this.refresh(this.baseEvents);
         }

--- a/libs/event/src/lib/event.module.ts
+++ b/libs/event/src/lib/event.module.ts
@@ -24,6 +24,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   declarations: [
@@ -59,6 +60,7 @@ import { MatSelectModule } from '@angular/material/select';
     MatInputModule,
     MatCheckboxModule,
     MatSelectModule,
+    MatSlideToggleModule,
   ]
 })
 export class EventModule {}

--- a/libs/event/src/lib/form/create/create.component.html
+++ b/libs/event/src/lib/form/create/create.component.html
@@ -38,6 +38,5 @@
 </form>
 
 <footer fxLayout fxLayoutAlign="end center"  fxLayoutGap="16px">
-  <button type="button" mat-button (click)="createAndRedirect(true)" test-id="more-details">More details</button>
-  <button type="submit" mat-flat-button color="primary" (click)="createAndRedirect(false)">Create</button>
+  <button type="button" mat-flat-button color="primary" (click)="createAndRedirect()" test-id="more-details">More details</button>
 </footer>

--- a/libs/event/src/lib/form/create/create.component.html
+++ b/libs/event/src/lib/form/create/create.component.html
@@ -5,6 +5,15 @@
 <h3>Add a new Event</h3>
 
 <form [formGroup]="form" fxLayout="column">
+  <mat-form-field fxFlex appearance="outline">
+    <mat-label>Type</mat-label>
+    <mat-select required formControlName="type">
+      <ng-container *ngFor="let type of types">
+        <mat-option [value]="type">{{ type | titlecase }}</mat-option>
+      </ng-container>
+    </mat-select>
+  </mat-form-field>
+
   <mat-form-field appearance="outline">
     <mat-label>Title</mat-label>
     <input matInput formControlName="title" />
@@ -22,21 +31,10 @@
     </mat-form-field>
   </div>
 
-  <div *ngIf="types.length">
-    <mat-form-field fxFlex appearance="outline">
-      <mat-label>Type</mat-label>
-      <mat-select required formControlName="type">
-        <ng-container *ngFor="let type of types">
-          <mat-option [value]="type">{{ type | titlecase }}</mat-option>
-        </ng-container>
-      </mat-select>
-    </mat-form-field>
-  </div>
-
   <mat-checkbox formControlName="allDay" color="primary">All day</mat-checkbox>
   <mat-checkbox formControlName="isPrivate" color="primary">Private</mat-checkbox>
 </form>
 
 <footer fxLayout fxLayoutAlign="end center"  fxLayoutGap="16px">
-  <button type="button" mat-flat-button color="primary" (click)="createAndRedirect()" test-id="more-details">More details</button>
+  <button type="button" mat-flat-button color="primary" (click)="createAndRedirect()" test-id="more-details" [disabled]="form.invalid">More details</button>
 </footer>

--- a/libs/event/src/lib/form/create/create.component.html
+++ b/libs/event/src/lib/form/create/create.component.html
@@ -6,7 +6,7 @@
 
 <form [formGroup]="form" fxLayout="column">
   <mat-form-field fxFlex appearance="outline">
-    <mat-label>Select a meeting type</mat-label>
+    <mat-label>Select event type</mat-label>
     <mat-select required formControlName="type">
       <ng-container *ngFor="let type of types">
         <mat-option [value]="type">{{ type | titlecase }}</mat-option>

--- a/libs/event/src/lib/form/create/create.component.html
+++ b/libs/event/src/lib/form/create/create.component.html
@@ -6,7 +6,7 @@
 
 <form [formGroup]="form" fxLayout="column">
   <mat-form-field fxFlex appearance="outline">
-    <mat-label>Type</mat-label>
+    <mat-label>Select a meeting type</mat-label>
     <mat-select required formControlName="type">
       <ng-container *ngFor="let type of types">
         <mat-option [value]="type">{{ type | titlecase }}</mat-option>
@@ -31,8 +31,8 @@
     </mat-form-field>
   </div>
 
-  <mat-checkbox formControlName="allDay" color="primary">All day</mat-checkbox>
-  <mat-checkbox formControlName="isPrivate" color="primary">Private</mat-checkbox>
+  <mat-slide-toggle formControlName="allDay" color="primary">All day</mat-slide-toggle>
+  <mat-slide-toggle formControlName="isPrivate" color="primary">Private</mat-slide-toggle>
 </form>
 
 <footer fxLayout fxLayoutAlign="end center"  fxLayoutGap="16px">

--- a/libs/event/src/lib/form/create/create.component.ts
+++ b/libs/event/src/lib/form/create/create.component.ts
@@ -25,10 +25,7 @@ export class EventCreateComponent {
     this.types = data.types;
   }
 
-  /**
-   * @param redirect If true should redirect to the event page
-   */
-  async createAndRedirect(redirect: boolean) {
+  async createAndRedirect() {
     const event = this.form.value;
     event.ownerId = this.orgQuery.getActiveId();
     if (event.type === 'meeting') {
@@ -38,6 +35,6 @@ export class EventCreateComponent {
       event.start.setHours(0,0,0);
       event.end.setHours(23,59,59);
     }
-    this.dialogRef.close({ event, redirect });
+    this.dialogRef.close({ event });
   }
 }

--- a/libs/event/src/lib/form/event.form.ts
+++ b/libs/event/src/lib/form/event.form.ts
@@ -10,7 +10,7 @@ export function createEventControl(params?: Partial<Event>) {
     id: new FormControl(event.id),
     isPrivate: new FormControl(event.isPrivate),
     ownerId: new FormControl(event.ownerId),
-    type: new FormControl(event.type),
+    type: new FormControl(event.type, Validators.required),
     title: new FormControl(event.title),
     start: new FormControl(event.start),
     end: new FormControl(event.end),


### PR DESCRIPTION
To do's in issue #4290 
- [x] "Create" CTA becomes "More details" and we remove the secondary button to keep only one that leads to the event form
- [x] Move "Type" select on first position and add an empty field by default