### PR TITLE
Fix a linter issue with LandingHeader directive

### DIFF
--- a/libs/landing/src/lib/shell/shell.component.ts
+++ b/libs/landing/src/lib/shell/shell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ContentChild, Directive, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, Directive, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { createDemoRequestInformations, RequestDemoInformations } from '@blockframes/utils/request-demo';
 import { MatSnackBar } from '@angular/material/snack-bar'
@@ -9,9 +9,10 @@ import { RequestDemoRole } from '@blockframes/utils/request-demo';
 
 @Directive({
   selector: 'landing-header, [landingHeader]',
-  host: { class: 'dark-contrast-theme' },
 })
-export class LandingHeaderDirective { }
+export class LandingHeaderDirective {
+  @HostBinding('class') theme = 'dark-contrast-theme'
+}
 
 @Directive({selector: 'landing-content, [landingContent]'})
 export class LandingContentDirective { }


### PR DESCRIPTION
Only prefix warning remains.. ignored for now.

![image](https://user-images.githubusercontent.com/8731418/118976139-5194c480-b992-11eb-9fa4-0e523222dcb6.png)

