### PR TITLE
Invert budget filter

### DIFF
--- a/libs/movie/src/lib/movie/form/filters/budget/budget.component.html
+++ b/libs/movie/src/lib/movie/form/filters/budget/budget.component.html
@@ -6,4 +6,5 @@
   step="100000"
   [formControl]="form"
   color="primary"
+  invert
 ></mat-slider>

--- a/libs/movie/src/lib/movie/form/filters/budget/budget.component.html
+++ b/libs/movie/src/lib/movie/form/filters/budget/budget.component.html
@@ -2,7 +2,7 @@
   thumbLabel
   [displayWith]="formatLabel"
   min="0"
-  max="20000000"
+  [max]="max"
   step="100000"
   [formControl]="form"
   color="primary"

--- a/libs/movie/src/lib/movie/form/filters/budget/budget.component.ts
+++ b/libs/movie/src/lib/movie/form/filters/budget/budget.component.ts
@@ -3,6 +3,8 @@ import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
 
+export const max = 20000000;
+
 @Component({
   selector: '[form] filter-budget',
   templateUrl: './budget.component.html',
@@ -13,6 +15,8 @@ export class BudgetFilterComponent implements OnInit, OnDestroy {
 
   @Input() form: FormControl; // FormControl of number
   private sub: Subscription;
+
+  max = max;
 
   ngOnInit() {
     this.sub = this.form.valueChanges.pipe(
@@ -26,14 +30,14 @@ export class BudgetFilterComponent implements OnInit, OnDestroy {
   }
 
   formatLabel(value: number) {
-    const invertedValue = 20000000 - value
-    if (invertedValue >= 1000 && invertedValue < 1000000) {
-      return Math.round(invertedValue / 1000) + 'k';
-    } else if (invertedValue >= 1000000) {
-      return (invertedValue / 1000000) + 'M';
+    const minBudget = max - value;
+    if (minBudget >= 1000 && minBudget < 1000000) {
+      return Math.round(minBudget / 1000) + 'k';
+    } else if (minBudget >= 1000000) {
+      return (minBudget / 1000000) + 'M';
     }
 
-    return invertedValue;
+    return minBudget;
   }
 
 }

--- a/libs/movie/src/lib/movie/form/filters/budget/budget.component.ts
+++ b/libs/movie/src/lib/movie/form/filters/budget/budget.component.ts
@@ -26,13 +26,14 @@ export class BudgetFilterComponent implements OnInit, OnDestroy {
   }
 
   formatLabel(value: number) {
-    if (value >= 1000 && value < 1000000) {
-      return Math.round(value / 1000) + 'k';
-    } else if (value >= 1000000) {
-      return (value / 1000000) + 'M';
+    const invertedValue = 20000000 - value
+    if (invertedValue >= 1000 && invertedValue < 1000000) {
+      return Math.round(invertedValue / 1000) + 'k';
+    } else if (invertedValue >= 1000000) {
+      return (invertedValue / 1000000) + 'M';
     }
 
-    return value;
+    return invertedValue;
   }
 
 }

--- a/libs/movie/src/lib/movie/form/search.form.ts
+++ b/libs/movie/src/lib/movie/form/search.form.ts
@@ -7,6 +7,7 @@ import algoliasearch, { Index } from 'algoliasearch';
 import { StoreStatus, ProductionStatus, Territory, Language, Genre, StoreType, SocialGoal } from '@blockframes/utils/static-model/types';
 import { App } from "@blockframes/utils/apps";
 import { AlgoliaOrganization, AlgoliaSearch } from '@blockframes/utils/algolia';
+import { max } from './filters/budget/budget.component';
 
 export interface LanguagesSearch {
   original: Language[];
@@ -144,7 +145,7 @@ export class MovieSearchForm extends FormEntity<MovieSearchControl> {
     } as any;
 
     if (this.minBudget.value) {
-      search.filters = `budget >= ${20000000 - this.minBudget.value ?? 0}`;
+      search.filters = `budget >= ${max - this.minBudget.value ?? 0}`;
     }
     return this.movieIndex.search(search);
   }

--- a/libs/movie/src/lib/movie/form/search.form.ts
+++ b/libs/movie/src/lib/movie/form/search.form.ts
@@ -144,7 +144,7 @@ export class MovieSearchForm extends FormEntity<MovieSearchControl> {
     } as any;
 
     if (this.minBudget.value) {
-      search.filters = `budget >= ${this.minBudget.value ?? 0}`;
+      search.filters = `budget >= ${20000000 - this.minBudget.value ?? 0}`;
     }
     return this.movieIndex.search(search);
   }


### PR DESCRIPTION
To do in issue #4514 
- [x] Change budget filter behaviour: we should reverse the way it works and go from right to left, starting at a maximum 20M$ budget and choosing till how much it goes down.
E.g. I go halfway from 20M to 10M and got all films that have budget range between 10M & 20M$

I am curious if this is the way to go. If the value in budget is for example 1.000.000, it will search for movies of 19.000.000+. The user doesn't notice this because the label on the slider will be 19.000.000. It's just the value in the form that might cause later confusion.