### PR TITLE
4716 deny access to draft or refused titles if no edit rights

### DIFF
--- a/apps/rules/src/tests/firestore/fixtures/data.ts
+++ b/apps/rules/src/tests/firestore/fixtures/data.ts
@@ -40,6 +40,9 @@ export const testFixture = {
   'orgs/O001': {
     status: 'accepted', //belongs to O001
   },
+  'orgs/O002': {
+    status: 'accepted'
+  },
 
   //Users Collection
   'users/uid-bfAdmin': {
@@ -70,6 +73,11 @@ export const testFixture = {
     email: 'tom@no-org.com',
     uid: 'uid-peeptom',
   },
+  'users/uid-user3': {
+    email: 'u3@cascade8.com',
+    uid: 'uid-user3',
+    orgId: 'O002'
+  },
 
   //Blockframes Admin
   'blockframesAdmin/uid-bfAdmin': {},
@@ -83,12 +91,22 @@ export const testFixture = {
     'distributionRights/DR001': {
       id: 'DR001',
     },
+    storeConfig: {
+      appAccess: { festival: true },
+      status: 'accepted'
+    },
+    orgIds: ['O001']
   },
   'movies/MI-0d7': {
     id: 'MI-0d7',
     title: {
       original: 'UnitTest Eraser',
     },
+    storeConfig: {
+      appAccess: { festival: true },
+      status: 'accepted'
+    },
+    orgIds: ['O001']
   },
   'movies/MI-077': {
     id: 'MI-077',
@@ -100,8 +118,11 @@ export const testFixture = {
       status: 'draft',
     },
     note: '',
+    orgIds: ['O001']
   },
 
+
+  // Events
   'events/E001': {
     id: 'E001',
   },

--- a/apps/rules/src/tests/firestore/movies.spec.ts
+++ b/apps/rules/src/tests/firestore/movies.spec.ts
@@ -121,7 +121,7 @@ describe('Movies Rules Tests', () => {
       const movieRef = db.doc(`movies/${draftMovieId}`);
       await assertFails(movieRef.delete());
     });
-  });
+  }); 
 
   describe('With User not in org', () => {
     const newMovieId = 'MI-007';
@@ -149,6 +149,24 @@ describe('Movies Rules Tests', () => {
     test("user without valid org shouldn't be able to delete movie title", async () => {
       const movieRef = db.doc(`movies/${draftMovieId}`);
       await assertFails(movieRef.delete());
+    });
+  });
+
+  // User not owner of movie
+  describe('User without rights to edit movie', () => {
+    const draftMovieId = 'MI-077';
+    
+    beforeAll(async () => {
+      db = await initFirestoreApp(projectId, 'firestore.rules', testFixture, {
+        uid: 'uid-user3'
+      })
+    });
+
+    afterAll(() => Promise.all(apps().map((app) => app.delete())));
+
+    test("user without rights to edit movie shouldn't be able to read movie title when in draft", async () => {
+      const movieRef = db.doc(`movies/${draftMovieId}`);
+      await assertFails(movieRef.get());
     });
   });
 });

--- a/apps/rules/src/tests/firestore/movies.spec.ts
+++ b/apps/rules/src/tests/firestore/movies.spec.ts
@@ -158,7 +158,6 @@ describe('Movies Rules Tests', () => {
     });
   });
 
