### PR TITLE
5410 improve avails

### DIFF
--- a/apps/catalog/catalog/src/app/landing/landing.component.scss
+++ b/apps/catalog/catalog/src/app/landing/landing.component.scss
@@ -22,6 +22,7 @@ landing-content {
     margin-top: 24px;
     img {
       max-width: 600px;
+      height: 100%;
     }
   }
 

--- a/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
@@ -60,7 +60,7 @@
   <!-- TITLE CARD -->
   <ng-template listPageCard let-title>
     <movie-card [movie]="title" [link]="['/c/o/marketplace/title',  title.objectID]" size="poster">
-      <button mat-icon-button (click)="addAvail(title.objectID)">
+      <button mat-icon-button (click)="addAvail(title)">
         <mat-icon svgIcon="shopping_basket"></mat-icon>
       </button>
     </movie-card>

--- a/apps/catalog/catalog/src/app/marketplace/title/list/list.component.ts
+++ b/apps/catalog/catalog/src/app/marketplace/title/list/list.component.ts
@@ -20,7 +20,7 @@ import { Media, StoreStatus } from '@blockframes/utils/static-model/types';
 import { AvailsForm } from '@blockframes/contract/avails/form/avails.form';
 import { AvailsFilter, getMandateTerms, isInBucket, isSold } from '@blockframes/contract/avails/avails';
 import { Contract, ContractService } from '@blockframes/contract/contract/+state';
-import { createTerm, Term } from '@blockframes/contract/term/+state/term.model';
+import { Term } from '@blockframes/contract/term/+state/term.model';
 import { TermService } from '@blockframes/contract/term/+state/term.service';
 import { SearchResponse } from '@algolia/client-search';
 import { Bucket, BucketQuery, BucketService, createBucket } from '@blockframes/contract/bucket/+state';
@@ -29,6 +29,7 @@ import { centralOrgID } from '@env';
 import { BucketContract, createBucketContract } from '@blockframes/contract/bucket/+state/bucket.model';
 import { toDate } from '@blockframes/utils/helpers';
 import { Territory } from '@blockframes/utils/static-model';
