### PR TITLE
Admin invite user to join org

### DIFF
--- a/apps/backend-functions/src/invitation.ts
+++ b/apps/backend-functions/src/invitation.ts
@@ -44,6 +44,7 @@ export async function onInvitationWrite(
       const invitationCollectionRef = db.collection('invitations')
         .where('toUser.uid', '==', user.uid)
         .where('mode', '==', 'invitation')
+        .where('status', '==', 'pending')
       const existingInvitation = await invitationCollectionRef.get();
 
       // If there is an other invitation or the user has already an org, we don't want to delete its account

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -98,8 +98,11 @@ export const onPermissionDeleteEvent = onDocumentDelete('permissions/{orgID}',on
 /** Trigger: when an invitation is updated (e. g. when invitation.status change). */
 export const onInvitationUpdateEvent = onDocumentWrite('invitations/{invitationID}', onInvitationWrite);
 
-/** Trigger: when an invitation is updated (e. g. when invitation.status change). */
+/** Trigger: when an invitation is deleted. */
 export const onInvitationDeleteEvent = onDocumentDelete('invitations/{invitationID}', onInvitationDelete);
+
+/** Used to check if users have already an invitation to join org existing */
+export const isInvitationToJoinOrgExisted = functions.https.onCall(invitations.isInvitationToJoinOrgExists);
 
 //--------------------------------
 //    Events Management          //

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -7,7 +7,7 @@ import {
   onDocumentWrite,
 } from './utils';
 import { logErrors } from './internals/sentry';
-import { onInvitationWrite, onInvitationDelete } from './invitation';
+import { onInvitationWrite } from './invitation';
 import { onOrganizationCreate, onOrganizationDelete, onOrganizationUpdate, accessToAppChanged } from './orgs';
 import { onMovieUpdate, onMovieCreate, onMovieDelete } from './movie';
 import * as bigQuery from './bigQuery';
@@ -98,11 +98,8 @@ export const onPermissionDeleteEvent = onDocumentDelete('permissions/{orgID}',on
 /** Trigger: when an invitation is updated (e. g. when invitation.status change). */
 export const onInvitationUpdateEvent = onDocumentWrite('invitations/{invitationID}', onInvitationWrite);
 
-/** Trigger: when an invitation is deleted. */
-export const onInvitationDeleteEvent = onDocumentDelete('invitations/{invitationID}', onInvitationDelete);
-
 /** Used to check if users have already an invitation to join org existing */
-export const isInvitationToJoinOrgExisted = functions.https.onCall(invitations.isInvitationToJoinOrgExists);
+export const isInvitationToJoinOrgExist = functions.https.onCall(invitations.isInvitationToJoinOrgExist);
 
 //--------------------------------
 //    Events Management          //

--- a/apps/backend-functions/src/main.ts
+++ b/apps/backend-functions/src/main.ts
@@ -7,7 +7,7 @@ import {
   onDocumentWrite,
 } from './utils';
 import { logErrors } from './internals/sentry';
-import { onInvitationWrite } from './invitation';
+import { onInvitationWrite, onInvitationDelete } from './invitation';
 import { onOrganizationCreate, onOrganizationDelete, onOrganizationUpdate, accessToAppChanged } from './orgs';
 import { onMovieUpdate, onMovieCreate, onMovieDelete } from './movie';
 import * as bigQuery from './bigQuery';
@@ -97,6 +97,9 @@ export const onPermissionDeleteEvent = onDocumentDelete('permissions/{orgID}',on
 
 /** Trigger: when an invitation is updated (e. g. when invitation.status change). */
 export const onInvitationUpdateEvent = onDocumentWrite('invitations/{invitationID}', onInvitationWrite);
+
+/** Trigger: when an invitation is updated (e. g. when invitation.status change). */
+export const onInvitationDeleteEvent = onDocumentDelete('invitations/{invitationID}', onInvitationDelete);
 
 //--------------------------------
 //    Events Management          //

--- a/libs/invitation/src/lib/+state/invitation.firestore.ts
+++ b/libs/invitation/src/lib/+state/invitation.firestore.ts
@@ -4,9 +4,9 @@ import { PublicUser } from "@blockframes/user/+state/user.firestore";
 
 type Timestamp = firestore.Timestamp;
 
-/** 
+/**
  * Raw type for Invitation.
- * 
+ *
  * For Events:
  *  When a invitation is created, a backend function will check if:
  *  If we have an user or an org we can create a notification.
@@ -39,7 +39,8 @@ export type InvitationDocument = InvitationBase<Timestamp>;
 export type InvitationOrUndefined = InvitationDocument | undefined;
 
 /** Status of an Invitation. Set to pending by default, get erased if accepted, archived if declined. */
-export type InvitationStatus = 'accepted' | 'declined' | 'pending';
+export const invitationStatus = ['accepted', 'declined', 'pending'] as const;
+export type InvitationStatus = typeof invitationStatus[number];
 
 /** Type of Invitation depending of its purpose. */
 export type InvitationType = 'attendEvent' | 'joinOrganization';

--- a/libs/invitation/src/lib/+state/invitation.service.ts
+++ b/libs/invitation/src/lib/+state/invitation.service.ts
@@ -15,6 +15,8 @@ import { getCurrentApp } from '@blockframes/utils/apps';
 @Injectable({ providedIn: 'root' })
 @CollectionConfig({ path: 'invitations' })
 export class InvitationService extends CollectionService<InvitationState> {
+  private isInvitationToJoinOrgExist = this.functions.httpsCallable('isInvitationToJoinOrgExist');
+
   constructor(
     store: InvitationStore,
     private authQuery: AuthQuery,
@@ -56,8 +58,7 @@ export class InvitationService extends CollectionService<InvitationState> {
 
   /** Return true if there is already a pending invitation for a list of users */
   public async orgInvitationExists(userEmails: string[]): Promise<boolean> {
-    const f = this.functions.httpsCallable('isInvitationToJoinOrgExisted');
-    return f(userEmails).toPromise();
+    return this.isInvitationToJoinOrgExist(userEmails).toPromise();
   }
 
   public isInvitationForMe(invitation: Invitation): boolean {

--- a/libs/invitation/src/lib/+state/invitation.service.ts
+++ b/libs/invitation/src/lib/+state/invitation.service.ts
@@ -56,14 +56,8 @@ export class InvitationService extends CollectionService<InvitationState> {
 
   /** Return true if there is already a pending invitation for a list of users */
   public async orgInvitationExists(userEmails: string[]): Promise<boolean> {
-    const orgId = this.authQuery.orgId;
-    const orgInvitations = await this.getValue(ref => ref.where('mode', '==', 'invitation')
-      .where('type', '==', 'joinOrganization')
-      .where('fromOrg.id', '==', orgId));
-
-    return orgInvitations.some(
-      invitation => userEmails.includes(invitation.toUser.email) && invitation.status === 'pending'
-    );
+    const f = this.functions.httpsCallable('isInvitationToJoinOrgExisted');
+    return f(userEmails).toPromise();
   }
 
   public isInvitationForMe(invitation: Invitation): boolean {

--- a/libs/invitation/src/lib/+state/invitation.service.ts
+++ b/libs/invitation/src/lib/+state/invitation.service.ts
@@ -58,7 +58,7 @@ export class InvitationService extends CollectionService<InvitationState> {
 
   /** Return true if there is already a pending invitation for a list of users */
   public async orgInvitationExists(userEmails: string[]): Promise<boolean> {
-    return this.isInvitationToJoinOrgExist(userEmails).toPromise();
+    return await this.isInvitationToJoinOrgExist(userEmails).toPromise();
   }
 
   public isInvitationForMe(invitation: Invitation): boolean {

--- a/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
+++ b/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
@@ -56,14 +56,15 @@ export class MemberAddComponent {
       this._isSending.next(true);
       const emails = this.form.value;
       const invitationsExist = await this.invitationService.orgInvitationExists(emails);
-      if (invitationsExist) throw new Error('You already send an invitation to one or more of these users');
+      console.log(invitationsExist)
+      if (invitationsExist) throw new Error('There is already invitation existing for one or more of these users');
       await this.invitationService.invite('user', emails).from('org', this.org).to('joinOrganization', this.org.id);
-      this.snackBar.open('Your invitation was sent', 'close', { duration: 2000 });
+      this.snackBar.open('Your invitation was sent', 'close', { duration: 5000 });
       this._isSending.next(false);
       this.form.reset();
     } catch (error) {
       this._isSending.next(false);
-      this.snackBar.open(error.message, 'close', { duration: 2000 });
+      this.snackBar.open(error.message, 'close', { duration: 5000 });
     }
   }
 }

--- a/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
+++ b/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
@@ -56,7 +56,6 @@ export class MemberAddComponent {
       this._isSending.next(true);
       const emails = this.form.value;
       const invitationsExist = await this.invitationService.orgInvitationExists(emails);
-      console.log(invitationsExist)
       if (invitationsExist) throw new Error('There is already invitation existing for one or more of these users');
       await this.invitationService.invite('user', emails).from('org', this.org).to('joinOrganization', this.org.id);
       this.snackBar.open('Your invitation was sent', 'close', { duration: 5000 });

--- a/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
+++ b/libs/organization/src/lib/organization/components/member-add/member-add.component.ts
@@ -56,7 +56,7 @@ export class MemberAddComponent {
       this._isSending.next(true);
       const emails = this.form.value;
       const invitationsExist = await this.invitationService.orgInvitationExists(emails);
-      if (invitationsExist) throw new Error('There is already invitation existing for one or more of these users');
+      if (invitationsExist) throw new Error('There is already an invitation existing for one or more of these users');
       await this.invitationService.invite('user', emails).from('org', this.org).to('joinOrganization', this.org.id);
       this.snackBar.open('Your invitation was sent', 'close', { duration: 5000 });
       this._isSending.next(false);


### PR DESCRIPTION
Here is the problem :
when an admin invite user to join org, then remove the invitation, and invite again the same user, there is only one email sent to the user to invite him on the platform, but 2 invitations were sent.
This is because we don't remove the user in the authentication part when we delete the first invitation, so the second email isn't sent correctly.

I create a backend function when an invitation is removed to delete also the user in the authentication part IF the user hasn't orgId already (that would mean he joined an other org or create his own) and if there is no other invitation (if 2 organizations sent him an invitation, we don't want to delete his account if one of the org cancel its invitation).

I'm opened to more improvement and in case I didn't think about an other scenario.

Fix #2638 
Fix #739 