### PR TITLE
Fix arrow bug

### DIFF
--- a/libs/ui/src/lib/carousel/carousel.component.ts
+++ b/libs/ui/src/lib/carousel/carousel.component.ts
@@ -92,7 +92,6 @@ export class CarouselComponent implements AfterViewInit, AfterContentInit, OnDes
       startWith(direction === 'right'),
       // offset can have tiny numbers when visually it is 0 - therefore we check if the offset is small enough to hide buttons
       map(_ => this.scrollable.measureScrollOffset(direction) > 3),
-      tap(_ => console.log("123", _)),
       tap(_ => this.ngZone.run(() => this.cdr.detectChanges())))
   }
 

--- a/libs/ui/src/lib/carousel/carousel.component.ts
+++ b/libs/ui/src/lib/carousel/carousel.component.ts
@@ -45,6 +45,7 @@ export class CarouselComponent implements AfterViewInit, AfterContentInit, OnDes
 
   private subRight: Subscription;
   private subLeft: Subscription;
+  private itemsSub: Subscription;
 
   private currentPosition: number;
 
@@ -72,6 +73,7 @@ export class CarouselComponent implements AfterViewInit, AfterContentInit, OnDes
 
   ngAfterContentInit() {
     this.amount$ = this.items.changes.pipe(startWith(this.items), map(items => items.length));
+    this.itemsSub = this.items.changes.subscribe(_ => this.showForward = !!this.scrollable.measureScrollOffset('right'));
   }
 
   scrollTo(direction: 'left' | 'right') {
@@ -86,14 +88,15 @@ export class CarouselComponent implements AfterViewInit, AfterContentInit, OnDes
   onScrolling(direction: 'right' | 'left') {
     return this.scrollable.elementScrolled().pipe(
       debounceTime(50),
-      map(_ => !!this.scrollable.measureScrollOffset(direction)),
       distinctUntilChanged(),
       startWith(direction === 'right'),
+      map(_ => !!Math.round(this.scrollable.measureScrollOffset(direction))),
       tap(_ => this.ngZone.run(() => this.cdr.detectChanges())))
   }
 
   ngOnDestroy() {
     if (this.subLeft) this.subLeft.unsubscribe();
     if (this.subRight) this.subRight.unsubscribe();
+    if (this.itemsSub) this.itemsSub.unsubscribe();
   }
 }

--- a/libs/ui/src/lib/carousel/carousel.component.ts
+++ b/libs/ui/src/lib/carousel/carousel.component.ts
@@ -90,7 +90,9 @@ export class CarouselComponent implements AfterViewInit, AfterContentInit, OnDes
       debounceTime(50),
       distinctUntilChanged(),
       startWith(direction === 'right'),
-      map(_ => !!Math.round(this.scrollable.measureScrollOffset(direction))),
+      // offset can have tiny numbers when visually it is 0 - therefore we check if the offset is small enough to hide buttons
+      map(_ => this.scrollable.measureScrollOffset(direction) > 3),
+      tap(_ => console.log("123", _)),
       tap(_ => this.ngZone.run(() => this.cdr.detectChanges())))
   }
 


### PR DESCRIPTION
To do in issue #4290 
- [x] Arrow on the right shouldn't appear when not needed

Items can dynamically be added/removed to the carousel in file selector during meeting therefore a subscription is needed to check if arrow is needed when items are added.

Also, tiny numbers as offset caused arrows to not disappear even though they should. Rounding to 0 decimals fixed this.