### PR TITLE
Update UI of event lobby and session

### DIFF
--- a/apps/festival/festival/src/app/marketplace/event/lobby/lobby.component.html
+++ b/apps/festival/festival/src/app/marketplace/event/lobby/lobby.component.html
@@ -22,7 +22,7 @@
         </ng-container>
         <ng-container *ngIf="!local.tracks.video">
           <!-- We put the tooltip on a parent <span> because tooltip are not displayed on disabled buttons -->
-          <span matTooltip="Your browser don't have the permission to access the camera">
+          <span matTooltip="Your browser doesn't allow us to access your camera. To activate it, please change your browser preferences.">
             <button mat-fab disabled>
               <mat-icon svgIcon="videocam"></mat-icon>
             </button>
@@ -42,7 +42,7 @@
         </ng-container>
         <ng-container *ngIf="!local.tracks.audio">
           <!-- We put the tooltip on a parent <span> because tooltip are not displayed on disabled buttons -->
-          <span matTooltip="Your browser don't have the permission to access the microphone">
+          <span matTooltip="Your browser doesn't allow us to access your microphone. To activate it, please change your browser preferences.">
             <button mat-fab disabled>
               <mat-icon svgIcon="unmute"></mat-icon>
             </button>

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.html
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.html
@@ -38,7 +38,9 @@
 
       <div class="meeting-container">
 
-        <media-viewer [event]="event" [style]="{width: mediaContainerSize}"></media-viewer>
+        <ng-container *ngIf="!!event.meta.selectedFile">
+          <media-viewer [event]="event" [style]="{width: mediaContainerSize}"></media-viewer>
+        </ng-container>
         <meeting-video-room [style]="{width: visioContainerSize}"></meeting-video-room>
 
       </div>

--- a/apps/festival/festival/src/app/marketplace/event/session/session.component.ts
+++ b/apps/festival/festival/src/app/marketplace/event/session/session.component.ts
@@ -58,7 +58,10 @@ export class SessionComponent implements OnInit, OnDestroy {
     this.service.startLocalSession();
     this.event$ = this.service.queryDocs(this.eventQuery.getActiveId());
     this.sub = this.event$.subscribe(async event => {
-      if (event.isOwner) {
+      const fileSelected = !!event?.meta?.selectedFile;
+      if (!fileSelected) {
+        this.visioContainerSize = '100%';
+      } else if (event.isOwner) {
         this.mediaContainerSize = '40%';
         this.visioContainerSize = '60%';
       } else {

--- a/libs/event/src/lib/components/meeting/media-list/media-list.component.html
+++ b/libs/event/src/lib/components/meeting/media-list/media-list.component.html
@@ -1,4 +1,10 @@
 
+<section fxLayout fxLayoutAlign="space-between">
+  <h3>Your Files</h3>
+  <button mat-mini-fab color="primary" matTooltip="Add a file" (click)="openFileSelector()">
+    <mat-icon svgIcon="add"></mat-icon>
+  </button>
+</section>
 <ng-container *ngIf="event.meta?.files?.length; else noFiles">
   <bf-carousel flex>
 
@@ -11,7 +17,7 @@
 
     <ng-container *ngFor="let file of event.meta.files">
       <button mat-button (click)="select(file)" [disabled]="isSelected(file)" carouselItem>
-        <div fxLayout="column" fxLayoutAlign="center center" [matTooltip]="file | fileName">
+        <div fxLayout="column" fxLayoutAlign="center center" matTooltip="Share on screen">
           <img [asset]="file | fileTypeImage" alt="file type">
           <span>{{file | fileName }}</span>
         </div>
@@ -22,4 +28,3 @@
 <ng-template #noFiles>
   <p>There is no files in this meeting.</p>
 </ng-template>
-<p>Go to the <a [routerLink]="['/c/o/dashboard/event', event.id, 'edit']">edit page</a> to add more files.</p>

--- a/libs/event/src/lib/components/meeting/media-list/media-list.component.scss
+++ b/libs/event/src/lib/components/meeting/media-list/media-list.component.scss
@@ -4,9 +4,18 @@
   border-radius: 4px;
   background-color: var(--background-card);
   text-align: center;
+  padding: 12px;
+
+  section {
+    h3 {
+      margin-bottom: 12px;
+      text-align: left;
+    }
+  }
 
   bf-carousel {
-    margin: 24px;
+    margin: 12px;
+
     button {
       padding: 0;
       width: 140px;
@@ -15,7 +24,6 @@
         width: 30px;
         height: 42px;
       }
-
     }
   }
 }

--- a/libs/event/src/lib/components/meeting/media-list/media-list.component.ts
+++ b/libs/event/src/lib/components/meeting/media-list/media-list.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
+import { FileSelectorComponent } from '@blockframes/media/components/file-selector/file-selector.component';
 import { Event, EventService } from '@blockframes/event/+state';
 import { Meeting } from '@blockframes/event/+state/event.firestore';
-import { EventForm, MeetingForm } from '@blockframes/event/form/event.form';
+import { MatDialog } from '@angular/material/dialog';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: '[event] event-meeting-media-list',
@@ -17,6 +19,7 @@ export class MeetingMediaListComponent {
   @Input() event: Event<Meeting>;
 
   constructor(
+    private dialog: MatDialog,
     private eventService: EventService
   ) { }
 
@@ -34,5 +37,20 @@ export class MeetingMediaListComponent {
     const meta = { ...this.event.meta };
     meta.selectedFile = '';
     this.eventService.update(this.event.id, { meta });
+  }
+
+  openFileSelector() {
+    this.dialog.open(FileSelectorComponent, {
+      width: '80%',
+      height: '80%',
+      disableClose: true,
+      data: {
+        selectedFiles: this.event.meta.files,
+      }
+    }).afterClosed().pipe(take(1)).subscribe(result => {
+      const meta = { ...this.event.meta };
+      meta.files = result;
+      this.eventService.update(this.event.id, { meta })
+    });
   }
 }

--- a/libs/event/src/lib/components/meeting/media-list/media-list.module.ts
+++ b/libs/event/src/lib/components/meeting/media-list/media-list.module.ts
@@ -17,6 +17,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { MatLayoutModule } from '@blockframes/ui/layout/layout.module';
 import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   declarations: [ MeetingMediaListComponent ],
@@ -36,6 +37,7 @@ import { MatIconModule } from '@angular/material/icon';
     MatCardModule,
     MatListModule,
     MatIconModule,
+    MatDialogModule,
   ],
   exports: [ MeetingMediaListComponent ],
 })

