### PR TITLE
5924 Avail improvements

### DIFF
--- a/apps/catalog/catalog/src/app/marketplace/title/avails/calendar/avails-calendar.component.scss
+++ b/apps/catalog/catalog/src/app/marketplace/title/avails/calendar/avails-calendar.component.scss
@@ -8,6 +8,10 @@ li {
   }
 }
 
+a {
+  text-decoration: underline;
+}
+
 section {
   position: relative;
   margin-bottom: 24px;

--- a/apps/catalog/catalog/src/app/marketplace/title/avails/map/avails-map.component.scss
+++ b/apps/catalog/catalog/src/app/marketplace/title/avails/map/avails-map.component.scss
@@ -4,6 +4,10 @@ p {
   line-height: 24px;
 }
 
+a {
+  text-decoration: underline;
+}
+
 world-map {
   height: 500px;
   z-index: 0;

--- a/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/title/list/list.component.html
@@ -43,13 +43,9 @@
     </ng-template>
 
     <ng-template filter label="Country of Origin" [form]="searchForm.originCountries">
-      <chips-autocomplete [form]="searchForm.originCountries" placeholder="Country of Origin" scope="territories">
+      <chips-autocomplete [form]="searchForm.originCountries" placeholder="Country of Origin" scope="territories" [withoutValues]="['world']">
         <mat-label>Country of Origin</mat-label>
       </chips-autocomplete>
-    </ng-template>
-
-    <ng-template filter label="Language & Version" [form]="searchForm.languages">
-      <title-language-filter [languagesFilterForm]="searchForm.languages"></title-language-filter>
     </ng-template>
 
     <button mat-icon-button (click)="clear()" matTooltip="Clear all filters">

--- a/apps/catalog/catalog/src/app/marketplace/title/view/view.component.html
+++ b/apps/catalog/catalog/src/app/marketplace/title/view/view.component.html
@@ -15,5 +15,11 @@
         <movie-promotional-links [movie]="movie" [links]="promoLinks"></movie-promotional-links>
       </movie-header-actions>
     </movie-header>
+    <section bgAsset="hero.png">
+      <div fxLayout="column" fxLayoutAlign="center center" class="dark-contrast-theme">
+        <h2>Any questions on this Title?</h2>
+        <button mat-flat-button color="accent" (click)="openIntercom()">Contact us</button>        
+      </div>
+    </section>
   </title-marketplace-shell>
 </ng-container>

--- a/apps/catalog/catalog/src/app/marketplace/title/view/view.component.scss
+++ b/apps/catalog/catalog/src/app/marketplace/title/view/view.component.scss
@@ -1,3 +1,7 @@
 org-chip {
   margin-bottom: 32px;
 }
+
+section {
+  padding: 40px;
+}

--- a/apps/catalog/catalog/src/app/marketplace/title/view/view.component.ts
+++ b/apps/catalog/catalog/src/app/marketplace/title/view/view.component.ts
@@ -1,10 +1,11 @@
-import { Component, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnInit, Optional } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Movie } from '@blockframes/movie/+state/movie.model';
 import { MovieQuery } from '@blockframes/movie/+state/movie.query';
 import { mainRoute, additionalRoute, artisticRoute, productionRoute } from '@blockframes/movie/marketplace';
 import { Organization, OrganizationService } from '@blockframes/organization/+state';
 import { Router } from '@angular/router';
+import { Intercom } from 'ng-intercom';
 
 @Component({
   selector: 'catalog-movie-view',
@@ -40,7 +41,8 @@ export class MarketplaceMovieViewComponent implements OnInit {
   constructor(
     private movieQuery: MovieQuery,
     private orgService: OrganizationService,
-    private router: Router
+    private router: Router,
+    @Optional() private intercom: Intercom
   ) { }
 
   ngOnInit() {
@@ -54,4 +56,7 @@ export class MarketplaceMovieViewComponent implements OnInit {
     })
   }
 
+  public openIntercom(): void {
+    return this.intercom.show();
+  }
 }

--- a/apps/catalog/catalog/src/app/marketplace/title/view/view.module.ts
+++ b/apps/catalog/catalog/src/app/marketplace/title/view/view.module.ts
@@ -1,6 +1,7 @@
 // Angular
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FlexLayoutModule } from '@angular/flex-layout';
 
 // Component
 import { MarketplaceMovieViewComponent } from './view.component';
@@ -12,6 +13,7 @@ import { PromotionalLinksModule } from '@blockframes/movie/components/promotiona
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { OrgChipModule } from '@blockframes/organization/components/chip/chip.module';
+import { ImageModule } from '@blockframes/media/image/directives/image.module';
 
 const routes = [{
   path: '',
@@ -64,6 +66,8 @@ const routes = [{
     WishlistButtonModule,
     PromotionalLinksModule,
     OrgChipModule,
+    ImageModule,
+    FlexLayoutModule,
     MatButtonModule,
     MatIconModule,
     RouterModule.forChild(routes)

--- a/libs/contract/src/lib/avails/form/avails.form.ts
+++ b/libs/contract/src/lib/avails/form/avails.form.ts
@@ -7,7 +7,16 @@ import { compareDates, isDateInFuture } from '@blockframes/utils/form/validators
 
 function createAvailControl(avail: Partial<AvailsFilter> = {}, required: ('territories' | 'duration')[]) {
   const fromValidators = required.includes('duration') ? [compareDates('from', 'to', 'from'), isDateInFuture, Validators.required] : [];
-  const toValidators = required.includes('duration') ? [compareDates('from', 'to', 'to'), isDateInFuture, Validators.required] : []
+  const toValidators = required.includes('duration') ? [compareDates('from', 'to', 'to'), isDateInFuture, Validators.required] : [];
+
+  if (!avail.duration) {
+    const date = new Date();
+    avail.duration = {
+      from: date,
+      to: new Date(date.getFullYear() + 1, date.getMonth(), date.getDate())
+    }
+  }
+
   return {
     territories: new FormStaticValueArray<'territories'>(avail.territories, 'territories', required.includes('territories') ? [Validators.required] : []),
     medias: new FormStaticValueArray<'medias'>(avail.medias, 'medias', [Validators.required]),


### PR DESCRIPTION
To do's in issue #5924
- [x] Country of origin filter: remove "World" from the list
- [x] Remove Language & version filter from `catalog` app only
- [x] Avails filter: if possible, fill start date by default with current day & end date with the current day + 1 year

#### Movie view marketplace 
- [x] Avails tab, world map: do the same as avails filter above (start date = current date; end date = current date + 1 year by default)
- [x] add a hero with a "Contact Us" CTA that opens Intercom cf [zeplin](https://app.zeplin.io/project/5fecb41a2e806651584e265c/screen/6086ad1bcd8a35129d08f3e3)
![image.png](https://images.zenhubusercontent.com/5c6a89ac8de1b31d5443ab99/3793ac15-cc36-4479-b62a-09d5fbd3e82c)
- [x] Check with @jdrns how to change the contact link UI above the map & calendar 
![image.png](https://images.zenhubusercontent.com/5c6a89ac8de1b31d5443ab99/178ff8cb-3780-44b0-b00e-63f33d87da90)