### PR TITLE
Fix links on media form

### DIFF
--- a/apps/financiers/financiers/src/app/dashboard/tunnel/summary/summary.component.html
+++ b/apps/financiers/financiers/src/app/dashboard/tunnel/summary/summary.component.html
@@ -27,7 +27,7 @@
 
     <section id="storyline-elements">
       <h3>Storyline Elements</h3>
-      <movie-summary-synopsis [movie]="form" [link]="('synopsis' | getPath)"></movie-summary-synopsis>
+      <movie-summary-synopsis [movie]="form" [link]="('story-elements' | getPath)"></movie-summary-synopsis>
     </section>
 
     <mat-divider></mat-divider>
@@ -97,7 +97,7 @@
 
     <section id="technical-information">
       <h3>Technical Information</h3>
-      <movie-summary-technical-info [movie]="form" [link]="('technical-info' | getPath)"></movie-summary-technical-info>
+      <movie-summary-technical-info [movie]="form" [link]="('technical-spec' | getPath)"></movie-summary-technical-info>
     </section>
 
     <mat-divider></mat-divider>


### PR DESCRIPTION
- [x] Summary page, some edit links are broken:
- all the ones included in Storyline Elements (logline, synopsis, Key assets, Keywords)
- technical information format
