### PR TITLE
fix rule datamodel

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -369,9 +369,9 @@ service cloud.firestore {
     }
 
     match /incomes/{incomeId} {
-      allow read: if userOrgId() in getContract(existingData().id).stakeholders
+      allow read: if userOrgId() in getContract(incomeId).stakeholders
         && notInMaintenance();
-      allow create: if (userOrgId() == getContract(incomingData().id).buyerId)
+      allow create: if (userOrgId() == getContract(incomeId).buyerId)
         && notInMaintenance();
       allow update: if false;
       allow delete: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -194,7 +194,7 @@ service cloud.firestore {
     }
 
     function isNotUpdatingCommonInvitationFields() {
-      return ( 
+      return (
         isNotUpdatingId('id', existingData().id)
         && isNotUpdatingField(['mode'])
         && isNotUpdatingField(['fromOrg', 'id'])
@@ -369,9 +369,9 @@ service cloud.firestore {
     }
 
     match /incomes/{incomeId} {
-      allow read: if userOrgId() in getContract(existingData().contractId).stakeholders
+      allow read: if userOrgId() in getContract(existingData().id).stakeholders
         && notInMaintenance();
-      allow create: if (userOrgId() == getContract(incomingData().contractId).buyerId)
+      allow create: if (userOrgId() == getContract(incomingData().id).buyerId)
         && notInMaintenance();
       allow update: if false;
       allow delete: if false;


### PR DESCRIPTION
Incomes data model was updated to remove `contractId` and instead use the contract id as the income id.
However the firestore rules have been updated to reflect this change.

This PR fix that.