### PR TITLE
5356 notifications improvements

### DIFF
--- a/apps/backend-functions/src/notification.ts
+++ b/apps/backend-functions/src/notification.ts
@@ -288,7 +288,7 @@ async function sendRequestToAttendEventUpdatedEmail(recipient: User, notificatio
       const template = requestToAttendEventFromUserAccepted(recipient, orgName(organizerOrg), eventData);
       await sendMailFromTemplate(template, eventAppKey, unsubscribeId);
     } else {
-      const template = requestToAttendEventFromUserRefused(recipient, orgName(organizerOrg), eventData);
+      const template = requestToAttendEventFromUserRefused(recipient, orgName(organizerOrg), eventData, notification.organization.id);
       await sendMailFromTemplate(template, eventAppKey, unsubscribeId);
     }
   } else {
@@ -309,11 +309,11 @@ async function sendInvitationToAttendEventUpdatedEmail(recipient: User, notifica
     const userOrgName = orgName(userOrg);
     if (notification.invitation.status === 'accepted') {
       const templateId = templateIds.invitation.attendEvent.accepted;
-      const template = invitationToEventFromOrgUpdated(recipient, user, userOrgName, eventData, templateId);
+      const template = invitationToEventFromOrgUpdated(recipient, user, userOrgName, eventData, invitation.fromOrg.id, templateId);
       return sendMailFromTemplate(template, eventAppKey, unsubscribeId);
     } else {
       const templateId = templateIds.invitation.attendEvent.declined;
-      const template = invitationToEventFromOrgUpdated(recipient, user, userOrgName, eventData, templateId);
+      const template = invitationToEventFromOrgUpdated(recipient, user, userOrgName, eventData, invitation.fromOrg.id, templateId);
       return sendMailFromTemplate(template, eventAppKey, unsubscribeId);
     }
   } else {

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -203,6 +203,7 @@ export function invitationToEventFromOrgUpdated(
   user: User,
   userOrgName: string,
   event: EventEmailData,
+  orgId: string,
   templateId: string
 ): EmailTemplateRequest {
   const data = {
@@ -211,7 +212,8 @@ export function invitationToEventFromOrgUpdated(
     userLastName: user.lastName,
     userOrgName,
     event,
-    eventUrl: `${appUrl.market}/c/o/dashboard/event/${event.id}`
+    eventUrl: `${appUrl.market}/c/o/dashboard/event/${event.id}`,
+    pageUrl: `${appUrl.market}/c/o/marketplace/organization/${orgId}}/title`
   };
   return { to: admin.email, templateId, data };
 }
@@ -268,12 +270,14 @@ export function requestToAttendEventFromUserAccepted(
 export function requestToAttendEventFromUserRefused(
   toUser: PublicUser,
   organizerOrgName: string,
-  event: EventEmailData
+  event: EventEmailData,
+  orgId: string
 ): EmailTemplateRequest {
   const data = {
     userFirstName: toUser.firstName,
     organizerOrgName,
     event,
+    pageUrl: `${appUrl.market}/c/o/marketplace/organization/${orgId}/title`
   };
   return { to: toUser.email, templateId: templateIds.request.attendEvent.declined, data };
 }


### PR DESCRIPTION
Some to do's on issue #5356
- [x] d-f84d8c5a70884316870ca4ef657e368f is spawned for every new member in the org but in fact it would be better if it was used only when a user accepts an invitation to join an org.
Cause here it's sent also for requests being accepted but we already have 3 mails related to requests, it's a bit too much
- [x] Small improvement for Event request refused d-4e36dd72f50d4e7e9ec738476efa84a9, would be good to add a pageUrl that leads to the marketplace org view (/c/o/marketplace/organization/orgId/title) of the organizer org
- [x] New texts for notifications (2/3)