### PR TITLE
bug fixes

### DIFF
--- a/libs/event/src/lib/components/meeting/room/video-room.component.ts
+++ b/libs/event/src/lib/components/meeting/room/video-room.component.ts
@@ -59,8 +59,8 @@ export class MeetingVideoRoomComponent implements OnInit, OnDestroy {
     this.twilioService.toggleTrack(kind);
   }
 
-  quitMeeting() {
-    this.twilioService.disconnect();
-    this.router.navigate(['..', 'ended'], { relativeTo: this.route });
+  async quitMeeting() {
+    const hasConfirmed = await this.router.navigate(['..', 'ended'], { relativeTo: this.route });
+    if (hasConfirmed) this.twilioService.disconnect();
   }
 }

--- a/libs/media/src/lib/+state/media.service.ts
+++ b/libs/media/src/lib/+state/media.service.ts
@@ -104,9 +104,9 @@ export class MediaService {
    * @param ref (without "/protected")
    * @param parametersSet ImageParameters[]
    */
-  private async getProtectedMediaToken(ref: string, parametersSet: ImageParameters[]): Promise<string[]> {
+  private async getProtectedMediaToken(ref: string, parametersSet: ImageParameters[], eventId?: string): Promise<string[]> {
     ref = !ref.startsWith('/') ? `/${ref}` : ref;
-    return this.getMediaToken({ ref, parametersSet }).toPromise();
+    return this.getMediaToken({ ref, parametersSet, eventId }).toPromise();
   }
 
   async generateImageSrcset(ref: string, _parameters: ImageParameters): Promise<string> {
@@ -135,11 +135,10 @@ export class MediaService {
    * @param ref string
    * @param parameters ImageParameters
    */
-  async generateImgIxUrl(ref: string, parameters: ImageParameters = {}): Promise<string> {
+  async generateImgIxUrl(ref: string, parameters: ImageParameters = {}, eventId?: string): Promise<string> {
     if (!ref) {
       return '';
     }
-    ref = encodeURI(ref); // For accentuated files names
 
     const refParts = ref.split('/');
     const privacy = refParts.shift() as Privacy;
@@ -147,7 +146,7 @@ export class MediaService {
     if (privacies.includes(privacy)) {
       ref = refParts.join('/');
       if (privacy === 'protected') {
-        const [token] = await this.getProtectedMediaToken(ref, [parameters]);
+        const [token] = await this.getProtectedMediaToken(ref, [parameters], eventId);
         parameters.s = token;
       }
     }

--- a/libs/media/src/lib/components/viewers/media-viewer.component.html
+++ b/libs/media/src/lib/components/viewers/media-viewer.component.html
@@ -7,7 +7,7 @@
           <img [ref]="event.meta.selectedFile" asset="no_titles.webp" />
         </ng-container>
         <ng-container *ngSwitchCase="'pdf'">
-          <event-pdf-viewer [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]"></event-pdf-viewer>
+          <event-pdf-viewer [eventId]="event.id" [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]"></event-pdf-viewer>
         </ng-container>
         <ng-container *ngSwitchCase="'video'">
           <event-video-viewer [eventId]="event.id" [ref]="event.meta.selectedFile" [control]="event.meta.controls[event.meta.selectedFile]" ></event-video-viewer>

--- a/libs/media/src/lib/components/viewers/pdf-viewer/pdf-viewer.component.ts
+++ b/libs/media/src/lib/components/viewers/pdf-viewer/pdf-viewer.component.ts
@@ -31,6 +31,13 @@ export class PdfViewerComponent {
     this.generatePdfUrl();
   }
 
+  private _eventId: string;
+  get eventId() { return this._eventId; }
+  @Input() set eventId(value: string) {
+    this._eventId = value;
+    this.generatePdfUrl();
+  }
+
   pdfUrl$ = new BehaviorSubject('');
   loading$ = new BehaviorSubject(true);
 
@@ -57,7 +64,7 @@ export class PdfViewerComponent {
         page: this.control.currentPage,
         auto: 'compress,format'
       }
-      const url = await this.mediaService.generateImgIxUrl(this.ref, param);
+      const url = await this.mediaService.generateImgIxUrl(this.ref, param, this.eventId);
       this.pdfUrl$.next(url);
       this.loading$.next(false);
     }

--- a/libs/media/src/lib/directives/image-reference/imgix-helpers.ts
+++ b/libs/media/src/lib/directives/image-reference/imgix-helpers.ts
@@ -60,8 +60,8 @@ export function formatParameters(parameters: ImageParameters): string {
 
 /**
  * getImgIxResourceUrl : Generate ImgIx resource URL
- * @param ref 
- * @param parameters 
+ * @param ref
+ * @param parameters
  */
 export function getImgIxResourceUrl(ref: string, parameters: ImageParameters) {
   /**
@@ -73,5 +73,5 @@ export function getImgIxResourceUrl(ref: string, parameters: ImageParameters) {
   const protectedMediaDir: Privacy = 'protected';
   const query = formatParameters(parameters);
   const imgixSource = parameters.s ? `${firebase.projectId}-${protectedMediaDir}` : firebase.projectId;
-  return `https://${imgixSource}.imgix.net/${ref}?${query}`;
+  return `https://${imgixSource}.imgix.net/${encodeURI(ref)}?${query}`;
 }


### PR DESCRIPTION

related to Meeting Bug Tracker #4393
- [x] clicking on the "quit meeting" button, then clicking on "cancel" still kill Twilio (even if the user stays on the session page)
- [x] pdf view for private documents doesn't work for buyers