### PR TITLE
Email for request to event accepted by org

### DIFF
--- a/apps/backend-functions/src/internals/invitations/events.ts
+++ b/apps/backend-functions/src/internals/invitations/events.ts
@@ -4,12 +4,13 @@ import { NotificationDocument, OrganizationDocument, PublicUser } from "../../da
 import { createNotification, triggerNotifications } from "../../notification";
 import { db, getUser } from "../firebase";
 import { getAdminIds, getDocument } from "../../data/internals";
-import { invitationToEventFromOrg, requestToAttendEventFromUser } from '../../templates/mail';
+import { invitationToEventFromOrg, requestToAttendEventFromUser, requestToAttendEventFromUserAccepted } from '../../templates/mail';
 import { sendMailFromTemplate } from '../email';
 import { EventDocument, EventMeta } from "@blockframes/event/+state/event.firestore";
 import { EmailRecipient, getEventEmailData, EventEmailData } from "@blockframes/utils/emails/utils";
 import { App, applicationUrl } from "@blockframes/utils/apps";
 import { orgName, canAccessModule } from "@blockframes/organization/+state/organization.firestore";
+import { format } from "date-fns";
 
 function getEventLink(org: OrganizationDocument) {
   if (canAccessModule('marketplace', org)) {
@@ -144,6 +145,9 @@ async function onInvitationToAnEventAccepted({
 
   const notifications: NotificationDocument[] = [];
 
+  // @TODO (#2848) forcing to festival since invitations to events are only on this one
+  const appKey: App = 'festival';
+
   if (!!fromUser) {
     const notification = createNotification({
       toUserId: fromUser.uid,
@@ -154,6 +158,21 @@ async function onInvitationToAnEventAccepted({
     if (!!toUser) {
       notification.user = toUser; // The subject that have accepted the invitation
     } else if (!!toOrg) {
+      const org = await getDocument<OrganizationDocument>(`orgs/${toOrg.id}`);
+      const organizerOrgName = orgName(org);
+      const event = await getDocument<EventDocument<EventMeta>>(`events/${eventId}`);
+      const eventStartDate = event.start.toDate();
+      const eventEndDate = event.end.toDate();
+      /**
+       * @dev Format from date-fns lib, here the date will be 'month/day/year, hours:min:sec am/pm GMT'
+       * See the doc here : https://date-fns.org/v2.16.1/docs/format
+       */
+      const eventStart = format(eventStartDate, 'Pppp');
+      const eventEnd = format(eventEndDate, 'Pppp');
+
+      const templateRequest = requestToAttendEventFromUserAccepted(fromUser, organizerOrgName, event.title, eventStart, eventEnd);
+      await sendMailFromTemplate(templateRequest, appKey);
+
       notification.organization = toOrg; // The subject that have accepted the invitation
     } else {
       throw new Error('Did not found invitation recipient.');
@@ -172,6 +191,7 @@ async function onInvitationToAnEventAccepted({
       if (!!toUser) {
         notification.user = toUser; // The subject that have accepted the invitation
       } else if (!!toOrg) {
+
         notification.organization = toOrg; // The subject that have accepted the invitation
       } else {
         throw new Error('Did not found invitation recipient.');

--- a/apps/backend-functions/src/internals/invitations/events.ts
+++ b/apps/backend-functions/src/internals/invitations/events.ts
@@ -159,8 +159,9 @@ async function onInvitationToAnEventAccepted({
       const org = await getDocument<OrganizationDocument>(`orgs/${toOrg.id}`);
       const event = await getDocument<EventDocument<EventMeta>>(`events/${eventId}`);
       const eventData: EventEmailData = getEventEmailData(event);
+      const url = applicationUrl[appKey];
 
-      const templateRequest = requestToAttendEventFromUserAccepted(fromUser, orgName(org), eventData);
+      const templateRequest = requestToAttendEventFromUserAccepted(fromUser, orgName(org), eventData, url);
       await sendMailFromTemplate(templateRequest, appKey);
 
       notification.organization = toOrg; // The subject that have accepted the invitation

--- a/apps/backend-functions/src/templates/ids.ts
+++ b/apps/backend-functions/src/templates/ids.ts
@@ -38,7 +38,8 @@ export const templateIds = {
       accepted: 'd-d32b25a504874a708de6bfc50a1acba7',
     },
     attendEvent: {
-      created: 'd-07f5e3cc6796455097b6082c22568d9e'
+      created: 'd-07f5e3cc6796455097b6082c22568d9e',
+      accepted: 'd-df7b0a372b994a3090a48dc6cf17ba3e',
     }
   },
   // Templates for invitations

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -189,6 +189,25 @@ export function requestToAttendEventFromUser(
   return { to: recipient.email, templateId: templateIds.request.attendEvent.created, data };
 }
 
+/** Generate an email to inform users that their request to attend an event was accepted */
+export function requestToAttendEventFromUserAccepted(
+  toUser: PublicUser,
+  organizerOrgName: string,
+  eventName: string,
+  eventStartDate: string,
+  eventEndDate: string
+): EmailTemplateRequest {
+  const data = {
+    userFirstName: toUser.firstName,
+    userLastName: toUser.lastName,
+    organizerOrgName,
+    eventName,
+    eventStartDate,
+    eventEndDate,
+  };
+  return { to: toUser.email, templateId: templateIds.request.attendEvent.accepted, data };
+}
+
 // ------------------------- //
 //      CASCADE8 ADMIN       //
 // ------------------------- //

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -193,17 +193,15 @@ export function requestToAttendEventFromUser(
 export function requestToAttendEventFromUserAccepted(
   toUser: PublicUser,
   organizerOrgName: string,
-  eventName: string,
-  eventStartDate: string,
-  eventEndDate: string
+  eventData: EventEmailData,
 ): EmailTemplateRequest {
   const data = {
     userFirstName: toUser.firstName,
     userLastName: toUser.lastName,
     organizerOrgName,
-    eventName,
-    eventStartDate,
-    eventEndDate,
+    eventName: eventData.title,
+    eventStartDate: eventData.start,
+    eventEndDate: eventData.end,
   };
   return { to: toUser.email, templateId: templateIds.request.attendEvent.accepted, data };
 }

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -194,6 +194,7 @@ export function requestToAttendEventFromUserAccepted(
   toUser: PublicUser,
   organizerOrgName: string,
   eventData: EventEmailData,
+  pageURL: string = appUrl.market,
 ): EmailTemplateRequest {
   const data = {
     userFirstName: toUser.firstName,
@@ -202,6 +203,7 @@ export function requestToAttendEventFromUserAccepted(
     eventName: eventData.title,
     eventStartDate: eventData.start,
     eventEndDate: eventData.end,
+    sessionURL: `${pageURL}/c/o/marketplace/event/${eventData.id}`
   };
   return { to: toUser.email, templateId: templateIds.request.attendEvent.accepted, data };
 }


### PR DESCRIPTION
Add a new function to create email when organization accepted a request from an user to attend one of its event.
Will need several changes on the template on Sendgrid :
- OrgName variable in the subject need to be changed
- I don't put different variable for the time and the date of the event. It's in one variable (instead of 'month/day/year' and 'hours/min/sec', I have 'month/day/year hours:min:sec GMT')

See with Vincent but maybe we need an URL redirecting to the event page ?
Fix #4092 