### PR TITLE
Update UI

### DIFF
--- a/apps/festival/festival/src/app/marketplace/event/view/view.component.html
+++ b/apps/festival/festival/src/app/marketplace/event/view/view.component.html
@@ -26,16 +26,14 @@
             <div fxLayout="column" fxLayoutGap="4px">
               <h6>{{ event.org | orgName }}</h6>
               <ng-container *ngIf="event.organizedBy as user">
-                <span>{{ user | displayName }} | {{ user.position }}</span>
+                <span>{{ user | displayName }}{{ user.position ? ' | ' + user.position : '' }}</span>
               </ng-container>
             </div>
           </div>
-          <h5>Description</h5>
-          <p>{{ event.meta.description }}</p>
-        </article>
-        <article>
-          <h2>Guest List</h2>
-          <invitation-guest-list [invitations]="invitations$ | async"></invitation-guest-list>
+          <ng-container *ngIf="!!event.meta.description">
+            <h5>Description</h5>
+            <p>{{ event.meta.description }}</p>
+          </ng-container>
         </article>
       </section>
 

--- a/libs/invitation/src/lib/components/action/action.component.html
+++ b/libs/invitation/src/lib/components/action/action.component.html
@@ -18,24 +18,30 @@
     <div class="status" [ngSwitch]="invit.status">
       <span class="primary" *ngSwitchCase="'accepted'">Accepted</span>
       <span class="warn" *ngSwitchCase="'declined'">Declined</span>
-      <span *ngSwitchCase="'pending'">Pending</span>
+      <span *ngSwitchCase="'pending'">Your request has been sent to the organizer. We're waiting for them to let you in.</span>
     </div>
   </ng-template>
 </ng-container>
 
 <ng-template #noInvitation>
   <!-- TODO : Use ng-content here -->
-  <button test-id="invitation-request" mat-button (click)="request(event)">
-    <mat-icon svgIcon="calendar"></mat-icon>
+  <section fxLayout="column">
     <ng-container [ngSwitch]="event | eventTime">
       <ng-container  *ngSwitchCase="'early'">
-        <span *ngIf="event.isPrivate">Ask for Invitation</span>
-        <span *ngIf="!event.isPrivate">Add to my calendar</span>
+        <button test-id="invitation-request" mat-button (click)="request(event)">
+          <mat-icon svgIcon="calendar"></mat-icon>
+          <span *ngIf="event.isPrivate">Ask for Invitation</span>
+          <span *ngIf="!event.isPrivate">Add to my calendar</span>
+        </button>
       </ng-container>
       <ng-container *ngSwitchCase="'onTime'">
-        <span *ngIf="event.isPrivate">Session has already started, request access</span>
-        <span *ngIf="!event.isPrivate">Access event</span>
+        <p>This event has already started.</p>
+        <button test-id="invitation-request" mat-button (click)="request(event)">
+          <mat-icon svgIcon="calendar"></mat-icon>
+          <span *ngIf="event.isPrivate">Request access</span>
+          <span *ngIf="!event.isPrivate">Access event</span>
+        </button>
       </ng-container>
     </ng-container>
-  </button>
+  </section>
 </ng-template>


### PR DESCRIPTION
To do in issue #4290 
- [x] Remove «  | » after the organiser name
- [x] Remove « Description » when empty
- [x] Remove the Guest list section
- [x] If possible, when you are a member of the org organizing the event, hide the button "Session has already started, request access"
- [x] Change text of the button "Session has already started, request access" for: 
"This event has already started. 
(line break) Request access."