### PR TITLE
prevent to many operations trigger

### DIFF
--- a/apps/rules/src/tests/firestore/invitation.spec.ts
+++ b/apps/rules/src/tests/firestore/invitation.spec.ts
@@ -78,7 +78,7 @@ describe('Invitation Rules Tests', () => {
         ['fromUser', { uid: 'uid-user3' }],
         ['toOrg', { id: 'O008' }],
         ['toUser', { uid: 'uid-sAdmin' }],
-        ['docId', 'I002'],
+        ['eventId', 'I002'],
       ];
       test.each(fields)("updating restricted '%s' field shouldn't be able", async (key, value) => {
         const inviteRef = db.doc(`invitations/${existInviteId}`);

--- a/firestore.rules
+++ b/firestore.rules
@@ -134,8 +134,10 @@ service cloud.firestore {
         && isRequestFieldValueEqualToOrNotSetted(['id'], invitationId)
         && notInMaintenance();
     	allow update: if  (
-      	isOnlyChangingInvitationWatchTime()
-        || isOnlyChangingInvitationStatus()
+        isNotUpdatingCommonInvitationFields() && (
+          isOnlyChangingInvitationWatchTime()
+          || isOnlyChangingInvitationStatus()
+        )
       ) && notInMaintenance();
       allow delete: if isInvitationSender()
         && notInMaintenance();
@@ -178,32 +180,30 @@ service cloud.firestore {
     }
 
     function isOnlyChangingInvitationStatus() {
-      return isInvitationRecepient()
-        &&
-        (
-          isNotUpdatingId('id', existingData().id)
-          && isNotUpdatingField(['mode'])
-          && isNotUpdatingField(['fromOrg', 'id'])
-          && isNotUpdatingField(['fromUser', 'uid'])
-          && isNotUpdatingField(['toOrg', 'id'])
-          && isNotUpdatingField(['toUser', 'uid'])
-          && isNotUpdatingField(['docId'])
-        );
+      return (
+        isInvitationRecepient()
+        && isNotUpdatingField(['watchTime'])
+      );
     }
 
     function isOnlyChangingInvitationWatchTime() {
       return (
         existingData().type == 'attendEvent'
-        && isNotUpdatingId('id', existingData().id)
+        && isNotUpdatingField(['status'])
+    	);
+    }
+
+    function isNotUpdatingCommonInvitationFields() {
+      return ( 
+        isNotUpdatingId('id', existingData().id)
         && isNotUpdatingField(['mode'])
         && isNotUpdatingField(['fromOrg', 'id'])
         && isNotUpdatingField(['fromUser', 'uid'])
         && isNotUpdatingField(['toOrg', 'id'])
         && isNotUpdatingField(['toUser', 'uid'])
-        && isNotUpdatingField(['docId'])
-        && isNotUpdatingField(['status'])
+        && isNotUpdatingField(['eventId'])
         && isNotUpdatingField(['type'])
-    	);
+      );
     }
 
 


### PR DESCRIPTION
Accepting an invitation was not possible anymore because we reached the maximum number of operations allowed to verify a rule.

I updated the rules to make less operations
Also replaced docId by eventId because the notification interface was changed few months ago.