### PR TITLE
Update file explorer

### DIFF
--- a/libs/media/src/lib/components/cropper/cropper.component.ts
+++ b/libs/media/src/lib/components/cropper/cropper.component.ts
@@ -164,7 +164,7 @@ export class CropperComponent implements OnInit {
 
     const isFileTypeValid = this.types && this.types.includes(fileType);
     if (!isFileTypeValid) {
-      this.snackBar.open(`Unsupported file type: "${fileType}".`, 'close', { duration: 1000 });
+      this.snackBar.open(`Unsupported file type: "${fileType}".`, 'close', { duration: 3000 });
       this.delete();
     } else {
       this.nextStep('crop');

--- a/libs/media/src/lib/components/dialog/file-viewer/viewer.component.scss
+++ b/libs/media/src/lib/components/dialog/file-viewer/viewer.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 img {
   object-fit: contain;
   width: 100%;

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -28,7 +28,7 @@ import {
 
 const columns = { 
   ref: { value: 'Type', disableSort: true },
-  main: { value: 'Document Name', disableSort: false },
+  main: { value: 'Document Name', disableSort: true },
   actions: { value: 'Actions', disableSort: true } 
 };
 

--- a/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
+++ b/libs/media/src/lib/components/file-explorer/components/multiple-files-view/multiple-files-view.component.ts
@@ -126,7 +126,7 @@ export class MultipleFilesViewComponent implements OnInit {
 
   public async downloadFile(item: Partial<HostedMediaWithMetadata | OrganizationDocumentWithDates>, event: Event) {
     event.stopPropagation();
-    const ref = item[this.activeDirectory.fileRefField];
+    const ref = this.activeDirectory.fileRefField ? item[this.activeDirectory.fileRefField] : item;
     const url = await this.mediaService.generateImgIxUrl(ref);
     window.open(url);
   }

--- a/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.html
+++ b/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.html
@@ -16,7 +16,7 @@
       </file-upload>
     </ng-container>
     <div fxLayout="column" fxLayoutAlign="center center">
-      <button mat-stroked-button color="primary" (click)="update()" [disabled]="getSingleMediaForm().invalid">
+      <button mat-stroked-button color="primary" (click)="update()" [disabled]="getSingleMediaForm().invalid || getSingleMediaForm().pristine">
         <span>Update</span>
       </button>
     </div>

--- a/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.scss
+++ b/libs/media/src/lib/components/file-explorer/components/single-file-view/single-file-view.component.scss
@@ -4,4 +4,8 @@ section {
   drop-cropper {
     padding: 16px;
   }
+
+  file-upload {
+    padding: 16px;
+  }
 }

--- a/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
+++ b/libs/media/src/lib/components/file-explorer/file-explorer.model.ts
@@ -230,7 +230,7 @@ export function createMovieFileStructure(title: Movie, index: number): Directory
             docNameField: 'ref',
             fileRefField: 'ref',
             storagePath: `movies/${title.id}/promotional.videos.otherVideos`,
-            privacy: 'protected',
+            privacy: 'public',
             path: [index, 1, 5],
             hasFile: title.promotional.videos?.otherVideos?.length
           }
@@ -244,7 +244,7 @@ export function createMovieFileStructure(title: Movie, index: number): Directory
         docNameField: 'ref',
         fileRefField: 'ref',
         storagePath: `movies/${title.id}/promotional.notes`,
-        privacy: 'protected',
+        privacy: 'public',
         path: [index, 2],
         hasFile: title.promotional.notes.length
       }

--- a/libs/media/src/lib/components/viewers/pdf-viewer/pdf-viewer.component.scss
+++ b/libs/media/src/lib/components/viewers/pdf-viewer/pdf-viewer.component.scss
@@ -31,5 +31,6 @@ div {
   }
   button.fullscreen {
     background: #000;
+    margin: 24px;
   }
 }

--- a/libs/movie/src/lib/movie/form/media-notes/notes.component.html
+++ b/libs/movie/src/lib/movie/form/media-notes/notes.component.html
@@ -17,7 +17,7 @@
               </mat-select>
             </mat-form-field>
             <file-upload test-id="intent-note" [form]="noteForm.get('ref')" [storagePath]="getPath()"
-              allowedFileType="pdf" filePrivacy="protected">
+              allowedFileType="pdf">
             </file-upload>
             <div fxLayout="column" class="captions">
               <span class="mat-caption">Attach a note / statement of intent from your project's director or


### PR DESCRIPTION
To do's in issue #4437 
- [x] Update btn should be disabled when form is not dirty
- [x] Padding around single file-upload component

- [x] When you see a document in full screen you uploaded, the button at bottom-right sticks the edge of the window
![image](https://user-images.githubusercontent.com/48033264/101620059-5f721100-3a14-11eb-8f55-1ab8259491f5.png)
- [x] When you try to upload a document in a wrong format, the snackbar that shows the error message disappear really quickly, and we don't have enough time to read the error.

- [x] I have a scrollbar when I look at an image, but the height isn't so big
![image](https://user-images.githubusercontent.com/48033264/101624539-58e69800-3a1a-11eb-8a18-8c0b173e76ef.png)
- [x] When I click on the uploader button, it opens a blank page and nothing happens
![image](https://user-images.githubusercontent.com/48033264/101624636-7f0c3800-3a1a-11eb-904c-31eb2f645b68.png)
- [x] The sort functionality doesn't work with images
![image](https://user-images.githubusercontent.com/48033264/101625193-5fc1da80-3a1b-11eb-9056-3dc46a8dd478.png)



And maybe fixes for documents not previewing/downloading. I'll have to check that tomorrow on Staging