### PR TITLE
5410 fix avails filter

### DIFF
--- a/libs/ui/src/lib/static-autocomplete/group/group.component.html
+++ b/libs/ui/src/lib/static-autocomplete/group/group.component.html
@@ -11,7 +11,7 @@
 					</mat-checkbox>
 					<input matInput placeholder="Tap to filter" [formControl]="search" />
 					<mat-icon *ngIf="!search.value" svgIcon="search"></mat-icon>
-					<button *ngIf="search.value" mat-icon-button type="button" (click)="search.reset()">
+					<button *ngIf="search.value" mat-icon-button type="button" (click)="search.reset()" matTooltip="Clear text">
             <mat-icon svgIcon="refresh"></mat-icon>
           </button>
 				</header>

--- a/libs/ui/src/lib/static-autocomplete/group/group.component.html
+++ b/libs/ui/src/lib/static-autocomplete/group/group.component.html
@@ -4,7 +4,7 @@
 			<mat-label>
 				<ng-content select="mat-label"></ng-content>{{ required ? ' *' : '' }}
 			</mat-label>
-			<mat-select multiple [formControl]="form" [disabled]="disabled" (openedChange)="onOpen()">
+			<mat-select multiple [formControl]="form" [disabled]="disabled" (openedChange)="onOpen($event)">
 				<header>
 					<mat-checkbox color="primary" [indeterminate]="(value | getMode:groups) === 'indeterminate'"
 						[checked]="(value | getMode:groups) === 'checked'" (change)="checkAll($event.checked)">

--- a/libs/ui/src/lib/static-autocomplete/group/group.module.ts
+++ b/libs/ui/src/lib/static-autocomplete/group/group.module.ts
@@ -10,6 +10,7 @@ import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatIconModule } from "@angular/material/icon";
 import { MatDividerModule } from "@angular/material/divider";
 import { MatRippleModule } from "@angular/material/core";
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { ToLabelModule } from '@blockframes/utils/pipes';
 
 @NgModule({
@@ -24,7 +25,8 @@ import { ToLabelModule } from '@blockframes/utils/pipes';
     MatInputModule,
     MatDividerModule,
     MatRippleModule,
-    ToLabelModule
+    MatTooltipModule,
+    ToLabelModule,
   ],
   declarations: [StaticGroupComponent, GetModePipe, TriggerDisplayValue],
   exports: [StaticGroupComponent]

--- a/libs/utils/src/lib/form/forms/static-value.form.ts
+++ b/libs/utils/src/lib/form/forms/static-value.form.ts
@@ -20,5 +20,6 @@ export class FormStaticValueArray<S extends Scope> extends FormControl {
 
   reset(value: S[] = []) {
     super.reset(value);
+    this.markAsPristine();
   }
 }


### PR DESCRIPTION
Fix issue #5410 
- [x] the avails filters were cleared, but the btn remains active. If filters cleared need to change back to initiate state.
- [x] Not able to select various territories. When selection a new territory by typing, it deletes the one previously selected
- [x] Add a tooltip "Clear text" on the icon of the round arrow