### PR TITLE
Exclude all languages from filter

### DIFF
--- a/libs/movie/src/lib/movie/form/filters/languages/language-filter.component.html
+++ b/libs/movie/src/lib/movie/form/filters/languages/language-filter.component.html
@@ -1,4 +1,4 @@
-<chips-autocomplete scope="languages" [form]="selectedLanguages">
+<chips-autocomplete scope="languages" [form]="selectedLanguages" [withoutValues]="['all']">
   <mat-label>Language & Version</mat-label>
 </chips-autocomplete>
 <static-check-boxes fxLayout="row wrap" fxLayoutGap="8px" scope="movieLanguageTypes" [form]="versions">


### PR DESCRIPTION
To do in issue #4514 
- [x] Remove "All languages" from Language & Version filter list