### PR TITLE
upgrade CI command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,18 @@ jobs:
       - build_deploy_prepare
       - slack/notify:
           message: 'PFT complete for << pipeline.git.branch >>'
+  build-deploy-upgrade:
+    executor: blockframes-ci
+    environment:
+      NG_CONFIG: ''
+    steps:
+      - prepare_environment
+      - run: echo "export PROJECT_ID=\"$(cut -d'/' -f2\<<<$CIRCLE_BRANCH)\"" >> $BASH_ENV
+      - fail_on_production
+      - select_environment
+      - build_deploy_upgrade
+      - slack/notify:
+          message: 'UPGRADE complete for << pipeline.git.branch >>'
   prepare-for-testing:
     executor: blockframes-ci
     environment:
@@ -318,6 +330,13 @@ workflows:
             branches:
               only:
                 - /deploy\/.*/
+  build-deploy-upgrade:
+    jobs:
+      - build-deploy-upgrade:
+          filters:
+            branches:
+              only:
+                - /upgrade\/.*/
   prepare-for-testing:
     jobs:
       - prepare-for-testing:

--- a/env/env.blockframes-demo-2.ts
+++ b/env/env.blockframes-demo-2.ts
@@ -163,6 +163,6 @@ export const centralOrgId = {
 // Import / Export parameters
 // =======
 
-export const backupBucket = 'demo2-backups';
+export const backupBucket = 'demo-2-backups-us';
 export const heavyChunkSize = 15;
 export const chunkSize = 30;


### PR DESCRIPTION
This PR allow, when code is pushed to branch `upgrade/blockframes-XXXX` to perform an upgrade on the env `blockframes-XXXX`

To do so, firebase-adminsdk-2sn1n@blockframes-ci.iam.gserviceaccount.com must be allowed for the project `blockframes-XXXX`
![image](https://user-images.githubusercontent.com/1194344/119686028-37515f80-be46-11eb-88cf-c97686eef08c.png)

Test in progress: https://app.circleci.com/pipelines/github/blockframes/blockframes/17865/workflows/da43e366-4f8b-4a57-9330-b12c6555bba7/jobs/28730