### PR TITLE
App access email

### DIFF
--- a/libs/organization/src/lib/organization/pages/request-access/request-access.component.html
+++ b/libs/organization/src/lib/organization/pages/request-access/request-access.component.html
@@ -8,6 +8,6 @@
     Please confirm your email to get access.
   </p>
   <p class="mat-body-2">PS : All your company members will also have an access to {{ appName }}.</p>
-  <button mat-flat-button color="primary" (click)="requestAccess()">Request Access</button>
+  <button mat-flat-button color="primary" (click)="requestAccess()" [disabled]="disabledRequest">Request Access</button>
   <button mat-button color="primary" (click)="refresh()">Refresh the page</button>
 </mat-card>

--- a/libs/organization/src/lib/organization/pages/request-access/request-access.component.ts
+++ b/libs/organization/src/lib/organization/pages/request-access/request-access.component.ts
@@ -18,6 +18,7 @@ export class OrgRequestAccessComponent implements OnInit {
   public org$ = this.orgQuery.selectActive();
   public orgId = this.orgQuery.getActiveId();
   public orgHasAccess$: Observable<boolean>;
+  public disabledRequest = false;
 
   constructor(
     private routerQuery: RouterQuery,
@@ -33,6 +34,7 @@ export class OrgRequestAccessComponent implements OnInit {
   }
 
   async requestAccess() {
+    this.disabledRequest = true;
     await this.orgService.requestToAccessToApp(this.app, this.orgId);
     this.snackBar.open('Your request to access to this platform has been sent.', 'close', { duration: 5000 });
   }


### PR DESCRIPTION
Remove a call to email function when org is updated.
- When an org is created, it sends an email to C8 admin to let them know a new organization is waiting their approval. CRM link is sent inside the email.
- An organization can ask a new access only if someone of the org connects to a wrong app, like for example, they have access to festival and an user connects on catalog. He will be stucked on the new request access page.
- C8 admin will received email only when an org is created and if an user clicks on the request access button on the request access page.
- We can change the appAccess of an org only on CRM. If we change it, we can choose to send email or not to the admin's org to let them know they have now a new access.

I don't think they can ask for access to a new app in an other way.