### PR TITLE
Fix 4585: wrong image shown

### DIFF
--- a/libs/media/src/lib/directives/image-reference/image-reference.directive.ts
+++ b/libs/media/src/lib/directives/image-reference/image-reference.directive.ts
@@ -33,7 +33,6 @@ export class ImageReferenceDirective implements OnInit, OnDestroy {
 
   /** the image to display */
   @Input() set ref(image: string) {
-    if (!image) return;
     this.ref$.next(image);
   }
 
@@ -119,13 +118,13 @@ export class ImageReferenceDirective implements OnInit, OnDestroy {
 
         // Next subscription change will be delayed
         _delay = this.delay;
-        this.cdr.markForCheck()
       } else {
 
         // asset
         this.srcset = getAssetPath(asset, theme, this.type);
         this.src = this.srcset;
       }
+      this.cdr.markForCheck()
     });
   }
 


### PR DESCRIPTION
Fix #4585 

Couldn't find any bugs caused by removing the `if (!image) return` line. Also can't find why it was added in the first place. Do you know potential bugs?