### PR TITLE
removed entry components

### DIFF
--- a/libs/admin/src/lib/admin-panel/components/crm-form-dialog/crm-form-dialog.module.ts
+++ b/libs/admin/src/lib/admin-panel/components/crm-form-dialog/crm-form-dialog.module.ts
@@ -17,7 +17,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatInputModule,
     MatFormFieldModule
   ],
-  exports: [CrmFormDialogComponent],
-  entryComponents: [CrmFormDialogComponent]
+  exports: [CrmFormDialogComponent]
 })
 export class CrmFormDialogModule { }

--- a/libs/event/src/lib/components/doorbell/doorbell.module.ts
+++ b/libs/event/src/lib/components/doorbell/doorbell.module.ts
@@ -17,7 +17,6 @@ import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
     MatButtonModule,
     MatBottomSheetModule
   ],
-  exports: [DoorbellBottomSheetComponent],
-  entryComponents: [DoorbellBottomSheetComponent]
+  exports: [DoorbellBottomSheetComponent]
 })
 export class DoorbellBottomSheetModule { }

--- a/libs/movie/src/lib/movie/components/movie-imdb-search/movie-imdb-search.module.ts
+++ b/libs/movie/src/lib/movie/components/movie-imdb-search/movie-imdb-search.module.ts
@@ -42,10 +42,6 @@ import { MovieImdbSearchComponent } from "./movie-imdb-search.component";
     // Librairies
     PasswordConfirmModule,
   ],
-  providers: [ ],
-  entryComponents: [
-    MovieImdbSearchComponent
-  ],
   exports: [
     MovieImdbSearchComponent
   ],

--- a/libs/ui/src/lib/confirm/confirm.module.ts
+++ b/libs/ui/src/lib/confirm/confirm.module.ts
@@ -7,7 +7,6 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 @NgModule({
   declarations: [ConfirmComponent],
   imports: [CommonModule, MatButtonModule, FlexLayoutModule,],
-  exports: [ConfirmComponent],
-  entryComponents: [ConfirmComponent,]
+  exports: [ConfirmComponent]
 })
 export class ConfirmModule { }


### PR DESCRIPTION
entryComponents and ANALYZE_FOR_ENTRY_COMPONENTS no longer required
Previously, the entryComponents array in the NgModule definition was used to tell the compiler which components would be created and inserted dynamically. With Ivy, this isn't a requirement anymore and the entryComponents array can be removed from existing module declarations. The same applies to the ANALYZE_FOR_ENTRY_COMPONENTS injection token.