### PR TITLE
5356 rename notification

### DIFF
--- a/apps/backend-functions/src/notification.ts
+++ b/apps/backend-functions/src/notification.ts
@@ -22,7 +22,7 @@ import {
   requestToJoinOrgDeclined,
   invitationToEventFromOrgUpdated,
   userJoinOrgPendingRequest,
-  offerCreatedEmail
+  offerCreatedConfirmationEmail
 } from './templates/mail';
 import { templateIds, unsubscribeGroupIds } from './templates/ids';
 import { canAccessModule, orgName } from '@blockframes/organization/+state/organization.firestore';
@@ -193,8 +193,8 @@ export async function onNotificationCreate(snap: FirebaseFirestore.DocumentSnaps
           .then(_ => notification.email.isSent = true)
           .catch(e => notification.email.error = e.message);
         break;
-      case 'offerCreated':
-        await sendOfferCreated(recipient, notification)
+      case 'offerCreatedConfirmation':
+        await sendOfferCreatedConfirmation(recipient, notification)
           .then(_ => notification.email.isSent = true)
           .catch(e => notification.email.error = e.message);
         break;
@@ -434,9 +434,9 @@ async function sendRequestToJoinOrgDeclined(recipient: User, notification: Notif
 }
 
 /** Send copy of offer that recipient has created */
-async function sendOfferCreated(recipient: User, notification: NotificationDocument) {
+async function sendOfferCreatedConfirmation(recipient: User, notification: NotificationDocument) {
   const org =  await getDocument<OrganizationDocument>(`orgs/${recipient.orgId}`);
   const app: App = 'catalog';
-  const template = offerCreatedEmail(org, notification.bucket, recipient);
+  const template = offerCreatedConfirmationEmail(org, notification.bucket, recipient);
   await sendMailFromTemplate(template, app, unsubscribeId);
 }

--- a/apps/backend-functions/src/offer.ts
+++ b/apps/backend-functions/src/offer.ts
@@ -41,7 +41,7 @@ export async function onOfferCreate(snap: FirebaseFirestore.DocumentSnapshot): P
   // Send copy of offer to user who created the offer 
   const notification = createNotification({
     toUserId: user.uid,
-    type: 'offerCreated',
+    type: 'offerCreatedConfirmation',
     docId: snap.id,
     bucket
   })

--- a/apps/backend-functions/src/templates/mail.ts
+++ b/apps/backend-functions/src/templates/mail.ts
@@ -306,7 +306,7 @@ export function movieAcceptedEmail(toUser: PublicUser, movieTitle: string, movie
 }
 
 /** */
-export function offerCreatedEmail(org: OrganizationDocument, bucket: Bucket, user: User): EmailTemplateRequest {
+export function offerCreatedConfirmationEmail(org: OrganizationDocument, bucket: Bucket, user: User): EmailTemplateRequest {
   const date = format(new Date(), 'dd MMMM, yyyy');
   const data = { org, bucket, user, baseUrl: appUrl.content, date };
   return { to: user.email, templateId: templateIds.offer.created, data };

--- a/libs/notification/src/lib/+state/notification.firestore.ts
+++ b/libs/notification/src/lib/+state/notification.firestore.ts
@@ -28,7 +28,7 @@ export const notificationTypesBase = [
   'invitationToAttendScreeningCreated',
 
   // Notifications related to offers
-  'offerCreated'
+  'offerCreatedConfirmation'
 ] as const;
 
 // All the other notification types

--- a/libs/notification/src/lib/+state/notification.store.ts
+++ b/libs/notification/src/lib/+state/notification.store.ts
@@ -217,7 +217,7 @@ export class NotificationStore extends EntityStore<NotificationState, Notificati
           placeholderUrl: 'profil_user.webp',
           url: `${applicationUrl['festival']}/c/o/${module}/event/${notification.docId}`
         };
-      case 'offerCreated':
+      case 'offerCreatedConfirmation':
         return {
           _meta: { ...notification._meta, createdAt: toDate(notification._meta.createdAt) },
           message: `Your offer was successfully sent.`,

--- a/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
+++ b/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
@@ -25,7 +25,7 @@ const titleType: Record<NotificationTypesBase, NotificationSetting> = {
   requestToAttendEventCreated: { text:'A user wants to join an event you\'re organizing. (RECOMMENDED)', tooltip: true },
   invitationToAttendMeetingCreated: { text:'You are invited to a meeting. (RECOMMENDED)', tooltip: true },
   invitationToAttendScreeningCreated: { text:'You are invited to a screening. (RECOMMENDED)', tooltip: true },
-  offerCreated: { text: 'You send an offer', tooltip: false }
+  offerCreatedConfirmation: { text: 'You send an offer', tooltip: false }
 };
 
 const tables: {title: string, types: string[], appAuthorized: App[]}[] = [
@@ -55,7 +55,7 @@ const tables: {title: string, types: string[], appAuthorized: App[]}[] = [
   },
   {
     title: 'Offer Management',
-    types: ['offerCreated'],
+    types: ['offerCreatedConfirmation'],
     appAuthorized: ['catalog']
   }
 ];

--- a/libs/user/src/lib/auth/forms/notifications-form/notifications.form.ts
+++ b/libs/user/src/lib/auth/forms/notifications-form/notifications.form.ts
@@ -31,7 +31,7 @@ function createNotificationsControls(settings: Partial<NotificationSettings> = {
     requestToAttendEventCreated: new  NotificationSettingsForm(settings.requestToAttendEventCreated, true),
     invitationToAttendMeetingCreated: new  NotificationSettingsForm(settings.invitationToAttendMeetingCreated, true),
     invitationToAttendScreeningCreated: new  NotificationSettingsForm(settings.invitationToAttendScreeningCreated, true),
-    offerCreated: new NotificationSettingsForm(settings.offerCreated)
+    offerCreatedConfirmation: new NotificationSettingsForm(settings.offerCreatedConfirmation)
   }
 }
 


### PR DESCRIPTION
Renamed the notification in order to make room for a notification which will be made in the future for which this is a more appropriate name.