### PR TITLE
Update file select modal ui

### DIFF
--- a/libs/media/src/lib/components/file-selector/file-selector.component.html
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.html
@@ -14,7 +14,7 @@
         <ng-container *ngIf="orgFiles.length; else noOrgFiles">
           <mat-list-item *ngFor="let file of orgFiles">
             <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-            <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle }} - {{file.path | fileName}}</div>
+            <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileFolder }} - {{file.path | fileName}}</div>
             <button mat-icon-button (click)="toggleSelect(file.path)">
               <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
               <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>
@@ -46,7 +46,7 @@
           <ng-container *ngIf="moviesFiles[movie.id].length; else noMovieFiles">
             <mat-list-item *ngFor="let file of moviesFiles[movie.id]">
               <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-              <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle }} - {{file.path | fileName}}</div>
+              <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileFolder }} - {{file.path | fileName}}</div>
               <button mat-icon-button (click)="toggleSelect(file.path)">
                 <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
                 <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>

--- a/libs/media/src/lib/components/file-selector/file-selector.component.html
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.html
@@ -14,7 +14,7 @@
         <ng-container *ngIf="orgFiles.length; else noOrgFiles">
           <mat-list-item *ngFor="let file of orgFiles">
             <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-            <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle | titlecase }} - {{file.path | fileName}}</div>
+            <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle }} - {{file.path | fileName}}</div>
             <button mat-icon-button (click)="toggleSelect(file.path)">
               <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
               <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>
@@ -46,7 +46,7 @@
           <ng-container *ngIf="moviesFiles[movie.id].length; else noMovieFiles">
             <mat-list-item *ngFor="let file of moviesFiles[movie.id]">
               <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-              <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle | titlecase }} - {{file.path | fileName}}</div>
+              <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle }} - {{file.path | fileName}}</div>
               <button mat-icon-button (click)="toggleSelect(file.path)">
                 <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
                 <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>

--- a/libs/media/src/lib/components/file-selector/file-selector.component.html
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.html
@@ -14,7 +14,7 @@
         <ng-container *ngIf="orgFiles.length; else noOrgFiles">
           <mat-list-item *ngFor="let file of orgFiles">
             <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-            <div mat-line [matTooltip]="file.path | fileName">{{file.path | fileName}}</div>
+            <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle | titlecase }} - {{file.path | fileName}}</div>
             <button mat-icon-button (click)="toggleSelect(file.path)">
               <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
               <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>
@@ -46,7 +46,7 @@
           <ng-container *ngIf="moviesFiles[movie.id].length; else noMovieFiles">
             <mat-list-item *ngFor="let file of moviesFiles[movie.id]">
               <mat-icon mat-list-icon [svgIcon]="file.path | fileTypeImage : 'icon'"></mat-icon>
-              <div mat-line [matTooltip]="file.path | fileName">{{file.path | fileName}}</div>
+              <div mat-line [matTooltip]="file.path | fileName">{{ file.path | fileTypeTitle | titlecase }} - {{file.path | fileName}}</div>
               <button mat-icon-button (click)="toggleSelect(file.path)">
                 <mat-icon *ngIf="file.isSelected" svgIcon="check" color="primary"></mat-icon>
                 <mat-icon *ngIf="!file.isSelected" svgIcon="add"></mat-icon>

--- a/libs/media/src/lib/components/file-selector/file-selector.component.html
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.html
@@ -72,6 +72,6 @@
         <button mat-icon-button (click)="toggleSelect(file)"><mat-icon svgIcon="cross"></mat-icon></button>
       </mat-list-item>
     </mat-list>
-    <button mat-raised-button color="primary" (click)="closeDialog()">Add Files</button>
+    <button mat-raised-button color="primary" (click)="closeDialog()" [disabled]="!selectedFiles.length">Add Files</button>
   </aside>
 </section>

--- a/libs/media/src/lib/components/file-selector/file-selector.component.html
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.html
@@ -63,9 +63,9 @@
 
     </mat-tab>
   </mat-tab-group>
-  <aside fxLayout="column" fxLayoutAlign="space-between">
+  <aside fxLayout="column">
     <h4>Selected Files ({{selectedFiles.length}})</h4>
-    <mat-list>
+    <mat-list fxFlex>
       <mat-list-item *ngFor="let file of selectedFiles">
         <mat-icon mat-list-icon [svgIcon]="file | fileTypeImage : 'icon'"></mat-icon>
         <div mat-line [matTooltip]="file | fileName">{{file | fileName}}</div>

--- a/libs/media/src/lib/components/file-selector/file-selector.component.scss
+++ b/libs/media/src/lib/components/file-selector/file-selector.component.scss
@@ -18,7 +18,7 @@
     mat-tab-group {
       width: 60%;
       mat-list {
-        margin-left: 42px;
+        margin-left: 12px;
       }
     }
 

--- a/libs/utils/src/lib/pipes/fileName.pipe.ts
+++ b/libs/utils/src/lib/pipes/fileName.pipe.ts
@@ -4,7 +4,7 @@ import { MovieService } from '@blockframes/movie/+state';
 import { OrganizationService } from '@blockframes/organization/+state';
 import { UserService } from '@blockframes/user/+state';
 import { getFileExtension } from '../file-sanitizer';
