### PR TITLE
Unsubscribe group

### DIFF
--- a/apps/backend-functions/src/internals/email.ts
+++ b/apps/backend-functions/src/internals/email.ts
@@ -14,19 +14,19 @@ import { EmailJSON } from '@sendgrid/helpers/classes/email-address';
  *
  * Handles development mode: logs a warning when no sendgrid API key is provided.
  */
-export async function sendMail({ to, subject, text }: EmailRequest, from: EmailJSON = getSendgridFrom(), unsubId?: number): Promise<any> {
+export async function sendMail({ to, subject, text }: EmailRequest, from: EmailJSON = getSendgridFrom(), groupId?: number): Promise<any> {
   const msg: MailDataRequired = {
     from,
     to,
     subject,
     text,
-    asm: { groupId: unsubId }
+    asm: { groupId: groupId }
   };
 
   return send(msg);
 }
 
-export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequest, app: App, unsubId?: number): Promise<any> {
+export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequest, app: App, groupId?: number): Promise<any> {
   const from: EmailJSON = getSendgridFrom(app);
   const { label } = getAppName(app);
   const appText = appDescription[app];
@@ -38,7 +38,7 @@ export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequ
     to,
     templateId,
     dynamicTemplateData: { ...data, app: appMailSettings, from },
-    asm: { groupId: unsubId }
+    asm: { groupId: groupId }
   };
 
   return send(msg);

--- a/apps/backend-functions/src/internals/email.ts
+++ b/apps/backend-functions/src/internals/email.ts
@@ -14,18 +14,19 @@ import { EmailJSON } from '@sendgrid/helpers/classes/email-address';
  *
  * Handles development mode: logs a warning when no sendgrid API key is provided.
  */
-export async function sendMail({ to, subject, text }: EmailRequest, from: EmailJSON = getSendgridFrom()): Promise<any> {
+export async function sendMail({ to, subject, text }: EmailRequest, from: EmailJSON = getSendgridFrom(), unsubId?: number): Promise<any> {
   const msg: MailDataRequired = {
     from,
     to,
     subject,
     text,
+    asm: { groupId: unsubId }
   };
 
   return send(msg);
 }
 
-export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequest, app: App): Promise<any> {
+export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequest, app: App, unsubId?: number): Promise<any> {
   const from: EmailJSON = getSendgridFrom(app);
   const { label } = getAppName(app);
   const appText = appDescription[app];
@@ -36,7 +37,8 @@ export function sendMailFromTemplate({ to, templateId, data }: EmailTemplateRequ
     from,
     to,
     templateId,
-    dynamicTemplateData: { ...data, app: appMailSettings, from }
+    dynamicTemplateData: { ...data, app: appMailSettings, from },
+    asm: { groupId: unsubId }
   };
 
   return send(msg);

--- a/apps/backend-functions/src/notification.ts
+++ b/apps/backend-functions/src/notification.ts
@@ -30,7 +30,7 @@ import { App, applicationUrl } from '@blockframes/utils/apps';
 // @TODO (#2848) forcing to festival since invitations to events are only on this one
 const eventAppKey: App = 'festival';
 // This is for letting user unsubscribe from every email except the critical ones as reset password.
-const unsubscribeId = unsubscribeGroupIds.allExceptCriticals
+const unsubscribeId = unsubscribeGroupIds.allExceptCriticals;
 
 /** Takes one or more notifications and add them on the notifications collection */
 export async function triggerNotifications(notifications: NotificationDocument[]): Promise<any> {

--- a/apps/backend-functions/src/templates/ids.ts
+++ b/apps/backend-functions/src/templates/ids.ts
@@ -60,3 +60,7 @@ export const templateIds = {
     accepted: 'd-bfcf2760bcb7484ab55f864a59331d26'
   }
 }
+
+export const unsubscribeGroupIds = {
+  allExceptCriticals: 15120
+}


### PR DESCRIPTION
Add a new parameter to let us send to sendgrid an group id. It will allow us to split email into several group and users will be able to unsubscribe to some group or every group depending on which emails they want to receive.

Close #4710 