### PR TITLE
Improvement of drop cropper

### DIFF
--- a/libs/media/src/lib/components/cropper/cropper.component.ts
+++ b/libs/media/src/lib/components/cropper/cropper.component.ts
@@ -121,7 +121,11 @@ export class CropperComponent implements OnInit {
   @HostListener('drop', ['$event'])
   onDrop($event: DragEvent) {
     $event.preventDefault();
-    this.filesSelected($event.dataTransfer.files);
+    if (!!$event.dataTransfer.files.length) {
+      this.filesSelected($event.dataTransfer.files);
+    } else {
+      this.resetState();
+    }
   }
 
   @HostListener('dragover', ['$event'])
@@ -133,6 +137,10 @@ export class CropperComponent implements OnInit {
   @HostListener('dragleave', ['$event'])
   onDragLeave($event: DragEvent) {
     $event.preventDefault();
+    this.resetState();
+  }
+
+  private resetState() {
     if (!!this.form.blobOrFile.value || (!!this.form.ref?.value)) {
       this.nextStep('show');
     } else {


### PR DESCRIPTION
Improvement on issue #4451 

It's not fully fixed. Dragging the image to the sides or top it does work, but if you drag the image to the bottom it still bugs - This is due to changing height of the drop-cropper dependent on the image within it.

I'll keep the issue open but it's already an improvement for now