-  // User not owner of movie
   describe('User without rights to edit movie', () => {
     const draftMovieId = 'MI-077';
     const acceptedMovieId = 'M001';

--- a/apps/rules/src/tests/firestore/movies.spec.ts
+++ b/apps/rules/src/tests/firestore/movies.spec.ts
@@ -15,7 +15,8 @@ describe('Movies Rules Tests', () => {
 
   describe('With User in org', () => {
     const newMovieId = 'MI-007';
-    const existMovieId = 'MI-077';
+    const existMovieInDraft = 'MI-077';
+    const existMovieAccepted = 'M001';
     const storeConfig = {
       status: <StoreStatus>'draft',
       storeType: <StoreType>'Library',
@@ -29,10 +30,15 @@ describe('Movies Rules Tests', () => {
     afterAll(() => Promise.all(apps().map((app) => app.delete())));
 
     describe('Read Movie', () => {
-      test('should be able to read movie', async () => {
-        const movieRef = db.doc('movies/M001');
+      test('should be able to read movie with status draft', async () => {
+        const movieRef = db.doc(`movies/${existMovieInDraft}`);
         await assertSucceeds(movieRef.get());
       });
+
+      test('should be able to read movie with status accepted', async () => {
+        const movieRef = db.doc(`movies/${existMovieAccepted}`);
+        await assertSucceeds(movieRef.get());
+      })
 
       test('should be able to read movie distribution rights', async () => {
         const movieDRRef = db.doc('movies/M001/distributionRights/DR001');
@@ -93,14 +99,14 @@ describe('Movies Rules Tests', () => {
         ['storeConfig', { appAccess: { festival: {} } }],
       ];
       test.each(fields)("updating restricted '%s' field shouldn't be able", async (key, value) => {
-        const movieRef = db.doc(`movies/${existMovieId}`);
+        const movieRef = db.doc(`movies/${existMovieInDraft}`);
         const details = {};
         details[key] = value;
         await assertFails(movieRef.update(details));
       });
 
       test('user valid org, updating unrestricted field should be able', async () => {
-        const movieRef = db.doc(`movies/${existMovieId}`);
+        const movieRef = db.doc(`movies/${existMovieInDraft}`);
         const movieDetailsOther = { notes: 'update in unit-test' };
         await assertSucceeds(movieRef.update(movieDetailsOther));
       });
@@ -121,7 +127,7 @@ describe('Movies Rules Tests', () => {
       const movieRef = db.doc(`movies/${draftMovieId}`);
       await assertFails(movieRef.delete());
     });
-  }); 
+  });
 
   describe('With User not in org', () => {
     const newMovieId = 'MI-007';
@@ -155,6 +161,7 @@ describe('Movies Rules Tests', () => {
   // User not owner of movie
   describe('User without rights to edit movie', () => {
     const draftMovieId = 'MI-077';
+    const acceptedMovieId = 'M001';
     
     beforeAll(async () => {
       db = await initFirestoreApp(projectId, 'firestore.rules', testFixture, {
@@ -167,6 +174,11 @@ describe('Movies Rules Tests', () => {
     test("user without rights to edit movie shouldn't be able to read movie title when in draft", async () => {
       const movieRef = db.doc(`movies/${draftMovieId}`);
       await assertFails(movieRef.get());
+    });
+
+    test("user without rights to edit movie should be able to read movie title when accepted", async () => {
+      const movieRef = db.doc(`movies/${acceptedMovieId}`);
+      await assertSucceeds(movieRef.get())
     });
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -285,7 +285,7 @@ service cloud.firestore {
 
     match /movies/{movieId} {
     	// @TODO (#2049) We allow all movie read as Archipel Content is a catalog of public movies.
-      allow read: if userHasValidOrg() && notInMaintenance();
+      allow read: if userHasValidOrg() && notInMaintenance() && ( existingData().storeConfig.status == 'accepted' || isAllowedToUpdateMovie() );
       allow create: if userHasValidOrg()
         && isRequestFieldValueEqualTo(['storeConfig', 'status'], 'draft')
       	&& isRequestFieldValueEqualToOrNotSetted(['id'], movieId)

--- a/firestore.rules
+++ b/firestore.rules
@@ -285,7 +285,11 @@ service cloud.firestore {
 
     match /movies/{movieId} {
     	// @TODO (#2049) We allow all movie read as Archipel Content is a catalog of public movies.
-      allow read: if userHasValidOrg() && notInMaintenance() && ( existingData().storeConfig.status == 'accepted' || isAllowedToUpdateMovie() );
+      allow read: if userHasValidOrg()
+        && notInMaintenance()
+        && ( existingData().storeConfig.status == 'accepted'
+         || ( isOrgMember(userOrgId()) && orgCan('canUpdate', userOrgId(), existingData().id) )
+        )
       allow create: if userHasValidOrg()
         && isRequestFieldValueEqualTo(['storeConfig', 'status'], 'draft')
       	&& isRequestFieldValueEqualToOrNotSetted(['id'], movieId)


### PR DESCRIPTION
Fix issue #4716 

Users are automatically redirected to homepage if they try to access the title page. This is because they can't read the movie doc due to the rules and therefore they can't pass the guard