### PR TITLE
Fix avail exclusivity check

### DIFF
--- a/libs/contract/src/lib/avails/avails.ts
+++ b/libs/contract/src/lib/avails/avails.ts
@@ -83,7 +83,7 @@ export function termsCollision(avails: AvailsFilter, terms: BucketTerm<Date>[]) 
 
 /** Get all the terms that overlap the avails filter */
 export function collidingTerms<T extends BucketTerm>(avails: AvailsFilter, terms: T[]) {
-  return terms.filter(term => saleExclusivityCheck(avails, term)
+  return terms.filter(term => !saleExclusivityCheck(avails, term)
     && someOf(avails.territories, 'optional').in(term.territories)
     && someOf(avails.medias, 'optional').in(term.medias)
     && someOf(avails.duration, 'optional').in(term.duration)

--- a/libs/contract/src/lib/avails/tests/territories.spec.ts
+++ b/libs/contract/src/lib/avails/tests/territories.spec.ts
@@ -1,6 +1,6 @@
 import { createMandate } from "../../contract/+state/contract.model";
 import { availableTerritories, getMandateTerms, collidingTerms, toTerritoryMarker } from "./../avails";
-import { createTerm, Term } from "../../term/+state/term.model";
+import { createTerm } from "../../term/+state/term.model";
 import { availDetailsExclusive, availDetailsNonExclusive } from './../fixtures/availsFilters';
 
 describe('Test availableTerritories pure function', () => {


### PR DESCRIPTION
solve one item of #7347

Exclusivity wasn't handle the right way, so I updated it with the following truth tables:

|Avails➡<br/>Mandate⬇|Exclusive|Non-Exclusive|
|-|-|-|
|Exclusive|✅|✅|
|Non-Exclusive|❌|✅|

|Avails➡<br/>Sale⬇|Exclusive|Non-Exclusive|
|-|-|-|
|Exclusive|❌|❌|
|Non-Exclusive|❌|✅|

> The above tables where defined during a discussion with @cams-goussale & @Jackseed 