### PR TITLE
overload toLabel

### DIFF
--- a/libs/ui/src/lib/marketplace/pages/wishlist/wishlist.component.html
+++ b/libs/ui/src/lib/marketplace/pages/wishlist/wishlist.component.html
@@ -28,7 +28,7 @@
       <ng-container matColumnDef="originCountry">
         <th mat-header-cell *matHeaderCellDef>Country of origin</th>
         <td mat-cell *matCellDef="let element">
-          <span>{{ element.originCountries | slice: 0:2 | toLabel: 'territories' }}</span>
+          <span>{{ $any(element.originCountries | slice: 0:2) | toLabel: 'territories' }}</span>
         </td>
       </ng-container>
 

--- a/libs/utils/src/lib/pipes/to-label.pipe.ts
+++ b/libs/utils/src/lib/pipes/to-label.pipe.ts
@@ -7,6 +7,8 @@ import { staticModel, Scope } from '@blockframes/utils/static-model';
 })
 export class ToLabelPipe implements PipeTransform {
   //@TODO #5530 remove limit and use css instead
+  transform(value: string, scope: Scope): string
+  transform(value: string[], scope: Scope): string[]
   transform(value: string | string[], scope: Scope): string | string[] {
     if (!value) return '';
     try {

--- a/libs/utils/src/lib/pipes/to-label.pipe.ts
+++ b/libs/utils/src/lib/pipes/to-label.pipe.ts
@@ -2,14 +2,12 @@ import { NgModule, Pipe, PipeTransform } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { staticModel, Scope } from '@blockframes/utils/static-model';
 
-@Pipe({
-  name: 'toLabel'
-})
+@Pipe({ name: 'toLabel' })
 export class ToLabelPipe implements PipeTransform {
   //@TODO #5530 remove limit and use css instead
-  transform(value: string, scope: Scope): string
+  transform(value: string | null | undefined, scope: Scope): string
   transform(value: string[], scope: Scope): string[]
-  transform(value: string | string[], scope: Scope): string | string[] {
+  transform(value: string | null | undefined | string[], scope: Scope): string | string[] {
     if (!value) return '';
     try {
       if (Array.isArray(value)) {
@@ -18,8 +16,9 @@ export class ToLabelPipe implements PipeTransform {
         return staticModel[scope][value];
       }
     } catch (error) {
-      console.error(`Could not find label for key "${value}" in scope "${scope}"`)
-      return value;
+      console.error(`Could not find label for key "${value}" in scope "${scope}"`);
+      if (typeof value === 'string') return value;
+      return '';
     }
   }
 }


### PR DESCRIPTION
Use case: 
```
{{ text | toLabel:'offerStatus' | titlecase }}
```
this would fails, because the output can be an array. by overloading you say that if the first param is a string, then the return value is a string.