--- a/libs/event/src/lib/components/meeting/room/video-room.component.html
+++ b/libs/event/src/lib/components/meeting/room/video-room.component.html
@@ -14,7 +14,7 @@
     </ng-container>
     <ng-container *ngIf="!local.tracks.video">
       <!-- We put the tooltip on a parent <span> because tooltip are not displayed on disabled buttons -->
-      <span matTooltip="Your browser don't have the permission to access the camera">
+      <span matTooltip="Your browser doesn't allow us to access your camera. To activate it, please change your browser preferences.">
         <button mat-fab disabled>
           <mat-icon svgIcon="videocam"></mat-icon>
         </button>
@@ -29,7 +29,7 @@
     </ng-container>
     <ng-container *ngIf="!local.tracks.audio">
       <!-- We put the tooltip on a parent <span> because tooltip are not displayed on disabled buttons -->
-      <span matTooltip="Your browser don't have the permission to access the microphone">
+      <span matTooltip="Your browser doesn't allow us to access your microphone. To activate it, please change your browser preferences.">
         <button mat-fab disabled>
           <mat-icon svgIcon="unmute"></mat-icon>
         </button>

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -28,7 +28,7 @@ import {
 
 const columns = { 
   ref: { value: 'Type', disableSort: true },
-  main: { value: 'Document Name', disableSort: false },
+  name: { value: 'Document Name', disableSort: false },
   actions: { value: 'Actions', disableSort: true } 
 };
 

--- a/libs/media/src/lib/components/viewers/media-viewer.component.html
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.html
@@ -23,11 +23,13 @@
       </ng-container>
     </ng-container>
   </article>
-  <article class="stop" fxLayout="column" fxLayoutAlign="center center">
-    <mat-divider></mat-divider>
-    <button mat-button (click)="stop()">
-      <mat-icon svgIcon="cross_circle"></mat-icon>
-      <span>Stop Sharing</span>
-    </button>
-  </article>
+  <ng-container *ngIf="event.isOwner">
+    <article class="stop" fxLayout="column" fxLayoutAlign="center center">
+      <mat-divider></mat-divider>
+      <button mat-button (click)="stop()">
+        <mat-icon svgIcon="cross_circle"></mat-icon>
+        <span>Stop Sharing</span>
+      </button>
+    </article>
+  </ng-container>
 </section>

--- a/libs/media/src/lib/components/viewers/media-viewer.component.html
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.html
@@ -1,34 +1,33 @@
 
-<ng-container *ngIf="!!event.meta.selectedFile; else noFile">
-  <ng-container [ngSwitch]="event.meta.selectedFile | fileType">
-    <ng-container *ngSwitchCase="'image'">
-      <img [ref]="event.meta.selectedFile" asset="no_titles.webp" />
+<section fxLayout="column" fxLayoutAlign="space-between">
+  <article class="file">
+    <ng-container *ngIf="!!event.meta.selectedFile">
+      <ng-container [ngSwitch]="event.meta.selectedFile | fileType">
+        <ng-container *ngSwitchCase="'image'">
+          <img [ref]="event.meta.selectedFile" asset="no_titles.webp" />
+        </ng-container>
+        <ng-container *ngSwitchCase="'pdf'">
+          <event-pdf-viewer [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]"></event-pdf-viewer>
+        </ng-container>
+        <ng-container *ngSwitchCase="'video'">
+          <event-video-viewer [eventId]="event.id" [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]" ></event-video-viewer>
+        </ng-container>
+        <ng-container *ngSwitchDefault>
+          <article class="noFile">
+            <h3>Sorry</h3>
+            <img asset="no_titles.webp" alt="Flying saucer">
+            <p>We don't know how to display this file.</p>
+            <p class="mat-caption">Supported files are: pdfs, images, and videos</p>
+          </article>
+        </ng-container>
+      </ng-container>
     </ng-container>
-    <ng-container *ngSwitchCase="'pdf'">
-      <event-pdf-viewer [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]"></event-pdf-viewer>
-    </ng-container>
-    <ng-container *ngSwitchCase="'video'">
-      <event-video-viewer [eventId]="event.id" [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]" ></event-video-viewer>
-    </ng-container>
-    <ng-container *ngSwitchDefault>
-      <article>
-        <h3>Sorry</h3>
-        <img asset="no_titles.webp" alt="Flying saucer">
-        <p>We don't know how to display this file.</p>
-        <p class="mat-caption">Supported files are: pdfs, images, and videos</p>
-      </article>
-    </ng-container>
-  </ng-container>
-</ng-container>
-<ng-template #noFile>
-  <article>
-    <h3>No File Selected</h3>
-    <img asset="moodboard.webp" alt="No files to display">
-    <ng-container *ngIf="event.isOwner; else notOwner">
-      <p>Select a file in the list below to display it to every attendees of this meeting.</p>
-    </ng-container>
-    <ng-template #notOwner>
-      <p>The meeting owner hasn't shared any file yet. When the meeting owner will share a file it will appear here</p>
-    </ng-template>
   </article>
-</ng-template>
+  <article class="stop" fxLayout="column" fxLayoutAlign="center center">
+    <mat-divider></mat-divider>
+    <button mat-button (click)="stop()">
+      <mat-icon svgIcon="cross_circle"></mat-icon>
+      <span>Stop Sharing</span>
+    </button>
+  </article>
+</section>

--- a/libs/media/src/lib/components/viewers/media-viewer.component.scss
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.scss
@@ -5,21 +5,25 @@
   background-color: var(--background-card);
 }
 
