### PR TITLE
Rework event details form

### DIFF
--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -102,7 +102,7 @@
             </mat-list>
           </ng-container>
           <ng-template #empty>
-            <p class="no-files">There no selected files yet. Click on the "Manage Files" button above to add some files.</p>
+            <p class="no-files">There no selected files yet. Click on the button above to add some files.</p>
           </ng-template>
 
         </section>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -75,8 +75,9 @@
               maxlength="500"></textarea>
             <mat-hint>Limited to 500 characters.</mat-hint>
           </mat-form-field>
-
-          <h6>Files</h6>
+        </section>
+        <section>
+          <h6>My Files for this Meeting</h6>
           <p>
             Add the files you want to share during meeting.
             If you didn’t upload the needed files, please add them on <a routerLink="/c/o/dashboard/files">My Files</a> page.
@@ -109,6 +110,6 @@
     </ng-container>
   </event-edit>
   <ng-container *ngIf="isEventStarted()">
-    <event-analytics [eventId]="form.id.value"></event-analytics>
+    <!-- <event-analytics [eventId]="form.id.value"></event-analytics> -->
   </ng-container>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -80,7 +80,7 @@
           <h6>My Files for this Meeting</h6>
           <p>
             Add the files you'll want to share during the meeting.
-            f you can't find the files you're looking for, you can upload them directly in <a routerLink="/c/o/dashboard/files">My Files</a> page.
+            If you can't find the files you're looking for, you can upload them directly in <a routerLink="/c/o/dashboard/files">My Files</a> page.
           </p>
 
           <div fxLayout="row">

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -49,9 +49,9 @@
           <div class="link" fxLayout>
             <mat-form-field class="link" appearance="outline" fxFlex>
               <mat-label>Link to video call</mat-label>
-              <input matInput type="text" disabled [value]="getLink()">
+              <input matInput type="text" disabled [value]="link">
             </mat-form-field>
-            <button mat-icon-button [cdkCopyToClipboard]="getLink()">
+            <button mat-icon-button [cdkCopyToClipboard]="link">
               <mat-icon svgIcon="copy"></mat-icon>
             </button>
           </div>
@@ -110,6 +110,6 @@
     </ng-container>
   </event-edit>
   <ng-container *ngIf="isEventStarted()">
-    <!-- <event-analytics [eventId]="form.id.value"></event-analytics> -->
+    <event-analytics [eventId]="form.id.value"></event-analytics>
   </ng-container>
 </ng-container>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -46,6 +46,15 @@
       <ng-container *ngSwitchCase="'meeting'">
         <h2>Meeting</h2>
         <section [formGroup]="form.meta" fxLayout="column">
+          <div class="link" fxLayout>
+            <mat-form-field class="link" appearance="outline" fxFlex>
+              <mat-label>Link to video call</mat-label>
+              <input matInput type="text" disabled [value]="getLink()">
+            </mat-form-field>
+            <button mat-icon-button [cdkCopyToClipboard]="getLink()">
+              <mat-icon svgIcon="copy"></mat-icon>
+            </button>
+          </div>
           <mat-form-field appearance="outline">
             <mat-label>Organized By</mat-label>
             <mat-select formControlName="organizerId">
@@ -73,7 +82,7 @@
           </p>
 
           <div fxLayout="row" fxLayoutAlign="end">
-            <button mat-stroked-button color="primary" (click)="openFileSelector()">
+            <button class="manage-files-btn" mat-stroked-button color="primary" (click)="openFileSelector()">
               <mat-icon svgIcon="folder"></mat-icon>
               <span>Manage Files</span>
             </button>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -79,14 +79,14 @@
         <section>
           <h6>My Files for this Meeting</h6>
           <p>
-            Add the files you want to share during meeting.
-            If you didn’t upload the needed files, please add them on <a routerLink="/c/o/dashboard/files">My Files</a> page.
+            Add the files you'll want to share during the meeting.
+            f you can't find the files you're looking for, you can upload them directly in <a routerLink="/c/o/dashboard/files">My Files</a> page.
           </p>
 
-          <div fxLayout="row" fxLayoutAlign="end">
+          <div fxLayout="row">
             <button class="manage-files-btn" mat-stroked-button color="primary" (click)="openFileSelector()">
               <mat-icon svgIcon="folder"></mat-icon>
