### PR TITLE
fix rules for reading multiple movies

### DIFF
--- a/apps/rules/src/tests/firestore/movies.spec.ts
+++ b/apps/rules/src/tests/firestore/movies.spec.ts
@@ -129,7 +129,7 @@ describe('Movies Rules Tests', () => {
     });
   });
 
-  describe('With User not in org', () => {
+  describe('With User not belonging to any org', () => {
     const newMovieId = 'MI-007';
     const draftMovieId = 'MI-0d7';
     const newMovieDetails = { id: `${newMovieId}` };
@@ -158,7 +158,7 @@ describe('Movies Rules Tests', () => {
     });
   });
 
-  describe('User without rights to edit movie', () => {
+  describe('User not belonging to organization in movies.orgIds', () => {
     const draftMovieId = 'MI-077';
     const acceptedMovieId = 'M001';
     

--- a/firestore.rules
+++ b/firestore.rules
@@ -288,7 +288,7 @@ service cloud.firestore {
       allow read: if userHasValidOrg()
         && notInMaintenance()
         && ( existingData().storeConfig.status == 'accepted'
-         || ( isOrgMember(userOrgId()) && userOrgId() in existingData().orgIds ) 
+         || ( isOrgMember(userOrgId()) && ( userOrgId() in existingData().orgIds )) 
         )
       allow create: if userHasValidOrg()
         && isRequestFieldValueEqualTo(['storeConfig', 'status'], 'draft')

--- a/firestore.rules
+++ b/firestore.rules
@@ -288,7 +288,7 @@ service cloud.firestore {
       allow read: if userHasValidOrg()
         && notInMaintenance()
         && ( existingData().storeConfig.status == 'accepted'
-         || ( isOrgMember(userOrgId()) && orgCan('canUpdate', userOrgId(), existingData().id) )
+         || ( isOrgMember(userOrgId()) && userOrgId() in existingData().orgIds ) 
         )
       allow create: if userHasValidOrg()
         && isRequestFieldValueEqualTo(['storeConfig', 'status'], 'draft')
@@ -526,7 +526,7 @@ service cloud.firestore {
 		// Parameter "action" can either be "canCreate", "canRead", "canUpdate" or "canDelete"
     function orgCan(action, orgId, docId) {
       return (getDocumentPermissions(orgId, docId).ownerId == orgId)
-        || (getDocumentPermissions(orgId, docId).admin == true)
+        || (getDocumentPermissions(orgId, docId).isAdmin == true)
         || (getDocumentPermissions(orgId, docId)[action] == true)
         || (isOrgAdmin(orgId) && orgId == docId);
     }


### PR DESCRIPTION
This fixes rules update #4799 .

The  rule change introduced in #4799 is causing permissions errors when we attempt to fetch movies in `/c/o/dashboard/title` . The query should have worked since every movie document had correct permissions and if we attempt to fetch movies one by one, no issue with current rules. So ... My guess is that ` orgCan('canUpdate', userOrgId(), existingData().id) )` for "n" movies was making to much operation and we hit the limit..
Using `userOrgId() in existingData().orgIds`, no problem (and it fit the actual query in front  `fromOrg = (orgId: string): QueryFn => ref => ref.where('orgIds', 'array-contains', orgId);`).  But only users belonging to org that is in movie.orgIds will be allowed, if user from another org but with "canRead" permissions for this movie document will not be allowed. I don't think this is a problem, we don't give access to draft movies to users that are not belonging to our org.

@RemcoSimonides Can you confirm that this new rule is ok for you ? Do you also think that the problem for reading multiple movies is related to operations limit or another thing that I missed?  


@xmano  Is it possible to create an unit test to read multiples movies (with accepted and draft status, all movies belonging to user's org) and check it we can read all at once ? Like this we could try the previous rules set to check if it falls.  But I don't know if emulator have the same operation limits than real firestore while evaluating rules. Do you have an idea?