### PR TITLE
5356 notification improvements

### DIFF
--- a/apps/backend-functions/src/notification.ts
+++ b/apps/backend-functions/src/notification.ts
@@ -335,7 +335,6 @@ async function sendOrgAppAccessChangedEmail(recipient: User, notification: Notif
   const org = await getDocument<OrganizationDocument>(`orgs/${notification.organization.id}`);
   const app = await getOrgAppKey(org);
   const url = applicationUrl[app];
-  // @#4046 Change text to something more generic than `Your organization has now access to Archipel Market.` wich can be wrong
   const template = organizationAppAccessChanged(recipient, url);
   await sendMailFromTemplate(template, app, unsubscribeId);
 }

--- a/apps/backend-functions/src/notification.ts
+++ b/apps/backend-functions/src/notification.ts
@@ -332,10 +332,9 @@ async function sendMailToOrgAcceptedAdmin(recipient: User, notification: Notific
 
 /** Send email to organization's admins when org appAccess has changed */
 async function sendOrgAppAccessChangedEmail(recipient: User, notification: NotificationDocument) {
-  const org = await getDocument<OrganizationDocument>(`orgs/${notification.organization.id}`);
-  const app = await getOrgAppKey(org);
+  const app = notification.appAccess;
   const url = applicationUrl[app];
-  const template = organizationAppAccessChanged(recipient, url);
+  const template = organizationAppAccessChanged(recipient, url, notification.appAccess);
   await sendMailFromTemplate(template, app, unsubscribeId);
 }
 

--- a/apps/backend-functions/src/orgs.ts
+++ b/apps/backend-functions/src/orgs.ts
@@ -234,7 +234,7 @@ export async function onOrganizationDelete(
 }
 
 export const accessToAppChanged = async (
-  data: { orgId: string, accessGiven: boolean }
+  data: { orgId: string, app: App }
 ): Promise<ErrorResultResponse> => {
 
   const adminIds = await getAdminIds(data.orgId);
@@ -246,7 +246,8 @@ export const accessToAppChanged = async (
       toUserId: admin.uid,
       docId: admin.orgId,
       organization: createPublicOrganizationDocument(organization),
-      type: data.accessGiven ? 'orgAppAccessChanged' : 'orgAppAccessRemoved'
+      appAccess: data.app,
+      type: 'orgAppAccessChanged'
     });
 
     notifications.push(notification);

--- a/apps/backend-functions/src/orgs.ts
+++ b/apps/backend-functions/src/orgs.ts
@@ -234,19 +234,19 @@ export async function onOrganizationDelete(
 }
 
 export const accessToAppChanged = async (
-  orgId: string
+  data: { orgId: string, accessGiven: boolean }
 ): Promise<ErrorResultResponse> => {
 
-  const adminIds = await getAdminIds(orgId);
+  const adminIds = await getAdminIds(data.orgId);
   const admins = await Promise.all(adminIds.map(id => getUser(id)));
-  const organization = await getDocument<OrganizationDocument>(`orgs/${orgId}`);
+  const organization = await getDocument<OrganizationDocument>(`orgs/${data.orgId}`);
   const notifications: NotificationDocument[] = [];
   admins.map(async admin => {
     const notification = createNotification({
       toUserId: admin.uid,
       docId: admin.orgId,
       organization: createPublicOrganizationDocument(organization),
-      type: 'orgAppAccessChanged'
+      type: data.accessGiven ? 'orgAppAccessChanged' : 'orgAppAccessRemoved'
     });
 
     notifications.push(notification);

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -101,10 +101,11 @@ export function userJoinOrgPendingRequest(email: string, orgName: string, userFi
 }
 
 /** Email to let org admin knows that his/her organization has access to a new app */
-export function organizationAppAccessChanged(admin: PublicUser, url: string): EmailTemplateRequest {
+export function organizationAppAccessChanged(admin: PublicUser, url: string, app: App): EmailTemplateRequest {
   const data = {
     adminFirstName: admin.firstName,
-    url
+    url,
+    app
   }
   return { to: admin.email, templateId: templateIds.org.appAccessChanged, data };
 }

--- a/libs/admin/src/lib/admin-panel/pages/organization/organization.component.ts
+++ b/libs/admin/src/lib/admin-panel/pages/organization/organization.component.ts
@@ -17,6 +17,7 @@ import { EventService } from '@blockframes/event/+state';
 import { ContractService } from '@blockframes/contract/contract/+state';
 import { Movie } from '@blockframes/movie/+state/movie.model';
 import { FileUploaderService } from '@blockframes/media/+state/file-uploader.service';
+import { OrgAppAccess } from '@blockframes/utils/apps';
 
 @Component({
   selector: 'admin-organization',
@@ -139,7 +140,14 @@ export class OrganizationComponent implements OnInit {
     await this.organizationService.update(this.orgId, this.orgForm.value);
 
     if (this.notifyCheckbox.value) {
-      this.organizationService.notifyAppAccessChange(this.orgId);
+      const before = this.org.appAccess;
+      const after = this.orgForm.value.appAccess as OrgAppAccess;
+      const accessGiven = Object.keys(after).some(app => {
+        return Object.keys(after[app]).some(module => {
+          return after[app][module] === true && before[app][module] === false
+        });
+      });
+      this.organizationService.notifyAppAccessChange(this.orgId, accessGiven);
     }
 
     this.snackBar.open('Informations updated !', 'close', { duration: 5000 });

--- a/libs/admin/src/lib/admin-panel/pages/organization/organization.component.ts
+++ b/libs/admin/src/lib/admin-panel/pages/organization/organization.component.ts
@@ -17,7 +17,7 @@ import { EventService } from '@blockframes/event/+state';
 import { ContractService } from '@blockframes/contract/contract/+state';
 import { Movie } from '@blockframes/movie/+state/movie.model';
 import { FileUploaderService } from '@blockframes/media/+state/file-uploader.service';
-import { OrgAppAccess } from '@blockframes/utils/apps';
+import { App, OrgAppAccess } from '@blockframes/utils/apps';
 
 @Component({
   selector: 'admin-organization',
@@ -135,19 +135,21 @@ export class OrganizationComponent implements OnInit {
       this.snackBar.open('Information not valid', 'close', { duration: 5000 });
       return;
     }
+    const org = await this.organizationService.getValue(this.orgId); 
 
     this.uploaderService.upload();
     await this.organizationService.update(this.orgId, this.orgForm.value);
 
     if (this.notifyCheckbox.value) {
-      const before = this.org.appAccess;
+      const before = org.appAccess;
       const after = this.orgForm.value.appAccess as OrgAppAccess;
-      const accessGiven = Object.keys(after).some(app => {
-        return Object.keys(after[app]).some(module => {
-          return after[app][module] === true && before[app][module] === false
-        });
-      });
-      this.organizationService.notifyAppAccessChange(this.orgId, accessGiven);
+
+      for (const app in after) {
+        if (Object.keys(after[app]).every(module => before[app][module] === false)
+          && Object.keys(after[app]).some(module => after[app][module] === true)) {
+          this.organizationService.notifyAppAccessChange(this.orgId, app as App)
+        }
+      }
     }
 
     this.snackBar.open('Informations updated !', 'close', { duration: 5000 });

--- a/libs/notification/src/lib/+state/notification.firestore.ts
+++ b/libs/notification/src/lib/+state/notification.firestore.ts
@@ -41,6 +41,7 @@ export const notificationTypesPlus = [
   'movieSubmitted', // (catalog only)
   'organizationAcceptedByArchipelContent',
   'orgAppAccessChanged',
+  'orgAppAccessRemoved'
 ] as const;
 
 export type NotificationTypesBase = typeof notificationTypesBase[number];

--- a/libs/notification/src/lib/+state/notification.firestore.ts
+++ b/libs/notification/src/lib/+state/notification.firestore.ts
@@ -6,6 +6,7 @@ import { firestore } from 'firebase-admin';
 import { DocumentMeta } from '@blockframes/utils/models-meta';
 import { EmailErrorCodes } from '@blockframes/utils/emails/utils';
 import { Bucket } from '@blockframes/contract/bucket/+state/bucket.model';
+import { App } from '@blockframes/utils/apps';
 
 // Type of notification used in front
 export const notificationTypesBase = [
@@ -40,8 +41,7 @@ export const notificationTypesPlus = [
   // Other notifications
   'movieSubmitted', // (catalog only)
   'organizationAcceptedByArchipelContent',
-  'orgAppAccessChanged',
-  'orgAppAccessRemoved'
+  'orgAppAccessChanged'
 ] as const;
 
 export type NotificationTypesBase = typeof notificationTypesBase[number];
@@ -61,6 +61,7 @@ export interface NotificationBase<D> {
   organization?: PublicOrganization;
   invitation?: PublicInvitation;
   bucket?: Bucket;
+  appAccess?: App;
   /** @dev Type of the notification */
   type: NotificationTypes;
   email?: {

--- a/libs/notification/src/lib/+state/notification.store.ts
+++ b/libs/notification/src/lib/+state/notification.store.ts
@@ -127,6 +127,7 @@ export class NotificationStore extends EntityStore<NotificationState, Notificati
           url: `/c/o/dashboard/title/${notification.docId}/main`,
         };
       case 'orgAppAccessChanged':
+      case 'orgAppAccessRemoved':
         // @TODO #4046 Update text if needed
         return {
           _meta: { ...notification._meta, createdAt: toDate(notification._meta.createdAt) },

--- a/libs/notification/src/lib/+state/notification.store.ts
+++ b/libs/notification/src/lib/+state/notification.store.ts
@@ -127,12 +127,12 @@ export class NotificationStore extends EntityStore<NotificationState, Notificati
           url: `/c/o/dashboard/title/${notification.docId}/main`,
         };
       case 'orgAppAccessChanged':
-        const message = !!notification.appAccess
+        const msg = !!notification.appAccess
           ? `Your organization has now access to ${appName[notification.appAccess]}`
           : 'Your organization\'s app access have changed.'
         return {
           _meta: { ...notification._meta, createdAt: toDate(notification._meta.createdAt) },
-          message,
+          message: msg,
           placeholderUrl: `empty_organization.webp`,
           imgRef: notification.organization?.logo,
           url: `${applicationUrl[notification.appAccess]}`

--- a/libs/notification/src/lib/+state/notification.store.ts
+++ b/libs/notification/src/lib/+state/notification.store.ts
@@ -127,15 +127,16 @@ export class NotificationStore extends EntityStore<NotificationState, Notificati
           url: `/c/o/dashboard/title/${notification.docId}/main`,
         };
       case 'orgAppAccessChanged':
-      case 'orgAppAccessRemoved':
-        // @TODO #4046 Update text if needed
+        const message = !!notification.appAccess
+          ? `Your organization has now access to ${notification.appAccess}`
+          : 'Your organization\'s app access have changed.'
         return {
           _meta: { ...notification._meta, createdAt: toDate(notification._meta.createdAt) },
-          message: 'Your organization\'s app access have changed.',
+          message,
+          placeholderUrl: `empty_organization.webp`,
           imgRef: notification.organization?.logo,
-          placeholderUrl: 'empty_organization.webp',
-          url: `${applicationUrl[this.app]}/c/o/organization/${notification.organization.id}/view/org`,
-        };
+          url: `${applicationUrl[notification.appAccess]}`
+        }
       case 'eventIsAboutToStart':
 
         // we perform async fetch to display more meaningful info to the user later (because we cannot do await in akitaPreAddEntity)

--- a/libs/notification/src/lib/+state/notification.store.ts
+++ b/libs/notification/src/lib/+state/notification.store.ts
@@ -128,7 +128,7 @@ export class NotificationStore extends EntityStore<NotificationState, Notificati
         };
       case 'orgAppAccessChanged':
         const message = !!notification.appAccess
-          ? `Your organization has now access to ${notification.appAccess}`
+          ? `Your organization has now access to ${appName[notification.appAccess]}`
           : 'Your organization\'s app access have changed.'
         return {
           _meta: { ...notification._meta, createdAt: toDate(notification._meta.createdAt) },

--- a/libs/organization/src/lib/organization/+state/organization.service.ts
+++ b/libs/organization/src/lib/organization/+state/organization.service.ts
@@ -100,9 +100,9 @@ export class OrganizationService extends CollectionService<OrganizationState> {
   /**
    * @param accessGiven true if access given to new app, false if only revoked access
    */
-  public notifyAppAccessChange(orgId: string, accessGiven: boolean) {
+  public notifyAppAccessChange(orgId: string, app: App) {
     const callOnAccessToAppChanged = this.functions.httpsCallable('onAccessToAppChanged');
-    return callOnAccessToAppChanged({orgId, accessGiven}).toPromise();
+    return callOnAccessToAppChanged({orgId, app}).toPromise();
   }
 
   public requestAppAccess(app: App, orgId: string) {

--- a/libs/organization/src/lib/organization/+state/organization.service.ts
+++ b/libs/organization/src/lib/organization/+state/organization.service.ts
@@ -97,9 +97,12 @@ export class OrganizationService extends CollectionService<OrganizationState> {
     return this.update(orgId, { isBlockchainEnabled: value });
   }
 
-  public notifyAppAccessChange(orgId: string) {
+  /**
+   * @param accessGiven true if access given to new app, false if only revoked access
+   */
+  public notifyAppAccessChange(orgId: string, accessGiven: boolean) {
     const callOnAccessToAppChanged = this.functions.httpsCallable('onAccessToAppChanged');
-    return callOnAccessToAppChanged(orgId).toPromise();
+    return callOnAccessToAppChanged({orgId, accessGiven}).toPromise();
   }
 
   public requestAppAccess(app: App, orgId: string) {

--- a/libs/organization/src/lib/organization/+state/organization.service.ts
+++ b/libs/organization/src/lib/organization/+state/organization.service.ts
@@ -97,9 +97,6 @@ export class OrganizationService extends CollectionService<OrganizationState> {
     return this.update(orgId, { isBlockchainEnabled: value });
   }
 
-  /**
-   * @param accessGiven true if access given to new app, false if only revoked access
-   */
   public notifyAppAccessChange(orgId: string, app: App) {
     const callOnAccessToAppChanged = this.functions.httpsCallable('onAccessToAppChanged');
     return callOnAccessToAppChanged({orgId, app}).toPromise();


### PR DESCRIPTION
To do in issue #5356
- [x] Don't send email if the app access are removed and not added
- [x] We need a more accurate variable for app access email, it shall give us the new app name that has been given during the update. Send email for every app the org gained access to. Also, update notification text.