### PR TITLE
hide running time

### DIFF
--- a/libs/movie/src/lib/movie/form/main/main.component.html
+++ b/libs/movie/src/lib/movie/form/main/main.component.html
@@ -62,7 +62,7 @@
       </ng-container>
       <article flxLayout="row" fxLayoutAlign="start start" fxLayoutGap="24px">
 
-        <ng-container *ngIf="form.get('runningTime').get('status').value != 'tobedetermined'">
+        <ng-container *ngIf="form.get('runningTime').get('status').value !== 'tobedetermined'">
           <mat-form-field appearance="outline" fxFlex>
             <mat-label>{{ (form.contentType.value | typeDictionary).runningTime }}</mat-label>
             <input test-id="run-time" matInput type="number" name="runningTime"

--- a/libs/movie/src/lib/movie/form/main/main.component.html
+++ b/libs/movie/src/lib/movie/form/main/main.component.html
@@ -62,13 +62,15 @@
       </ng-container>
       <article flxLayout="row" fxLayoutAlign="start start" fxLayoutGap="24px">
 
-        <mat-form-field appearance="outline" fxFlex>
-          <mat-label>{{ (form.contentType.value | typeDictionary).runningTime }}</mat-label>
-          <input test-id="run-time" matInput type="number" name="runningTime"
-            [formControl]="form.runningTime.get('time')" min="0" required />
-          <mat-hint>In minutes.</mat-hint>
-          <mat-error>{{ (form.contentType.value | typeDictionary).runningTimeError }}</mat-error>
-        </mat-form-field>
+        <ng-container *ngIf="form.get('runningTime').get('status').value != 'tobedetermined'">
+          <mat-form-field appearance="outline" fxFlex>
+            <mat-label>{{ (form.contentType.value | typeDictionary).runningTime }}</mat-label>
+            <input test-id="run-time" matInput type="number" name="runningTime"
+              [formControl]="form.runningTime.get('time')" min="0" required />
+            <mat-hint>In minutes.</mat-hint>
+            <mat-error>{{ (form.contentType.value | typeDictionary).runningTimeError }}</mat-error>
+          </mat-form-field>
+        </ng-container>
 
         <ng-container *ngIf="form | hasStatus: ['development', 'shooting', 'post_production']">
           <static-select test-id="screening-status" scope="screeningStatus" [control]="form.runningTime.get('status')"


### PR DESCRIPTION
When the status of running time is 'to be determined', we hide the running time 'time'
![image](https://user-images.githubusercontent.com/48033264/109959062-46ad8a80-7ce7-11eb-9b19-67725c545ae2.png)
OR
![image](https://user-images.githubusercontent.com/48033264/109959073-4b723e80-7ce7-11eb-90fe-9d606b1a1779.png)
