### PR TITLE
5410 fix avails filter

### DIFF
--- a/libs/ui/src/lib/list/filter/list-filter.component.html
+++ b/libs/ui/src/lib/list/filter/list-filter.component.html
@@ -3,7 +3,7 @@
     <button mat-stroked-button [widgetTarget]="filterWidget" [color]="filter.color$ | async">
       {{filter.label}}
     </button>
-    <overlay-widget #filterWidget (openedChanged)="filter.active = $event">
+    <overlay-widget #filterWidget (openedChanged)="filter.active = $event" overflow="auto">
       <mat-card>
         <mat-card-header>
           <mat-card-title>{{ filter.label }}</mat-card-title>

--- a/libs/ui/src/lib/list/table-filter/table-filter.component.scss
+++ b/libs/ui/src/lib/list/table-filter/table-filter.component.scss
@@ -44,6 +44,10 @@ widget-card {
   max-height: 300px;
   max-width: 500px;
   overflow: auto;
+
+  mat-selection-list {
+    border-radius: unset;
+  }
 }
 
 // Name your column 'main' in order to make it span the full width of the column

--- a/libs/ui/src/lib/list/table-filter/table-filter.component.ts
+++ b/libs/ui/src/lib/list/table-filter/table-filter.component.ts
@@ -18,7 +18,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { Observable } from 'rxjs';
-import { startWith } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { getValue } from '@blockframes/utils/helpers';
 import { sortingDataAccessor, fallbackFilterPredicate } from '@blockframes/utils/table';
 import { ColRef } from '@blockframes/utils/directives/col-ref.directive';
@@ -85,6 +85,10 @@ export class TableFilterComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.columnFilter.patchValue(this.initialColumns);
     this.displayedColumns$ = this.columnFilter.valueChanges.pipe(
+      map(filter => {
+        if (!!this.colAction) filter.push(this.colAction.ref)
+        return filter
+      }),
       startWith(this.columnFilter.value)
     );
 

--- a/libs/ui/src/lib/overlay-widget/overlay-widget.component.ts
+++ b/libs/ui/src/lib/overlay-widget/overlay-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild, Directive, ViewEncapsulation, ViewContainerRef, OnDestroy, ElementRef, Output, EventEmitter } from '@angular/core';
+import { Component, TemplateRef, ViewChild, Directive, ViewEncapsulation, ViewContainerRef, OnDestroy, ElementRef, Output, EventEmitter, Input } from '@angular/core';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
@@ -18,16 +18,12 @@ const fade = trigger('fade', [
   selector: 'overlay-widget',
   template: `
   <ng-template #ref>
-    <div tabindex="-1" role="menu" @fade class="bf-widget">
+    <div tabindex="-1" role="menu" @fade class="bf-widget" [ngStyle]="{ 'overflow': overflow }">
       <ng-content></ng-content>
     </div>
   </ng-template>
   `,
   styles: [`
-    .bf-widget {
-      overflow: auto;
-    }
-  `, `
     .bf-widget:focus {
       outline: none;
     }
@@ -59,6 +55,8 @@ const fade = trigger('fade', [
 export class OverlayWidgetComponent implements OnDestroy {
   @ViewChild('ref') public ref: TemplateRef<any>;
   @Output() openedChanged = new EventEmitter<boolean>();
+  // Toggle scrolling ability. if set to auto, border-box may be invisible.
+  @Input() overflow: 'auto' | 'unset' = 'unset';
   private overlayRef: OverlayRef;
   private widgetPortal: TemplatePortal;
   private isOpen = false;

--- a/libs/ui/src/lib/overlay-widget/overlay-widget.module.ts
+++ b/libs/ui/src/lib/overlay-widget/overlay-widget.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { OverlayWidgetButtonDirective, OverlayWidgetInputDirective, OverlayWidgetTooltipDirective } from './overlay-widget.directive';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { OverlayWidgetComponent, WidgetHeaderDirective, WidgetCardDirective, WidgetFooterDirective } from './overlay-widget.component';
@@ -14,7 +15,7 @@ const components = [
 ]
 
 @NgModule({
-  imports: [OverlayModule],
+  imports: [CommonModule, OverlayModule],
   declarations: components,
   exports: components
 })

--- a/libs/ui/src/lib/static-autocomplete/group/group.component.html
+++ b/libs/ui/src/lib/static-autocomplete/group/group.component.html
@@ -9,7 +9,7 @@
 					<mat-checkbox color="primary" [indeterminate]="(value | getMode:groups) === 'indeterminate'"
 						[checked]="(value | getMode:groups) === 'checked'" (change)="checkAll($event.checked)">
 					</mat-checkbox>
-					<input matInput placeholder="Tap to filter" [formControl]="search" />
+					<input #inputEl matInput placeholder="Tap to filter" [formControl]="search"/>
 					<mat-icon *ngIf="!search.value" svgIcon="search"></mat-icon>
 					<button *ngIf="search.value" mat-icon-button type="button" (click)="search.reset()" matTooltip="Clear text">
             <mat-icon svgIcon="refresh"></mat-icon>

--- a/libs/ui/src/lib/static-autocomplete/group/group.component.ts
+++ b/libs/ui/src/lib/static-autocomplete/group/group.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
   Input,
   forwardRef,
-  Pipe, PipeTransform,
+  Pipe, PipeTransform, ElementRef, ViewChild
 } from "@angular/core";
 import {
   FormControl,
@@ -84,6 +84,7 @@ export class StaticGroupComponent implements ControlValueAccessor {
   // all items includes the values of checked items which are not in the filter
   allItems: string[] = [];
 
+  @ViewChild('inputEl') input: ElementRef<HTMLInputElement>;
   @Input() displayAll = '';
   @Input() @boolean required = false;
   @Input() @boolean disabled = false;
@@ -123,7 +124,9 @@ export class StaticGroupComponent implements ControlValueAccessor {
   }
 
   onOpen(opened: boolean) {
-    if (!opened) {
+    if (opened) {
+      this.input.nativeElement.focus();
+    } else {
       this.form.setValue(this.allItems);
       this.search.setValue('');
     }


### PR DESCRIPTION
Todo's in issue #5410
- [x] After touching the filters, the column "Action" disappears
- [x] Background visible behind rounded corner of drop down
- [x] If possible, could we select by default the typing zone when user clicks on the "Territories" select?
- [x] When typing a wrong value on Territories, the select doesn't open anymore