### PR TITLE
Draft Fix for Movie Form setAllValue bug

### DIFF
--- a/libs/movie/src/lib/movie/form/movie.form.ts
+++ b/libs/movie/src/lib/movie/form/movie.form.ts
@@ -161,6 +161,11 @@ export class MovieForm extends FormEntity<MovieControl, Movie> {
       if (this.contains(key)) {
         const control = this.get(key as keyof MovieControl);
         const value = controls[key].value;
+        if (control instanceof StakeholderMapForm) {
+          for (const key2 in control.controls) {
+            control.controls[key2].patchAllValue(value[key2])
+          }
+        } else 
         if (control instanceof FormList) {
           control.patchAllValue(value);
         } else {


### PR DESCRIPTION
[Link to issue](https://github.com/blockframes/blockframes/issues/4440#issuecomment-743349349) #4440 

- [ ] Why are these 2 companies suggested as producers ? When you save a production company on another movie, it is automatically proposed for other movies ? 
<img width="1437" alt="Capture d’écran 2020-12-11 à 19 17 22" src="https://user-images.githubusercontent.com/73707444/101939740-b24ef280-3be5-11eb-956a-da50425742ff.png">

Reproduced by:
- going on dashboard movie view of a film
- creating a new film
=> Production company use the prod info from the movie view visited

The function `setAllValue()` on `MovieForm` has a bug for controls like 'stakeholders'. The 'stakeholders' object consists out of multiple FormList which values are not properly updated by `control.patchValue(value)` function which it currently runs through.
For the 'stakeholders' object it is necessary to loop through each control to update all values properly - see Files Changed for a working solution

Note that the solution has to be generic so it also works for other objects with FormList as child controls.