### PR TITLE
Input and name team

### DIFF
--- a/libs/landing/src/lib/shell/shell.component.html
+++ b/libs/landing/src/lib/shell/shell.component.html
@@ -30,13 +30,13 @@
         <h1>Want to learn more?</h1>
         <h3>Schedule a demo with our team!</h3>
         <p>
-          Program a personalized demonstration of the platform with a member of the Archipel team.
+          Program a personalized demonstration of the platform with a member of the {{ appName.label }} team.
           <br />
           Please fill out the form and we will get back to you to choose the best time.
         </p>
       </article>
       <form fxLayout="column" fxLayoutAlign="start center" [formGroup]="form" (ngSubmit)="sendRequest(form)">
-        <article fxLayout="row" fxLayoutAlign="space-between center" fxLayout.lt-md="column" fxLayoutGap="24px">
+        <article fxLayout="row" fxLayoutAlign="space-between start" fxLayout.lt-md="column" fxLayoutGap="24px">
           <mat-form-field appearance="outline">
             <mat-label>First name</mat-label>
             <input matInput type="text" placeholder="First name" formControlName="firstName" required />
@@ -52,7 +52,7 @@
             </mat-error>
           </mat-form-field>
         </article>
-        <article fxLayout="row" fxLayoutAlign="space-between center" fxLayout.lt-md="column" fxLayoutGap="24px">
+        <article fxLayout="row" fxLayoutAlign="space-between start" fxLayout.lt-md="column" fxLayoutGap="24px">
           <mat-form-field appearance="outline">
             <mat-label>Company name</mat-label>
             <input matInput type="text" placeholder="Company name" formControlName="companyName" required />
@@ -70,7 +70,7 @@
             </mat-error>
           </mat-form-field>
         </article>
-        <article fxLayout="row" fxLayoutAlign="space-between center" fxLayout.lt-md="column" fxLayoutGap="24px">
+        <article fxLayout="row" fxLayoutAlign="space-between start" fxLayout.lt-md="column" fxLayoutGap="24px">
           <mat-form-field appearance="outline">
             <mat-label>Email</mat-label>
             <input matInput type="email" placeholder="Email" formControlName="email" required />

--- a/libs/landing/src/lib/shell/shell.component.ts
+++ b/libs/landing/src/lib/shell/shell.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, ContentChild, Directive, Input, Vie
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { createDemoRequestInformations, RequestDemoInformations } from '@blockframes/utils/request-demo';
 import { MatSnackBar } from '@angular/material/snack-bar'
-import { getCurrentApp } from '@blockframes/utils/apps';
+import { getCurrentApp, getAppName } from '@blockframes/utils/apps';
 import { RouterQuery } from '@datorama/akita-ng-router-store';
 import { AngularFireFunctions } from '@angular/fire/functions';
 import { RequestDemoRole } from '@blockframes/utils/request-demo';
@@ -39,6 +39,7 @@ export class LandingFooterComponent { }
 })
 export class LandingShellComponent {
   public submitted = false;
+  public appName = getAppName(getCurrentApp(this.routerQuery));
 
   @Input() roles: RequestDemoRole[] = [
     'buyer',


### PR DESCRIPTION
Fix input on landing page, and the Archipel/Media financiers team name just before the `Want to learn more` form.