+import { AlgoliaMovie } from '@blockframes/utils/algolia';
 
 @Component({
   selector: 'catalog-marketplace-title-list',
@@ -136,9 +137,10 @@ export class ListComponent implements OnInit, OnDestroy {
     return Promise.all(promises);
   }
 
-  addAvail(titleId: string) {
+  addAvail(title: AlgoliaMovie) {
+    const titleId = title.objectID;
     if (this.availsForm.invalid) {
-      this.snackbar.open('Specify the avails before adding to selection', 'close', { duration: 3000 })
+      this.snackbar.open('Fill in avails filter to add title to your Selection.', 'close', { duration: 5000 })
       return;
     }
     // Get the parent term
@@ -225,6 +227,7 @@ export class ListComponent implements OnInit, OnDestroy {
       })
       this.bucketService.add(bucket);
     }
+    this.snackbar.open(`${title.title.international} was added to your Selection`, 'close', { duration: 4000 });
   }
 
   ngOnDestroy() {

--- a/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.html
@@ -28,9 +28,9 @@
     </section>
 
     <ng-container *ngFor="let contract of bucket.contracts; trackBy: trackById; let i = index">
-      <section class="contract surface">
-        <header fxLayout fxLayoutAlign="space-between start">
-          <ng-container *ngIf="contract.titleId | getTitle | async as title">
+      <ng-container *ngIf="contract.titleId | getTitle | async as title">
+        <section class="contract surface">
+          <header fxLayout fxLayoutAlign="space-between start">
             <section fxLayout="column">
               <h2>{{ title.title.international }}</h2>
               <article fxLayout fxLayoutGap="12px">
@@ -38,7 +38,7 @@
                   alt="Movie Illustration" [delay]="0">
                 <div fxLayout="column">
                   <h3>{{ title.directors | displayName }}</h3>
-                  <p>{{ title | movieFeature}}</p>
+                  <p>{{ title | movieFeature }}</p>
                 </div>
               </article>
             </section>
@@ -48,35 +48,35 @@
                 (input)="debouncedUpdatePriceControl(i, $event.target.value)" />
               <mat-icon matPrefix [svgIcon]="bucket.currency"></mat-icon>
             </mat-form-field>
-          </ng-container>
-        </header>
-        <bf-table-filter [source]="contract.terms" [columns]="columns" [initialColumns]="initialColumns" showFilter>
-          <ng-template colRef="duration" let-duration>
-            {{ duration.from | date }} - {{ duration.to | date }}
-          </ng-template>
-          <ng-template colRef="territories" let-territories>
-            <section (click)="openDetails(territories, 'territories')">
-              {{ territories | toLabel:'territories':3 }}
-            </section>
-          </ng-template>
-          <ng-template colRef="medias" let-medias>
-            {{ medias | toLabel:'medias' }}
-          </ng-template>
-          <ng-template colRef="exclusive" let-exclusive>
-            {{ exclusive ? 'Yes' : 'No' }}
-          </ng-template>
-          <ng-template colAction="action" label="Actions" let-termIndex="index">
-            <button mat-icon-button (click)="removeTerm(i, termIndex)">
-              <mat-icon svgIcon="delete"></mat-icon>
+          </header>
+          <bf-table-filter [source]="contract.terms" [columns]="columns" [initialColumns]="initialColumns" showFilter>
+            <ng-template colRef="duration" let-duration>
+              {{ duration.from | date }} - {{ duration.to | date }}
+            </ng-template>
+            <ng-template colRef="territories" let-territories>
+              <section (click)="openDetails(territories, 'territories')">
+                {{ territories | toLabel:'territories':3 }}
+              </section>
+            </ng-template>
+            <ng-template colRef="medias" let-medias>
+              {{ medias | toLabel:'medias' }}
+            </ng-template>
+            <ng-template colRef="exclusive" let-exclusive>
+              {{ exclusive ? 'Yes' : 'No' }}
+            </ng-template>
+            <ng-template colAction="action" label="Actions" let-termIndex="index">
+              <button mat-icon-button (click)="removeTerm(i, termIndex)">
+                <mat-icon svgIcon="delete"></mat-icon>
+              </button>
+            </ng-template>
+          </bf-table-filter>
+          <footer>
+            <button mat-button (click)="removeContract(i, title)">
+              Delete all the rights for the title
             </button>
-          </ng-template>
-        </bf-table-filter>
-        <footer>
-          <button mat-button (click)="removeContract(i)">
-            Delete all the rights for the title
-          </button>
-        </footer>
-      </section>
+          </footer>
+        </section>
+      </ng-container>
     </ng-container>
 
     <footer fxLayout="column" fxLayoutAlign="center center" class="summary">

--- a/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.scss
+++ b/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.scss
@@ -16,6 +16,7 @@ section {
 
   img {
     width: 150px;
+    height: 100%;
   } 
 }
 

--- a/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.ts
+++ b/apps/catalog/catalog/src/app/marketplace/title/selection/selection.component.ts
@@ -10,6 +10,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SpecificTermsComponent } from './specific-terms/specific-terms.component';
 import { debounceFactory } from '@blockframes/utils/helpers';
 import { DetailedTermsComponent } from '@blockframes/contract/term/components/detailed/detailed.component';
+import { Movie } from '@blockframes/movie/+state';
 
 @Component({
   selector: 'catalog-selection',
@@ -63,11 +64,12 @@ export class MarketplaceSelectionComponent {
     });
   }
 
-  removeContract(index: number) {
+  removeContract(index: number, title: Movie) {
     const id = this.bucketQuery.getActiveId();
     this.bucketService.update(id, bucket => ({
       contracts: bucket.contracts.filter((_, i) => i !== index)
     }));
+    this.snackBar.open(`${title.title.international} was removed from your Selection`, 'close', { duration: 5000 });
   }
 
   removeTerm(contractIndex: number, termIndex: number) {
@@ -81,6 +83,7 @@ export class MarketplaceSelectionComponent {
       contracts[contractIndex].terms = terms;
       return { contracts };
     });
+    this.snackBar.open(`Rights deleted`, 'close', { duration: 4000 })
   }
 
   createOffer(bucket: Bucket) {
@@ -104,9 +107,9 @@ export class MarketplaceSelectionComponent {
 
       })
     })) {
-      this.snackBar.open('Some terms conflict with each other. Please remove duplicate terms', '', { duration: 2000 });
+      this.snackBar.open('Some terms conflict with each other. Please remove duplicate terms.', '', { duration: 2000 });
     } else if (bucket.contracts.some(contract => !contract.price || contract.price < 0)) {
-      this.snackBar.open('Please add price on every item', '', { duration: 2000 });
+      this.snackBar.open('Missing price information.', '', { duration: 2000 });
     } else {
       this.dialog.open(SpecificTermsComponent);
     }


### PR DESCRIPTION
Fix issue #5410
- [x] Add a snackbar when a title is added to Selection: "[ Title name ] was added to your Selection." for 4 sec
- [x] Change message when user clicks on add to selection without avails: "Fill in avails filter to add title to your Selection." for 5sec
- [x] Add a snackbar when removing an entire Title from a selection: "[ Title name ] was removed from your Selection." for 5 secs
- [x] Add a snackbar when removing a terms from a title in the selection: "Rights deleted." for 4 secs
- [x] Change snackbar message when user clics on Send offer without a price: "Missing price information." 
- [x] Safari img bug: posters on selection are stretched out 

issue #5419 
- [x] landing images are stretched out