-import { extensionToType } from '../utils';
+import { extensionToType, titleCase } from '../utils';
 
 @Pipe({ name: 'fileName' })
 export class FileNamePipe implements PipeTransform {
@@ -45,7 +45,7 @@ export class FilePathPipe implements PipeTransform {
     const docId = arrayedRef[2];
     const fileName = arrayedRef.pop();
     const subFolders = arrayedRef.pop();
-    const folder = subFolders.split('.').pop();
+    const folder = getFileTypeTitle(subFolders.split('.').pop());
 
     let docName = docId;
     if (collection === 'movies') {
@@ -114,26 +114,30 @@ export class FileTypeImagePipe implements PipeTransform {
   }
 }
 
+export const getFileTypeTitle = (folder: string) => {
+  switch (folder) {
+    case 'notes':
+      return 'Note'
+    case 'still_photo':
+      return 'Image' 
+    case 'otherVideos':
+      return 'Video'
+    case 'presentation_deck':
+      return 'Presentation deck'
+    default:
+      return titleCase(folder);
+  }
+}
+
 @Pipe({ name: 'fileTypeTitle' })
 export class FileTypeTitlePipe implements PipeTransform {
   transform(filePath: string) {
     const segments = filePath.split('/')
     segments.pop();
     const field = segments.pop();
-    const name = field.split('.').pop();
+    const folder = field.split('.').pop();
 
-    switch (name) {
-      case 'notes':
-        return 'note'
-      case 'still_photo':
-        return 'image' 
-      case 'otherVideos':
-        return 'video'
-      case 'presentation_deck':
-        return 'presentation deck'
-      default:
-        return name;
-    }
+    return getFileTypeTitle(folder);
   }
 }
 

--- a/libs/utils/src/lib/pipes/fileName.pipe.ts
+++ b/libs/utils/src/lib/pipes/fileName.pipe.ts
@@ -114,8 +114,31 @@ export class FileTypeImagePipe implements PipeTransform {
   }
 }
 
+@Pipe({ name: 'fileTypeTitle' })
+export class FileTypeTitlePipe implements PipeTransform {
+  transform(filePath: string) {
+    const segments = filePath.split('/')
+    segments.pop();
+    const field = segments.pop();
+    const name = field.split('.').pop();
+
+    switch (name) {
+      case 'notes':
+        return 'note'
+      case 'still_photo':
+        return 'image' 
+      case 'otherVideos':
+        return 'video'
+      case 'presentation_deck':
+        return 'presentation deck'
+      default:
+        return name;
+    }
+  }
+}
+
 @NgModule({
-  exports: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe],
-  declarations: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe],
+  exports: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileTypeTitlePipe],
+  declarations: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileTypeTitlePipe],
 })
 export class FileNameModule { }

