### PR TITLE
fix #5312

### DIFF
--- a/libs/media/src/lib/file/explorer/explorer.model.ts
+++ b/libs/media/src/lib/file/explorer/explorer.model.ts
@@ -11,7 +11,6 @@ import { StorageFileForm } from "@blockframes/media/form/media.form";
 import { FormList } from "@blockframes/utils/form";
 import { StorageFile } from "@blockframes/media/+state/media.firestore";
 
-
 interface DirectoryBase {
   type: 'directory' | 'file' | 'image' | 'fileList' | 'imageList';
   /** Display Name use in the UI */
@@ -43,28 +42,29 @@ export interface FileDirectoryBase extends DirectoryBase {
   // hasFile: boolean | number;
 }
 
-export interface ImgDirectory extends FileDirectoryBase {
+interface ImgDirectory extends FileDirectoryBase {
   type: 'image';
   ratio: MediaRatioType;
   form: StorageFileForm | FormList<StorageFile>;
 }
 
-export interface FileDirectory extends FileDirectoryBase {
+interface FileDirectory extends FileDirectoryBase {
   type: 'file';
   accept: AllowedFileType;
   form: StorageFileForm | FormList<StorageFile>;
 }
 
-export interface FileListDirectory extends FileDirectoryBase {
+interface FileListDirectory extends FileDirectoryBase {
   type: 'fileList',
   form: FormList<StorageFile>;
   accept: AllowedFileType;
 }
 
-export interface ImgListDirectory extends FileDirectoryBase {
+interface ImgListDirectory extends FileDirectoryBase {
   type: 'imageList',
   form: FormList<StorageFile>;
   ratio: MediaRatioType;
+  accept: AllowedFileType;
 }
 
 export function getFormList(form: OrganizationForm | MovieForm, field: string) {
@@ -162,6 +162,7 @@ function titleDirectory(title: Movie): Directory {
       'still_photo': {
         name: 'Images',
         type: 'imageList',
+        accept: 'image',
         ratio: 'still',
         meta: ['movies', 'still_photo', title.id],
         form: getFormListStorage(title, 'movies', 'still_photo'),

--- a/libs/media/src/lib/file/file-uploader/file-uploader.component.ts
+++ b/libs/media/src/lib/file/file-uploader/file-uploader.component.ts
@@ -26,7 +26,6 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { getDeepValue } from '@blockframes/utils/pipes';
 import { boolean } from '@blockframes/utils/decorators/decorators';
-import { MovieVideoForm } from '@blockframes/movie/form/movie.form';
 
 type UploadState = 'waiting' | 'hovering' | 'ready' | 'file';
 

--- a/libs/media/src/lib/image/uploader/uploader.component.html
+++ b/libs/media/src/lib/image/uploader/uploader.component.html
@@ -1,4 +1,4 @@
-<input #fileUploader multiple hidden type="file" (change)="filesSelected($event.target.files)" />
+<input #fileUploader multiple hidden [accept]="accept" type="file" (change)="filesSelected($event.target.files)" />
 <section [ngSwitch]="step$ | async">
 
   <!-- Drop -->
@@ -8,7 +8,7 @@
     </button>
     <ng-content select="[title]"></ng-content>
     <p class="mat-body-2">{{ cropDimensions }}</p>
-    <p class="mat-caption">Accepted Formats: .jpg, .png</p>
+    <p class="mat-caption">Accepted Formats: {{ accept.join(', ') }}</p>
     <p class="mat-caption">Drag and drop a file here or <a (click)="fileUploader.click()">browse</a></p>
   </article>
 

--- a/libs/media/src/lib/image/uploader/uploader.component.ts
+++ b/libs/media/src/lib/image/uploader/uploader.component.ts
@@ -14,6 +14,7 @@ import { StorageFileForm } from '@blockframes/media/form/media.form';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { getDeepValue } from '@blockframes/utils/pipes';
 import { boolean } from '@blockframes/utils/decorators/decorators';
+import { allowedFiles } from '@blockframes/utils/utils';
 
 type CropStep = 'drop' | 'crop' | 'hovering' | 'show';
 
@@ -139,8 +140,8 @@ export class ImageUploaderComponent implements OnInit, OnDestroy {
   @Input() useFileUploader?= true;
   @Input() useDelete?= true;
 
-  @Input() types: string[] = ['image/jpeg', 'image/png'];
-  @Input() accept: string[] = ['.jpg', '.png'];
+  @Input() types: string[] = allowedFiles.image.mime;
+  @Input() accept: string[] = allowedFiles.image.extension;
 
   // listen to db changes to keep form up-to-date after an upload
   @Input() @boolean listenToChanges: boolean;

--- a/libs/utils/src/lib/utils.ts
+++ b/libs/utils/src/lib/utils.ts
@@ -39,7 +39,7 @@ export const allowedFiles: Record<AllowedFileType, FileDefinition> = {
   },
   image: {
     mime: ['image/jpeg', 'image/png', 'image/webp'],
-    extension: ['.jpg', 'jpeg', '.png', '.webp'],
+    extension: ['.jpg', '.jpeg', '.png', '.webp'],
   },
   video: {
     mime: ['video/x-msvideo', 'video/x-matroska', 'video/mp4', 'video/3gpp', 'video/quicktime', 'video/x-ms-wmv'],


### PR DESCRIPTION
fix #5312 

Also I noticed this in `libs/media/src/lib/file/explorer/explorer.component.html`
```
<!-- File List -->
<ng-template #fileList let-dir>
  <file-list-uploader [form]="dir.form" [meta]="dir.meta" [accept]="dir.accept"></file-list-uploader>
</ng-template>

<!-- Image List -->
<ng-template #imageList let-dir>
  <file-list-uploader [form]="dir.form" [meta]="dir.meta" [accept]="dir.accept"></file-list-uploader>
</ng-template>
```

both template are the same. I think there should be a special file list uploader component for images (with cropper) but there is none.