### PR TITLE
5505 5049 replace crm by first accessible app

### DIFF
--- a/apps/catalog/catalog/src/app/dashboard/title/list/list.component.ts
+++ b/apps/catalog/catalog/src/app/dashboard/title/list/list.component.ts
@@ -17,7 +17,7 @@ const columns = {
   'title.international': 'TITLE',
   'release.year': 'RELEASE YEAR',
   directors: 'DIRECTOR(S)',
-  views: '# VIEWS',
+  views: { value: '# VIEWS', disableSort: true },
   'storeConfig.status': 'STATUS'
 };
 

--- a/apps/catalog/catalog/src/app/landing/landing.component.scss
+++ b/apps/catalog/catalog/src/app/landing/landing.component.scss
@@ -22,7 +22,7 @@ landing-content {
     margin-top: 24px;
     img {
       max-width: 600px;
-      height: 100%;
+      width: 100%;
     }
   }
 

--- a/apps/festival/festival/src/app/dashboard/title/list/list.component.ts
+++ b/apps/festival/festival/src/app/dashboard/title/list/list.component.ts
@@ -13,7 +13,7 @@ import { RouterQuery } from '@datorama/akita-ng-router-store';
 
 const columns = {
   'title.international': 'Title',
-  view: '# Views',
+  view: { value: '# VIEWS', disableSort: true },
   directors: 'Director(s)',
   productionStatus: 'Production Status',
   'storeConfig.status': 'Status'

--- a/libs/invitation/src/lib/+state/invitation.service.ts
+++ b/libs/invitation/src/lib/+state/invitation.service.ts
@@ -10,7 +10,7 @@ import { Invitation, createInvitation } from './invitation.model';
 import { InvitationDocument } from './invitation.firestore';
 import { cleanInvitation } from '../invitation-utils';
 import { RouterQuery } from '@datorama/akita-ng-router-store';
-import { App, getCurrentApp } from '@blockframes/utils/apps';
+import { getCurrentApp, getOrgAppAccess } from '@blockframes/utils/apps';
 
 @Injectable({ providedIn: 'root' })
 @CollectionConfig({ path: 'invitations' })
@@ -107,7 +107,7 @@ export class InvitationService extends CollectionService<InvitationState> {
         let app = getCurrentApp(this.routerQuery);
         if (app === 'crm') {
           // Instead use first found app where org has access to
-          app = Object.keys(fromOrg.appAccess).find((app: App) => Object.keys(fromOrg.appAccess[app]).some(module => fromOrg.appAccess[app][module])) as App
+          app = getOrgAppAccess(fromOrg)[0];
         }
         return f({ emails: recipients, invitation, app }).toPromise();
       }

--- a/libs/utils/src/lib/apps.ts
+++ b/libs/utils/src/lib/apps.ts
@@ -17,7 +17,7 @@ export interface AppMailSetting {
   url?: string,
 }
 
-export const app = ['catalog', 'festival', 'financiers'] as const;
+export const app = ['catalog', 'festival', 'financiers', 'crm'] as const;
 export type App = typeof app[number];
 
 export const modules = ['dashboard', 'marketplace'] as const;
@@ -37,6 +37,7 @@ export const sendgridEmailsFrom: Record<App | 'default', EmailJSON> = {
   catalog: { email: 'team@archipelcontent.com', name: 'Archipel Content' },
   festival: { email: 'team@archipelmarket.com', name: 'Archipel Market' },
   financiers: { email: 'team@mediafinanciers.com', name: 'Media Financiers' },
+  crm: { email: 'team@cascade8.com', name: 'Cascade 8' },
   default: { email: 'team@cascade8.com', name: 'Cascade 8' }
 } as const;
 
@@ -44,6 +45,7 @@ export const appLogo = {
   catalog: `${appUrl.content}/assets/logo/light/content-primary-blue.png`,
   festival: `${appUrl.market}/assets/logo/light/market-primary-blue.png`,
   financiers: `${appUrl.financiers}/assets/logo/light/mf-primary-blue.png`,
+  crm: ''
 };
 type AppLogoValue = typeof appLogo[App];
 
@@ -60,7 +62,8 @@ export type MovieAppAccess = Record<App, boolean>;
 export const applicationUrl: Record<App, string> = {
   festival: appUrl.market,
   catalog: appUrl.content,
-  financiers: appUrl.financiers
+  financiers: appUrl.financiers,
+  crm: appUrl.crm
 }
 
 export function getCurrentApp(routerQuery: RouterQuery): App {


### PR DESCRIPTION
Fix issue #5049 && to do in #5505
- [x] Org member invitations from CRM use "Blockframes CRM" as app.name variable in the invitation email. Instead it should be an app that the org has access to, if many take the first one.
- [x] Dashboard title list: sorting doesn't work on the "# Views" colum