-              <span>Manage Files</span>
+              <span>Attach the files you want to share during the meeting</span>
             </button>
           </div>
 

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.html
@@ -62,6 +62,7 @@
                 <mat-option [value]="member.uid">{{ member | displayName }}</mat-option>
               </ng-container>
             </mat-select>
+            <mat-hint>This person will be the one displayed in the invitations sent to buyers.</mat-hint>
           </mat-form-field>
           <mat-form-field appearance="outline">
             <mat-label>Description</mat-label>

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
@@ -10,7 +10,7 @@ section {
   padding: 24px 16px;
 
   .manage-files-btn {
-    width: 30%;
+    margin-bottom: 16px;
   }
 
   p.no-files {

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.scss
@@ -9,7 +9,7 @@ section {
   border: solid 1px var(--foreground-divider);
   padding: 24px 16px;
 
-  button {
+  .manage-files-btn {
     width: 30%;
   }
 
@@ -17,5 +17,15 @@ section {
     width: 70%;
     text-align: center;
     margin: 32px auto;
+  }
+}
+
+.link {
+  mat-form-field {
+    display: block;
+  }
+
+  button {
+    margin-top: 20px;
   }
 }

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
@@ -15,6 +15,8 @@ import { slideUpList } from '@blockframes/utils/animations/fade';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
 import { MatDialog } from '@angular/material/dialog';
 import { FileSelectorComponent } from '@blockframes/media/components/file-selector/file-selector.component';
+import { getCurrentApp, applicationUrl } from "@blockframes/utils/apps";
+import { RouterQuery } from '@datorama/akita-ng-router-store';
 
 @Component({
   selector: 'festival-event-edit',
@@ -27,6 +29,7 @@ export class EditComponent implements OnInit, OnDestroy {
 
   private sub: Subscription;
   private formSub: Subscription;
+  eventId: string;
   form: EventForm;
   titles$: Observable<Movie[]>;
   invitations$: Observable<Invitation[]>;
@@ -45,6 +48,7 @@ export class EditComponent implements OnInit, OnDestroy {
     private cdr: ChangeDetectorRef,
     private dynTitle: DynamicTitleService,
     private dialog: MatDialog,
+    private routerQuery: RouterQuery
   ) { }
 
   ngOnInit(): void {
@@ -68,6 +72,7 @@ export class EditComponent implements OnInit, OnDestroy {
     this.sub = eventId$.pipe(
       switchMap((eventId: string) => this.service.valueChanges(eventId))
     ).subscribe(event => {
+      this.eventId = event.id;
       this.type = event.type;
       this.form = new EventForm(event);
 
@@ -111,5 +116,11 @@ export class EditComponent implements OnInit, OnDestroy {
       this.files.patchAllValue(result);
       this.cdr.markForCheck();
     });
+  }
+
+  getLink() {
+    const app = getCurrentApp(this.routerQuery);
+    const url = applicationUrl[app];
+    return `${url}/c/o/marketplace/event/${this.eventId}/lobby`;
   }
 }

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.component.ts
@@ -29,7 +29,7 @@ export class EditComponent implements OnInit, OnDestroy {
 
   private sub: Subscription;
   private formSub: Subscription;
-  eventId: string;
+  link: string;
   form: EventForm;
   titles$: Observable<Movie[]>;
   invitations$: Observable<Invitation[]>;
@@ -72,7 +72,10 @@ export class EditComponent implements OnInit, OnDestroy {
     this.sub = eventId$.pipe(
       switchMap((eventId: string) => this.service.valueChanges(eventId))
     ).subscribe(event => {
-      this.eventId = event.id;
+      const app = getCurrentApp(this.routerQuery);
+      const url = applicationUrl[app];
+      this.link = `${url}/c/o/marketplace/event/${event.id}/lobby`;
+ 
       this.type = event.type;
       this.form = new EventForm(event);
 
@@ -116,11 +119,5 @@ export class EditComponent implements OnInit, OnDestroy {
       this.files.patchAllValue(result);
       this.cdr.markForCheck();
     });
-  }
-
-  getLink() {
-    const app = getCurrentApp(this.routerQuery);
-    const url = applicationUrl[app];
-    return `${url}/c/o/marketplace/event/${this.eventId}/lobby`;
   }
 }

--- a/apps/festival/festival/src/app/dashboard/event/edit/edit.module.ts
+++ b/apps/festival/festival/src/app/dashboard/event/edit/edit.module.ts
@@ -20,6 +20,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
+import { ClipboardModule } from '@angular/cdk/clipboard';
 
 @NgModule({
   declarations: [EditComponent],
@@ -32,6 +33,7 @@ import { MatDividerModule } from '@angular/material/divider';
     DisplayNameModule,
     FileSelectorModule,
     FileNameModule,
+    ClipboardModule,
 
     // Material
     MatProgressSpinnerModule,

--- a/libs/event/src/lib/layout/edit/edit.component.html
+++ b/libs/event/src/lib/layout/edit/edit.component.html
@@ -37,8 +37,8 @@
         </mat-form-field>
       </div>
 
-      <mat-checkbox formControlName="isPrivate" color="primary" test-id="event-private">Private</mat-checkbox>
-      <mat-checkbox test-id="all-day" formControlName="allDay" color="primary">All day</mat-checkbox>
+      <mat-slide-toggle formControlName="isPrivate" color="primary" test-id="event-private">Private</mat-slide-toggle>
+      <mat-slide-toggle test-id="all-day" formControlName="allDay" color="primary">All day</mat-slide-toggle>
 
     </mat-card>
 

--- a/libs/event/src/lib/layout/edit/edit.module.ts
+++ b/libs/event/src/lib/layout/edit/edit.module.ts
@@ -20,7 +20,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 
@@ -51,7 +51,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
     MatFormFieldModule,
     MatInputModule,
     MatListModule,
-    MatCheckboxModule,
+    MatSlideToggleModule,
     MatProgressBarModule,
   ]
 })

--- a/libs/user/src/lib/auth/components/terms-conditions/terms-conditions.component.ts
+++ b/libs/user/src/lib/auth/components/terms-conditions/terms-conditions.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
 import { Location } from "@angular/common";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
@@ -12,14 +12,16 @@ import { RouterQuery } from "@datorama/akita-ng-router-store";
   styleUrls: ['./terms-conditions.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TermsConditionsComponent {
+export class TermsConditionsComponent implements OnInit {
   section$: Observable<'dashboard' | 'marketplace'>;
   appUrl: string;
 
   constructor(
     private location: Location,
     private routerQuery: RouterQuery,
-  ) {
+  ) {}
+
+  ngOnInit() {
     this.section$ = this.routerQuery.select('state').pipe(map(data => getAppLocation(data.url)));
     const app = getCurrentApp(this.routerQuery);
     this.appUrl = applicationUrl[app];

--- a/libs/user/src/lib/auth/components/terms-conditions/terms-conditions.component.ts
+++ b/libs/user/src/lib/auth/components/terms-conditions/terms-conditions.component.ts
@@ -21,7 +21,7 @@ export class TermsConditionsComponent {
     private routerQuery: RouterQuery,
   ) {
     this.section$ = this.routerQuery.select('state').pipe(map(data => getAppLocation(data.url)));
-    const app = getCurrentApp(this.routerQuery);;
+    const app = getCurrentApp(this.routerQuery);
     this.appUrl = applicationUrl[app];
   }
 


### PR DESCRIPTION
To do in issue #4290 
- [x] (1) Change checkboxes for toggles for "All day" and "Private"
- [x] (2) add an autofilled input "Meeting link" filled with the meeting session url + a copy to clipboard button to copy it (already implemented for invitations)
- [x] (3) Add a hint below "Organized by": "This person will be the one displayed in the invitations sent to buyers."
- [x] (4) Remove "Files" from the Meeting block and create a dedicated card called "My Files for this Meeting"
- [x] (5) Change the subtitles of "My Files.." for: 
"Add the files you'll want to share during the meeting.
(line break) If you can't find the files you're looking for, you can upload them directly in My Files (hyperlink) page."
- [x] (6) Change "Manage Files" button text for: "Attach the files you want to share during the meeting" and align it to left

Result:
![event details page](https://user-images.githubusercontent.com/27687382/100754754-b9a71c80-33eb-11eb-8b29-9aa8d3305bbb.png)
