### PR TITLE
fix #5011 and #5384

### DIFF
--- a/apps/backend-functions/src/users.ts
+++ b/apps/backend-functions/src/users.ts
@@ -191,9 +191,7 @@ export async function onUserDelete(
 
 export const sendDemoRequest = async (data: RequestDemoInformations): Promise<RequestDemoInformations> => {
   const from = getSendgridFrom(data.app);
-  await sendMail(sendDemoRequestMail(data), from)
-    .catch(e => console.warn(e.message));
-
+  await sendMail(sendDemoRequestMail(data), from);
   return data;
 }
 
@@ -209,8 +207,7 @@ export const sendUserMail = async (data: { subject: string, message: string, app
 
   const from = getSendgridFrom(app);
 
-  await sendMail(sendContactEmail(`${user.firstName} ${user.lastName}`, user.email, subject, message, app), from)
-    .catch(e => console.warn(e.message));
+  await sendMail(sendContactEmail(`${user.firstName} ${user.lastName}`, user.email, subject, message, app), from);
 }
 
 

--- a/libs/utils/src/lib/sentry.module.ts
+++ b/libs/utils/src/lib/sentry.module.ts
@@ -23,6 +23,9 @@ export class SentryErrorHandler implements ErrorHandler {
   }
 
   handleError(error) {
+    if (sentryEnv as any !== 'production') {
+      console.error(error);
+    }
     Sentry.captureException(error.originalError || error);
   }
 }


### PR DESCRIPTION
- Errors in backend will now be catched by sentry but still logged in firebase functions log.
- Errors in frontend are still pushed to sentry if `sentryDsn` is enabled but if environment is not production, errors will still be logged into browser console for debugging