### PR TITLE
6111 Verify email of old users

### DIFF
--- a/libs/firebase-utils/src/lib/firestoreMigrations/0064.ts
+++ b/libs/firebase-utils/src/lib/firestoreMigrations/0064.ts
@@ -38,6 +38,10 @@ import { PublicUser } from '@blockframes/user/+state';
       ...user._meta
     }
 
+    if (new Date(authUser.metadata.creationTime) < new Date(2021, 5, 31)) {
+      auth.updateUser(authUser.uid, { emailVerified: true });
+    }
+
     return db.doc(`users/${user.uid}`).update({ _meta });
   });
 }

--- a/libs/user/src/lib/auth/forms/profile/profile.component.html
+++ b/libs/user/src/lib/auth/forms/profile/profile.component.html
@@ -21,15 +21,10 @@
       <mat-label>Position</mat-label>
       <input matInput test-id="position-form" placeholder="Position" type="text" [formControl]="form.get('position')" />
     </mat-form-field>
-    <section fxLayout fxLayoutAlign="space-between start">
-      <mat-form-field appearance="outline">
-        <mat-label>Email Address</mat-label>
-        <input matInput test-id="phone-form" placeholder="Email Address" type="tel" [formControl]="form.get('email')" />
-      </mat-form-field>
-      <div *ngIf="(authQuery.hasVerifiedEmail$ | async) === false" fxLayoutAlign="start center">
-        <button mat-flat-button color="accent" (click)="sendEmailVerification()" [disabled]="emailSent">{{ emailSent ? 'Email Sent' : 'Verify Email' }}</button>
-      </div>
-    </section>
+    <mat-form-field appearance="outline">
+      <mat-label>Email Address</mat-label>
+      <input matInput test-id="phone-form" placeholder="Email Address" type="tel" [formControl]="form.get('email')" />
+    </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>Phone number</mat-label>
       <input matInput test-id="phone-form" placeholder="Phone number" type="tel" [formControl]="form.get('phoneNumber')" />

--- a/libs/user/src/lib/auth/forms/profile/profile.component.ts
+++ b/libs/user/src/lib/auth/forms/profile/profile.component.ts
@@ -13,24 +13,9 @@ import { RouterQuery } from '@datorama/akita-ng-router-store';
 })
 export class ProfileFormComponent {
   public uid = this.authQuery.userId;
-  public emailSent = false;
 
   @Input() form: ProfileForm;
 
-  constructor(
-    public authQuery: AuthQuery,
-    private cdr: ChangeDetectorRef,
-    private functions: AngularFireFunctions,
-    private routerQuery: RouterQuery
-  ) {}
+  constructor(public authQuery: AuthQuery) {}
 
-  async sendEmailVerification() {
-    const publicUser = this.authQuery.user;
-    const app = getCurrentApp(this.routerQuery);
-
-    const sendVerifyEmail = this.functions.httpsCallable('sendVerifyEmailAddress');
-    await sendVerifyEmail({ email: publicUser.email, publicUser, app }).toPromise();
-    this.emailSent = true;
-    this.cdr.markForCheck();
-  }
 }

--- a/libs/user/src/lib/auth/forms/profile/profile.module.ts
+++ b/libs/user/src/lib/auth/forms/profile/profile.module.ts
@@ -11,7 +11,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [ProfileFormComponent],
@@ -25,8 +24,7 @@ import { MatButtonModule } from '@angular/material/button';
     MatCardModule,
     MatFormFieldModule,
     MatDividerModule,
-    MatInputModule,
-    MatButtonModule
+    MatInputModule
   ],
   exports: [ProfileFormComponent]
 })

--- a/libs/user/src/lib/auth/guard/email-verified.guard.ts
+++ b/libs/user/src/lib/auth/guard/email-verified.guard.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { AuthQuery } from '../+state';
 import { map } from 'rxjs/operators';
-import { toDate } from '@blockframes/utils/helpers';
 
 @Injectable({
   providedIn: 'root'
@@ -12,15 +11,7 @@ export class EmailVerifiedGuard implements CanActivate  {
 
   canActivate() {
     return this.authQuery.select().pipe(
-      map(user => {
-        // Only since the specified date we enforce users to verify their email address.
-        const isOld = !user.profile._meta || toDate(user.profile._meta.createdAt) < new Date('2021-05-31');
-        if (!isOld && !user.emailVerified) {
-          return this.router.createUrlTree(['/auth/identity']);
-        } else {
-          return true;
-        }
-      })
+      map(user => user.emailVerified ? true : this.router.createUrlTree(['/auth/identity']))
     )
   }
 


### PR DESCRIPTION
Fix issue #6111
- [x] Set emailVerified to true for users created before 31-5-2021
- [x] Create and save file with all current unverified users
- [x] Remove check for old users in EmailVerifiedGuard
- [x] Remove 'verify email' from Profile page