### PR TITLE
4800 workaround AngularFire bug

### DIFF
--- a/libs/media/src/lib/file/upload-widget/upload-widget.component.html
+++ b/libs/media/src/lib/file/upload-widget/upload-widget.component.html
@@ -59,7 +59,7 @@
 
               <!-- Error -->
               <ng-template ngSwitchCase="canceled">
-                <button mat-icon-button (click)="remove(i)">
+                <button mat-icon-button (click)="remove(i, true)">
                   <mat-icon svgIcon="cancel"></mat-icon>
                 </button>
               </ng-template>

--- a/libs/media/src/lib/file/upload-widget/upload-widget.component.ts
+++ b/libs/media/src/lib/file/upload-widget/upload-widget.component.ts
@@ -42,9 +42,9 @@ export class UploadWidgetComponent {
     task.cancel();
   }
 
-  remove(index: number) {
+  remove(index: number, removeReference = false) {
     const tasks = this.tasks.value;
-    this.removeReference(tasks[index]);
+    if (removeReference) this.removeReference(tasks[index]);
     tasks.splice(index, 1);
     this.tasks.value = tasks;
   }


### PR DESCRIPTION
Workaround for #4800

AngularFireUploadTask state is not updated with the latest state of the firebase.UploadTask. Therefore we use a workaround to get the state directly from firebase UploadTask until AngularFire fixes this bug.

This bug exists since update to firebase version 8 and higher.


Also, fixed the bug where it would remove the file when clicking on the button of completed uploads.