-article {
-  text-align: center;
-  h3 {
-    margin-top: 16px;
-  }
-  img {
-    width: 250px;
-  }
-  p {
-    padding: 0 16px;
-  }
-}
-
-img {
+section {
   height: 100%;
-  width: 100%;
-  object-fit: contain;
+
+  .file {
+    overflow: hidden;
+  }
+
+  .stop {
+    margin: 6px;
+
+    mat-divider {
+      width: 60%;
+      margin-bottom: 6px;
+    }
+  }
+  
+  img {
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
+  }
 }

--- a/libs/media/src/lib/components/viewers/media-viewer.component.ts
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.ts
@@ -16,6 +16,7 @@ export class MediaViewerComponent {
   @Input() event: Event<Meeting>;
 
   stop() {
+    if (!this.event.isOwner) return;
     const meta = { ...this.event.meta };
     meta.selectedFile = '';
     this.eventService.update(this.event.id, { meta });

--- a/libs/media/src/lib/components/viewers/media-viewer.component.ts
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { Event } from '@blockframes/event/+state';
+import { Event, EventService } from '@blockframes/event/+state';
 import { Meeting } from '@blockframes/event/+state/event.firestore';
 
 @Component({
@@ -11,6 +11,14 @@ import { Meeting } from '@blockframes/event/+state/event.firestore';
 })
 export class MediaViewerComponent {
 
+  constructor(private eventService: EventService) {}
+
   @Input() event: Event<Meeting>;
+
+  stop() {
+    const meta = { ...this.event.meta };
+    meta.selectedFile = '';
+    this.eventService.update(this.event.id, { meta });
+  }
 
 }

--- a/libs/media/src/lib/components/viewers/media-viewer.module.ts
+++ b/libs/media/src/lib/components/viewers/media-viewer.module.ts
@@ -10,6 +10,7 @@ import { FileNameModule } from '@blockframes/utils/pipes/fileName.pipe';
 import { MediaViewerComponent } from './media-viewer.component';
 import { PdfViewerComponent } from './pdf-viewer/pdf-viewer.component';
 import { VideoViewerComponent } from './video-viewer/video-viewer.component';
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { VideoViewerComponent } from './video-viewer/video-viewer.component';
     MatProgressSpinnerModule,
     MatButtonModule,
     MatIconModule,
+    MatDividerModule,
 
     FileNameModule,
     ImageReferenceModule,


### PR DESCRIPTION
To do in issue #4290 
- [x] Remove it when empty
- [x] Between shared ressource and ressource control add:
1. On the left add the icon + "Presentation shared with participants" for reassurance 
2. On the right, add the icon + Stop Sharing option (button that stops sharing)

- [x] (1) Add a title "Your Files" to this section 
- [x] (2) on hover, add a tooltip "Share on screen" + CSS style
- [x] (3) Change the link to edit page with a "+" button with "Add a file" tooltip, if possible it should open the Manage files modale directly in over the meeting session so the user doesn't leave session