### PR TITLE
e2e ci err fix

### DIFF
--- a/apps/festival/festival-e2e/src/support/pages/marketplace/FestivalMarketplaceCalendarPage.ts
+++ b/apps/festival/festival-e2e/src/support/pages/marketplace/FestivalMarketplaceCalendarPage.ts
@@ -3,14 +3,15 @@ import { SEC } from '@blockframes/e2e/utils';
 
 export default class FestivalMarketplaceCalendarPage {
   constructor() {
-    cy.get('festival-event-calendar')
+    cy.get('festival-event-calendar', {timeout: 30 * SEC});
+    cy.wait(5 * SEC);
   }
 
   clickOnEvent(movieTitle: string) {
     cy.get('festival-marketplace main', {timeout: 3 * SEC})
       .scrollTo('top');
-    cy.wait(1 * SEC);
-    cy.get('festival-event-calendar event-card h5[test-id=movie-title]')
+    cy.wait(2 * SEC);
+    cy.get('festival-event-calendar event-card h5[test-id=movie-title]', {timeout: 30 * SEC})
       .contains(movieTitle).click();
     return new FestivalMarketplaceEventPage();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12623,14 +12623,15 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.6.0.tgz",
-      "integrity": "sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
+      "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "12.12.50",
         "@types/sinonjs__fake-timers": "^6.0.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.1.2",
@@ -12642,7 +12643,8 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
+        "dayjs": "^1.9.3",
+        "debug": "4.3.2",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
         "executable": "^4.1.1",
@@ -12656,10 +12658,10 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
-        "ramda": "~0.26.1",
+        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
         "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
@@ -12668,6 +12670,12 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.12.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
+          "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -12717,6 +12725,15 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "execa": {
@@ -12771,15 +12788,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          }
-        },
-        "log-symbols": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0"
           }
         },
         "npm-run-path": {
@@ -13835,9 +13843,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter2": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
-      "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+      "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
       "dev": true
     },
     "eventemitter3": {
@@ -26220,9 +26228,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
-      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
     "pretty-format": {
@@ -26891,9 +26899,9 @@
       }
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "commander": "^7.0.0",
     "concurrently": "^5.0.0",
     "cross-env": "^7.0.2",
-    "cypress": "^5.2.0",
+    "cypress": "^6.8.0",
     "cypress-wait-until": "^1.7.1",
     "dotenv": "8.2.0",
     "faker": "^5.1.0",


### PR DESCRIPTION
Test results were not generated properly due to ffmpeg video err. The Cypress 6.8.0 rel has fix for this.

![image](https://user-images.githubusercontent.com/8731418/112122241-153d2600-8be6-11eb-91f8-1be750ce297e.png)

For festival create screening test fail - added some wait and timeout to make the element available in more stable way.