--- a/libs/utils/src/lib/pipes/fileName.pipe.ts
+++ b/libs/utils/src/lib/pipes/fileName.pipe.ts
@@ -8,14 +8,19 @@ import { extensionToType, titleCase } from '../utils';
 
 @Pipe({ name: 'fileName' })
 export class FileNamePipe implements PipeTransform {
-  transform(file: string) {
-    if (!file) return '';
-    if (typeof file !== 'string') {
-      console.warn('UNEXPECTED FILE', file);
+
+  /**
+   * Returns the name of the file
+   * e.g. org/id/logo/abc.jpg => 'abc.jpg'
+   */
+  transform(filePath: string) {
+    if (!filePath) return '';
+    if (typeof filePath !== 'string') {
+      console.warn('UNEXPECTED FILE', filePath);
       console.warn('This pipe require a string as input');
       return '';
     }
-    const arrayedRef = file.split('/');
+    const arrayedRef = filePath.split('/');
     return arrayedRef.pop();
   }
 }
@@ -29,15 +34,19 @@ export class FilePathPipe implements PipeTransform {
     private userService: UserService,
   ) {}
 
-  async transform(file: string, separator = '/') {
-    if (typeof file !== 'string') {
-      console.warn('UNEXPECTED FILE', file);
+  /**
+   * Returns a readable version of the file path
+   * e.g. org/id/documents.notes/abc.jpg => 'Organization > Cascade8 > Note > abc.jpg'
+   */
+  async transform(filePath: string, separator = '/') {
+    if (typeof filePath !== 'string') {
+      console.warn('UNEXPECTED FILE', filePath);
       console.warn('This pipe require a string as input');
       return '';
     }
-    const arrayedRef = file.split('/');
+    const arrayedRef = filePath.split('/');
     if (arrayedRef.length < 5) {
-      console.warn('MALFORMED FILE PATH', file);
+      console.warn('MALFORMED FILE PATH', filePath);
       console.warn('Path should be formed of <privacy>/<collection>/<ID>/<folders>/<fileName>');
       return '';
     }
@@ -70,14 +79,19 @@ export class FilePathPipe implements PipeTransform {
   name: 'fileType'
 })
 export class FileTypePipe implements PipeTransform {
-  transform(file: string) {
-    if (typeof file !== 'string') {
-      console.warn('UNEXPECTED FILE', file);
+
+  /**
+   * Returns the type of the file
+   * e.g. abc.jpg => 'image'
+   */
+  transform(fileName: string) {
+    if (typeof fileName !== 'string') {
+      console.warn('UNEXPECTED FILE', fileName);
       console.warn('This pipe require a string as input');
       return 'unknown';
     }
 
-    const extension = getFileExtension(file);
+    const extension = getFileExtension(fileName);
     return extensionToType(extension);
   }
 }
@@ -86,15 +100,20 @@ export class FileTypePipe implements PipeTransform {
   name: 'fileTypeImage'
 })
 export class FileTypeImagePipe implements PipeTransform {
-  transform(file: string, kind: 'image' | 'icon' = 'image'): string {
 
-    if (typeof file !== 'string') {
-      console.warn('UNEXPECTED FILE', file);
+  /**
+   * Returns the image or icon path for type of file
+   * e.g. abc.jpg => 'image.webp' for image or 'picture' for icon
+   */
+  transform(fileName: string, kind: 'image' | 'icon' = 'image'): string {
+
+    if (typeof fileName !== 'string') {
+      console.warn('UNEXPECTED FILE', fileName);
       console.warn('This pipe require a string as input');
       return kind === 'image' ? 'image.webp' : 'document';
     }
 
-    const extension = getFileExtension(file);
+    const extension = getFileExtension(fileName);
     const type = extensionToType(extension);
 
     switch (type) {
@@ -129,13 +148,14 @@ export const getFileFolder = (folder: string) => {
   }
 }
 
-/**
- * Returns the name of the folder where the file is stored
- * e.g. orgs/id/documents.notes/abc.pdf => Note
- * movie/promotional/screener/abc.mp4 => Screener
- */
 @Pipe({ name: 'fileFolder' })
 export class FileFolderPipe implements PipeTransform {
+  
+  /**
+   * Returns the name of the folder where the file is stored
+   * e.g. orgs/id/documents.notes/abc.pdf => 'Note'
+   * movie/promotional/screener/abc.mp4 => 'Screener'
+   */
   transform(filePath: string) {
     const segments = filePath.split('/')
     segments.pop();

--- a/libs/utils/src/lib/pipes/fileName.pipe.ts
+++ b/libs/utils/src/lib/pipes/fileName.pipe.ts
@@ -45,7 +45,7 @@ export class FilePathPipe implements PipeTransform {
     const docId = arrayedRef[2];
     const fileName = arrayedRef.pop();
     const subFolders = arrayedRef.pop();
-    const folder = getFileTypeTitle(subFolders.split('.').pop());
+    const folder = getFileFolder(subFolders.split('.').pop());
 
     let docName = docId;
     if (collection === 'movies') {
@@ -114,7 +114,7 @@ export class FileTypeImagePipe implements PipeTransform {
   }
 }
 
-export const getFileTypeTitle = (folder: string) => {
+export const getFileFolder = (folder: string) => {
   switch (folder) {
     case 'notes':
       return 'Note'
@@ -129,20 +129,25 @@ export const getFileTypeTitle = (folder: string) => {
   }
 }
 
-@Pipe({ name: 'fileTypeTitle' })
-export class FileTypeTitlePipe implements PipeTransform {
+/**
+ * Returns the name of the folder where the file is stored
+ * e.g. orgs/id/documents.notes/abc.pdf => Note
+ * movie/promotional/screener/abc.mp4 => Screener
+ */
+@Pipe({ name: 'fileFolder' })
+export class FileFolderPipe implements PipeTransform {
   transform(filePath: string) {
     const segments = filePath.split('/')
     segments.pop();
     const field = segments.pop();
     const folder = field.split('.').pop();
 
-    return getFileTypeTitle(folder);
+    return getFileFolder(folder);
   }
 }
 
 @NgModule({
-  exports: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileTypeTitlePipe],
-  declarations: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileTypeTitlePipe],
+  exports: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileFolderPipe],
+  declarations: [FileNamePipe, FileTypePipe, FileTypeImagePipe, FilePathPipe, FileFolderPipe],
 })
 export class FileNameModule { }


### PR DESCRIPTION
To do in issue #4290 
- [x] Add the file type before the file name, same as when it’s added to the event (e.g. instead of "Felicità_Script.pdf" > "Scenario - Felicità_Script.pdf"
- [x] On selected files, for images (ex Still photo) call it « Image X », X being their index + 1 (to avoid 0) instead of the index only
- [x] Disable "Add Files" button when nothing selected
- [x] Put selected files on top, not centerd

![image](https://user-images.githubusercontent.com/27687382/100879207-76ac7e00-34ab-11eb-88c9-d7b92aeadb19.png)

![image](https://user-images.githubusercontent.com/27687382/100879633-f5092000-34ab-11eb-93e7-063bcd38c4b8.png)
