### PR TITLE
Polishing file explorer and icon header

### DIFF
--- a/apps/festival/festival/src/app/marketplace/marketplace.component.scss
+++ b/apps/festival/festival/src/app/marketplace/marketplace.component.scss
@@ -3,3 +3,7 @@
   display: block;
   height: 100%;
 }
+
+header {
+  margin-right: 24px;
+}

--- a/libs/media/src/lib/components/dialog/file/file.component.html
+++ b/libs/media/src/lib/components/dialog/file/file.component.html
@@ -1,4 +1,4 @@
-<h1>Add File</h1>
+<h2>Add File</h2>
 <mat-divider></mat-divider>
 <form [formGroup]="data.form" fxLayout="column" fxLayoutGap="24px">
 
@@ -39,6 +39,6 @@
     <button mat-stroked-button color="primary" (click)="upload()" [disabled]="!data.form.valid">
       <span>Add file</span>
     </button>
-    <button mat-button (click)="cancel()">Cancel</button>
+    <button mat-button (click)="cancel()" color="primary">Cancel</button>
   </section>
 </form>

--- a/libs/media/src/lib/components/dialog/file/file.component.scss
+++ b/libs/media/src/lib/components/dialog/file/file.component.scss
@@ -1,0 +1,7 @@
+h2 {
+  text-align: center;
+}
+
+mat-divider {
+  padding-bottom: 24px;
+}

--- a/libs/media/src/lib/components/dialog/image/image.component.html
+++ b/libs/media/src/lib/components/dialog/image/image.component.html
@@ -1,4 +1,4 @@
-<h1>Edit Image</h1>
+<h2>Edit Image</h2>
 <mat-divider></mat-divider>
 <form [formGroup]="data.form" fxLayout="column" fxLayoutGap="24px">
   <drop-cropper [ratio]="data.ratio" [storagePath]="data.storagePath" [form]="data.form">
@@ -8,6 +8,6 @@
     <button mat-stroked-button color="primary" (click)="upload()" [disabled]="data.form.invalid">
       <span>Update</span>
     </button>
-    <button mat-button (click)="cancel()">Cancel</button>
+    <button mat-button (click)="cancel()" color="primary">Cancel</button>
   </section>
 </form>

--- a/libs/media/src/lib/components/dialog/image/image.component.scss
+++ b/libs/media/src/lib/components/dialog/image/image.component.scss
@@ -1,0 +1,3 @@
+mat-divider {
+  padding-bottom: 24px;
+}

--- a/libs/media/src/lib/components/dialog/image/image.component.ts
+++ b/libs/media/src/lib/components/dialog/image/image.component.ts
@@ -7,7 +7,8 @@ import { isHostedMediaForm } from '../../file-explorer/file-explorer.model';
 
 @Component({
   selector: 'image-dialog',
-  templateUrl: 'image.component.html'
+  templateUrl: 'image.component.html',
+  styleUrls: ['./image.component.scss']
 })
 export class ImageDialogComponent implements OnInit {
 

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.html
@@ -3,21 +3,23 @@
     <ng-template colRef="ref" let-item="item">
       <img [asset]="getFileRef(item) | fileTypeImage">
     </ng-template>
-    <ng-template colRef="name" let-item="item">
+    <ng-template colRef="main" let-item="item">
       <span (click)="previewFile(getFileRef(item))">
         {{ getTitleRef(item) | fileName }}
       </span>
     </ng-template>
     <ng-template colRef="actions" let-item="item">
-      <button mat-button (click)="downloadFile(item, $event)">
-        <mat-icon svgIcon="download"></mat-icon>
-      </button>
-      <button mat-button (click)="edit(item, $event)">
-        <mat-icon svgIcon="pencil"></mat-icon>
-      </button>
-      <button mat-button (click)="deleteFile(item, $event)">
-        <mat-icon svgIcon="trash"></mat-icon>
-      </button>
+      <section fxLayout="row" fxLayoutGap="12px">
+        <button mat-icon-button (click)="downloadFile(item, $event)">
+          <mat-icon svgIcon="download"></mat-icon>
+        </button>
+        <button mat-icon-button (click)="edit(item, $event)">
+          <mat-icon svgIcon="pencil"></mat-icon>
+        </button>
+        <button mat-icon-button (click)="deleteFile(item, $event)">
+          <mat-icon svgIcon="trash"></mat-icon>
+        </button>
+      </section>
     </ng-template>
   </bf-table-filter>
 </ng-container>

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -28,7 +28,7 @@ import {
 
 const columns = { 
   ref: { value: 'Type', disableSort: true },
-  name: { value: 'Document Name', disableSort: false },
+  main: { value: 'Document Name', disableSort: false },
   actions: { value: 'Actions', disableSort: true } 
 };
 

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.module.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { MultipleFilesViewComponent } from './multiple-files-view.component';
 
@@ -18,6 +19,7 @@ import { MatButtonModule } from '@angular/material/button';
   declarations: [MultipleFilesViewComponent],
   imports: [
     CommonModule,
+    FlexLayoutModule,
     ImageReferenceModule,
     TableFilterModule,
     ToArrayPipeModule,

--- a/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.scss
+++ b/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.scss
@@ -1,3 +1,7 @@
 section {
   margin-bottom: 16px;
+
+  drop-cropper {
+    padding: 16px;
+  }
 }

--- a/libs/ui/src/lib/layout/marketplace/marketplace.component.scss
+++ b/libs/ui/src/lib/layout/marketplace/marketplace.component.scss
@@ -21,6 +21,10 @@ mat-sidenav-content {
       margin-right: 24px;
     }
 
+    button mat-icon {
+      margin-right: 0px;
+    }
+
     a:first-of-type {
       margin-right: auto;
     }

--- a/libs/ui/src/lib/list/table-filter/table-filter.component.scss
+++ b/libs/ui/src/lib/list/table-filter/table-filter.component.scss
@@ -45,3 +45,9 @@ widget-card {
   max-width: 500px;
   overflow: auto;
 }
+
+// Name your column 'main' in order to make it span the full width of the column
+.mat-column-main {
+  width: 100%;
+  padding-left: 24px;
+}


### PR DESCRIPTION
To do's issue #4337 
### Cropper
- [x] Add 16px margin all around the blue dashed zone (same for all states "uploading" "cropping" "added"...)
Add same margin around tables in the same area. (if space is not enought, have a horizontal scroll inside tables like it's the case in some existing components (see tables inside dashboard)

### Upload statement (movie form)
- [x] Title: put h2 instead of h1. Text centered in the dialog. 
- [x] 24px under the title's divider
- [x] Take off the paper plane in the Update Button.
- [x] In this case, "cancel" button should also be primary since it's already differentiated with "update" by the button shape.
If you can (not mandatory at all) use a lighter shade of primary palette.

- [x] Action List icons on the right should be stuck on the right and aligned with same icons under and above in table lines. 
- [x] "Document name" and any column's width shouldn't be based on it's content's size and always be the same in every line.

### Navbar
- [x] If you can, center the icon inside the light effect. If impossible take it off.

### My Files
- [x] Icons "accept / refuse" have to be the same size (smaller one would be best)