### PR TITLE
Event email notif

### DIFF
--- a/apps/backend-functions/src/internals/invitations/events.ts
+++ b/apps/backend-functions/src/internals/invitations/events.ts
@@ -169,7 +169,7 @@ async function onInvitationToAnEventAccepted({
       const notification = createNotification({
         toUserId,
         docId: eventId,
-        type: 'invitationToAttendEventAccepted' //? Need a new type of notification ?
+        type: 'invitationToAttendEventAccepted'
       });
 
       if (!!toUser) {

--- a/apps/backend-functions/src/internals/invitations/events.ts
+++ b/apps/backend-functions/src/internals/invitations/events.ts
@@ -157,16 +157,6 @@ async function onInvitationToAnEventAccepted({
     if (!!toUser) {
       notification.user = toUser; // The subject that have accepted the invitation
     } else if (!!toOrg) {
-      // @TODO (#2848) forcing to festival since invitations to events are only on this one
-      const appKey: App = 'festival';
-      const org = await getDocument<OrganizationDocument>(`orgs/${toOrg.id}`);
-      const event = await getDocument<EventDocument<EventMeta>>(`events/${eventId}`);
-      const eventData: EventEmailData = getEventEmailData(event);
-      const url = applicationUrl[appKey];
-
-      const templateRequest = requestToAttendEventFromUserAccepted(fromUser, orgName(org), eventData, url);
-      await sendMailFromTemplate(templateRequest, appKey).catch(e => console.warn(e.message));
-
       notification.organization = toOrg; // The subject that have accepted the invitation
     } else {
       throw new Error('Did not found invitation recipient.');
@@ -179,13 +169,12 @@ async function onInvitationToAnEventAccepted({
       const notification = createNotification({
         toUserId,
         docId: eventId,
-        type: 'invitationToAttendEventAccepted'
+        type: 'invitationToAttendEventAccepted' //? Need a new type of notification ?
       });
 
       if (!!toUser) {
         notification.user = toUser; // The subject that have accepted the invitation
       } else if (!!toOrg) {
-
         notification.organization = toOrg; // The subject that have accepted the invitation
       } else {
         throw new Error('Did not found invitation recipient.');

--- a/apps/backend-functions/src/orgs.ts
+++ b/apps/backend-functions/src/orgs.ts
@@ -141,14 +141,7 @@ export async function onOrganizationUpdate(change: Change<FirebaseFirestore.Docu
   // Deploy org's smart-contract
   const becomeAccepted = before.status === 'pending' && after.status === 'accepted';
 
-  const { userIds } = before as OrganizationDocument;
-  const admin = await getDocument<PublicUser>(`users/${userIds[0]}`);
   if (becomeAccepted) {
-    // send email to let the org admin know that the org has been accepted
-    const urlToUse = await getAppUrl(after);
-    const appKey = await getOrgAppKey(after);
-    await sendMailFromTemplate(organizationWasAccepted(admin.email, admin.firstName, urlToUse), appKey).catch(e => console.warn(e.message));
-
     // Send a notification to the creator of the organization
     const notification = createNotification({
       // At this moment, the organization was just created, so we are sure to have only one userId in the array


### PR DESCRIPTION
Move email sending of `invitationToAttendEventAccepted`, `organizationAcceptedByArchipelContent` notifications and prepare one for `requestToAttendEventSent` notification, but need a template from sendgrid.