### PR TITLE
4551 Fix intercom white background color

### DIFF
--- a/styles/style.scss
+++ b/styles/style.scss
@@ -2,7 +2,6 @@
 
 
 :root {
-  color-scheme: light dark; // @dev check doc https://web.dev/color-scheme/
   --layout-margin: 24px;
   --toolbarHeight: 80px;
 }
@@ -13,7 +12,7 @@
 
 html{
   height: 100vh;
-}
+} 
 
 body {
   margin: 0;


### PR DESCRIPTION
Fix issue #4551
`color-scheme: light dark;` was also applied to iframe which causes the background color to be set according to UA (white)