### PR TITLE
4765 change production country to origin country

### DIFF
--- a/libs/movie/src/lib/movie/components/title-features/title-features.component.ts
+++ b/libs/movie/src/lib/movie/components/title-features/title-features.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { Movie } from '@blockframes/movie/+state';
-import { productionStatus, contentType, getISO3166TerritoryFromSlug, languages, territoriesISOA2 } from '@blockframes/utils/static-model';
+import { productionStatus, contentType, getISO3166TerritoryFromSlug, languages } from '@blockframes/utils/static-model';
 import { formatRunningTime } from "@blockframes/movie/pipes/running-time.pipe";
 
 interface TitleFeature {
@@ -15,19 +15,12 @@ function createTitleFeatureView(movie: Movie): TitleFeature[] {
   const convertedOriginalLanguages = originalLanguages.map(language => languages[language]);
   const convertedOriginCountries = originCountries.map(country => getISO3166TerritoryFromSlug(country)).map(country => country.iso_a2);
   const statusLabel = productionStatus[movie.productionStatus];
-  const productionCountries = [];
-  for (const company of stakeholders.productionCompany) {
-    for (const country of company.countries) {
-      if (!productionCountries.includes(territoriesISOA2[country])) productionCountries.push(territoriesISOA2[country]);
-    }
-  }
   const features = [
     contentType[movie.contentType],
     convertedRunTime,
     convertedGenres,
-    productionCountries,
-    convertedOriginalLanguages,
     convertedOriginCountries,
+    convertedOriginalLanguages,
     statusLabel
   ]
   return features.map(feature => {

--- a/libs/movie/src/lib/movie/pipes/movie-feature.pipe.ts
+++ b/libs/movie/src/lib/movie/pipes/movie-feature.pipe.ts
@@ -9,7 +9,7 @@ import { formatRunningTime } from "@blockframes/movie/pipes/running-time.pipe";
 })
 export class MovieFeaturePipe implements PipeTransform {
   transform(value: Movie): string {
-    const { contentType, runningTime, genres, originalLanguages, release, stakeholders } = value;
+    const { contentType, runningTime, genres, originalLanguages, originCountries, release } = value;
 
     let displayedGenres = '';
     if (genres.length > 0) displayedGenres += staticGenres[genres[0]];
@@ -19,25 +19,15 @@ export class MovieFeaturePipe implements PipeTransform {
     if (originalLanguages.length > 0) displayedLanguages += languages[originalLanguages[0]];
     if (originalLanguages.length > 1) displayedLanguages += ', ...';
 
-    let displayedProductionCountries = '';
-    if (!!stakeholders) {
-      const productionCountries = [];
-      for (const company of stakeholders.productionCompany) {
-        for (const country of company.countries) {
-          if (!productionCountries.includes(country)) productionCountries.push(country);
-        }
-      }
-      productionCountries.forEach((country, index) => {
-        if (index === 0) displayedProductionCountries += territoriesISOA2[country];
-        if (index === 1) displayedProductionCountries += `, ${territoriesISOA2[country]}`;
-        if (index === 2) displayedProductionCountries += `, ...`;
-      })
-    }
+    let displayedCountries = '';
+    if (originCountries.length > 0) displayedCountries += territoriesISOA2[originCountries[0]];
+    if (originCountries.length > 1) displayedCountries += `, ${territoriesISOA2[originCountries[1]]}`;
+    if (originCountries.length > 2) displayedCountries += ', ...';
 
     return [
       contentType ? contentType[contentType] : '',
       displayedGenres,
-      displayedProductionCountries,
+      displayedCountries,
       displayedLanguages,
       release.year,
       formatRunningTime(runningTime, false)

--- a/libs/utils/src/lib/static-model/static-model.ts
+++ b/libs/utils/src/lib/static-model/static-model.ts
@@ -1926,8 +1926,8 @@ export function getISO3166TerritoryFromSlug(slug: Territory) {
   }
   return {
     [territory]: territory,
-    'iso-a2': territoriesISOA2[territory],
-    'iso-3': territoriesISOA3[territory],
+    'iso_a2': territoriesISOA2[territory],
+    'iso_3': territoriesISOA3[territory],
     'numCode': territoriesNUMCODE[territory],
     'fr': territoriesFR[territory],
   }

--- a/libs/utils/src/lib/static-model/static-model.ts
+++ b/libs/utils/src/lib/static-model/static-model.ts
@@ -1926,9 +1926,9 @@ export function getISO3166TerritoryFromSlug(slug: Territory) {
   }
   return {
     [territory]: territory,
-    'iso_a2': territoriesISOA2[territory],
-    'iso_3': territoriesISOA3[territory],
-    'numCode': territoriesNUMCODE[territory],
-    'fr': territoriesFR[territory],
+    iso_a2: territoriesISOA2[territory],
+    iso_3: territoriesISOA3[territory],
+    numCode: territoriesNUMCODE[territory],
+    fr: territoriesFR[territory],
   }
 }


### PR DESCRIPTION
Fix issue #4765 
Original issue said 'production country' which is something else than 'origin country'.

@phpgeekfr should this be merged into release/2.1 directly or does this go via a different branch? There will probably be more fixes this week since Vincent made a list for fixes: https://github.com/blockframes/blockframes/issues/4767