### PR TITLE
KFH - fix mat-option in templateRef issue

### DIFF
--- a/libs/ui/src/lib/algolia/autocomplete/algolia-autocomplete.component.html
+++ b/libs/ui/src/lib/algolia/autocomplete/algolia-autocomplete.component.html
@@ -32,7 +32,12 @@
     <ng-template #default> {{ result | json }}</ng-template>
 
   </mat-option>
-  <mat-option style="display:none;"></mat-option> <!--If this line is removed, lastOptionRef is not displayed if there is no results-->
-  <ng-template *ngIf="lastOptionRef" [ngTemplateOutlet]="lastOptionRef" [ngTemplateOutletContext]="{ $implicit: (control.valueChanges | async) }"></ng-template>
+
+  <ng-container *ngIf="(control.valueChanges | async) as lastOptionValue">
+    <mat-option *ngIf="lastOptionRef && lastOptionValue.length >= 2" test-id="createNewOrgOption" [value]="lastOptionValue" >
+      <ng-template [ngTemplateOutlet]="lastOptionRef" [ngTemplateOutletContext]="{ $implicit: lastOptionValue }"></ng-template>
+    </mat-option>
+  </ng-container>
+
 
 </mat-autocomplete>

--- a/libs/ui/src/lib/algolia/autocomplete/algolia-autocomplete.component.html
+++ b/libs/ui/src/lib/algolia/autocomplete/algolia-autocomplete.component.html
@@ -32,7 +32,7 @@
     <ng-template #default> {{ result | json }}</ng-template>
 
   </mat-option>
-
+  <mat-option style="display:none;"></mat-option> <!--If this line is removed, lastOptionRef is not displayed if there is no results-->
   <ng-template *ngIf="lastOptionRef" [ngTemplateOutlet]="lastOptionRef" [ngTemplateOutletContext]="{ $implicit: (control.valueChanges | async) }"></ng-template>
 
 </mat-autocomplete>

--- a/libs/user/src/lib/auth/pages/identity/identity.component.html
+++ b/libs/user/src/lib/auth/pages/identity/identity.component.html
@@ -43,7 +43,7 @@
           </ng-template>
 
           <ng-template lastOptionRef let-value>
-            <mat-option test-id="createNewOrgOption" [value]="value" (click)="createOrg(value)">
+            <mat-option *ngIf="value && value.length >= 2" test-id="createNewOrgOption" [value]="value" (click)="createOrg(value)">
               <mat-icon svgIcon="add"></mat-icon> <span> CREATE {{ value }} COMPANY</span>
             </mat-option>
           </ng-template>

--- a/libs/user/src/lib/auth/pages/identity/identity.component.html
+++ b/libs/user/src/lib/auth/pages/identity/identity.component.html
@@ -43,9 +43,9 @@
           </ng-template>
 
           <ng-template lastOptionRef let-value>
-            <mat-option *ngIf="value && value.length >= 2" test-id="createNewOrgOption" [value]="value" (click)="createOrg(value)">
-              <mat-icon svgIcon="add"></mat-icon> <span> CREATE {{ value }} COMPANY</span>
-            </mat-option>
+            <div flexLayout="row" class="org-logo" fxLayoutGap="16px" fxLayoutAlign="start center" (click)="createOrg(value)">
+              <mat-icon svgIcon="add"></mat-icon> <span> CREATE "{{ value }}" COMPANY</span>
+            </div>
           </ng-template>
 
           <mat-label>Company Name</mat-label>


### PR DESCRIPTION
The hidden `<mat-option style="display:none;"></mat-option>` is added so `lastOptionRef` is displayed even if there is no results coming from Algolia

I hope there is a better solution than this.