### PR TITLE
small fixes for e2e tests

### DIFF
--- a/apps/backend-ops/src/generate-fixtures.ts
+++ b/apps/backend-ops/src/generate-fixtures.ts
@@ -39,7 +39,6 @@ async function generateUsers() {
 
 /**
  * This function will generate `tools/fixtures/movies.json` from local Firestore
- * TODO: update movie fixture generator once model changes #3582
  */
 async function generateMovies() {
   console.log('Generating movie fixtures file from Firestore...');

--- a/apps/festival/festival-e2e/src/support/pages/dashboard/EventEditPage.ts
+++ b/apps/festival/festival-e2e/src/support/pages/dashboard/EventEditPage.ts
@@ -44,11 +44,11 @@ export default class EventEditPage {
   //set event access
   uncheckPrivate(isPublic: boolean = false) {
     if (!isPublic) {
-      cy.get('event-edit mat-slide-toggle[test-id=event-private]', { timeout: 3 * SEC })
+      cy.get('event-edit mat-checkbox[test-id=event-private]', { timeout: 3 * SEC })
         .find('input')
         .check({ force: true });
     } else {
-      cy.get('event-edit mat-slide-toggle[test-id=event-private]', { timeout: 3 * SEC })
+      cy.get('event-edit mat-checkbox[test-id=event-private]', { timeout: 3 * SEC })
         .find('input')
         .uncheck({ force: true });
     }

--- a/libs/event/src/lib/components/week/week.component.ts
+++ b/libs/event/src/lib/components/week/week.component.ts
@@ -137,7 +137,7 @@ export class CalendarWeekComponent {
     this.dialog.open(EventCreateComponent, { data, width: '650px' }).afterClosed()
       .subscribe(async ({ event } = {}) => {
         if (event) {
-          this.service.add(event);
+          await this.service.add(event);
           this.router.navigate([event.id, 'edit'], { relativeTo: this.route });
         } else {
           this.refresh(this.baseEvents);

--- a/libs/event/src/lib/form/edit-details/edit-details.component.html
+++ b/libs/event/src/lib/form/edit-details/edit-details.component.html
@@ -1,17 +1,17 @@
 <form [formGroup]="form" fxLayout="column">
   <mat-form-field appearance="outline">
     <mat-label>Title</mat-label>
-    <input matInput formControlName="title" />
+    <input matInput formControlName="title" test-id="event-title"/>
   </mat-form-field>
 
   <div fxLayout fxLayoutAlign="space-between center" fxLayoutGap="24px">
-    <mat-form-field fxFlex appearance="outline">
+    <mat-form-field fxFlex appearance="outline" test-id="event-start">
       <mat-label>Start</mat-label>
       <time-picker formControlName="start" [allDay]="form.value.allDay"></time-picker>
       <mat-error *ngIf="form.hasError('startOverEnd', 'start')">Start date must not be later than end date</mat-error>
     </mat-form-field>
     <span>to</span>
-    <mat-form-field fxFlex appearance="outline">
+    <mat-form-field fxFlex appearance="outline" test-id="event-end">
       <mat-label>End</mat-label>
       <time-picker formControlName="end" [allDay]="form.value.allDay"></time-picker>
       <mat-error *ngIf="form.hasError('startOverEnd', 'end')">End date must not be earlier than start date</mat-error>
@@ -19,8 +19,8 @@
   </div>
 
   <div fxLayout="column" fxLayoutGap="12px">
-    <mat-slide-toggle formControlName="allDay" color="primary">All day</mat-slide-toggle>
-    <mat-checkbox formControlName="isPrivate" color="primary">Accessible only on invitation (private event)</mat-checkbox>
+    <mat-slide-toggle test-id="all-day" formControlName="allDay" color="primary">All day</mat-slide-toggle>
+    <mat-checkbox test-id="event-private" formControlName="isPrivate" color="primary">Accessible only on invitation (private event)</mat-checkbox>
     <div fxLayout fxLayoutAlign="start center" fxLayoutGap="16px">
       <mat-checkbox formControlName="isSecret" color="primary">Do not show on Marketplace</mat-checkbox>
       <mat-icon svgIcon="info" matTooltip="Only people with a link can access your event"></mat-icon>


### PR DESCRIPTION
@xmano `Felicità` is still used but is in draft. Tests are falling here on my side. 
I did not had issue about no-organization-guard  