### PR TITLE
Persistant cookie

### DIFF
--- a/libs/organization/src/lib/organization/pages/organization/organization.component.scss
+++ b/libs/organization/src/lib/organization/pages/organization/organization.component.scss
@@ -1,4 +1,3 @@
-footer {
-  margin-top: 56px;
-  margin-bottom: 80px;
+footer { 
+  padding: 24px;
 }

--- a/libs/user/src/lib/auth/pages/profile-cookie/profile-cookie.component.scss
+++ b/libs/user/src/lib/auth/pages/profile-cookie/profile-cookie.component.scss
@@ -1,3 +1,4 @@
-footer {
-  margin: 80px 0;
+footer { 
+  padding-top: 48px;
+  padding-bottom: 24px;
 }

--- a/libs/utils/src/lib/gdpr-cookie/cookie-banner/cookie-banner.component.ts
+++ b/libs/utils/src/lib/gdpr-cookie/cookie-banner/cookie-banner.component.ts
@@ -54,7 +54,8 @@ export class CookieBannerComponent implements OnInit {
   }
 
   confirmCookies() {
-    this.document.cookie = 'blockframes=';
+    // A max-age of 31536000 equals one year
+    this.document.cookie = 'blockframes=; path=/; max-age=31536000';
     this.hasAccepted = true;
     this.cdr.markForCheck();
   }

--- a/libs/utils/src/lib/safari-banner/safari-banner.component.ts
+++ b/libs/utils/src/lib/safari-banner/safari-banner.component.ts
@@ -26,7 +26,8 @@ export class SafariBannerComponent implements OnInit {
   }
 
   public userDismiss() {
-    this.document.cookie = 'archipel_safari=true';
+    // A max-age of 31536000 equals one year
+    this.document.cookie = 'archipel_safari=true; path=/; max-age=31536000';
     this.isHidden = true;
   }
 }


### PR DESCRIPTION
Fix issue #4442 
Cookies without an expiration date (or max-age) are set to last only for a session. Closing the browser ended the session and thus removing this cookie. By setting the max-age, the cookie is only deleted after one year.

- [x] The button "Update" is pretty stick at the bottom of the page in the organization settings. We just have to add some padding in the footer to resolve it : 
- [x] there are the same issue for the cookies preference page

- [x] ![issueCookies](https://user-images.githubusercontent.com/52285231/101521155-b4b31180-3985-11eb-9237-92aa8d52721e.png)