### PR TITLE
send contractId on addNegotiation

### DIFF
--- a/apps/catalog/catalog/src/app/dashboard/sales/shell/negotiation/negotiation.component.ts
+++ b/apps/catalog/catalog/src/app/dashboard/sales/shell/negotiation/negotiation.component.ts
@@ -66,11 +66,11 @@ export class NegotiationComponent implements NegotiationGuardedComponent, OnInit
   async confirm() {
     const onConfirm = async () => {
       const sale = await this.sale$.pipe(first()).toPromise();
-      this.form.markAsPristine(); // usefull to be able to route in the NegotiationGuard
       await this.contractService.addNegotiation(sale.id, {
         ...sale.negotiation,
         ...this.form.value,
       });
+      this.form.markAsPristine(); // usefull to be able to route in the NegotiationGuard
       this.snackBar.open('Your counter offer has been sent');
       this.router.navigate(['..', 'view'], { relativeTo: this.route });
     };

--- a/libs/contract/src/lib/contract/+state/contract.service.ts
+++ b/libs/contract/src/lib/contract/+state/contract.service.ts
@@ -57,7 +57,7 @@ export class ContractService extends CollectionService<ContractState> {
     const write = this.batch();
     const sale = await this.valueChanges(contractId).pipe(first()).toPromise();
 
-    this.negotiationService.add({
+    await this.negotiationService.add({
       _meta: createDocumentMeta({ createdAt: new Date(), }),
       status: 'pending',
       createdByOrg: activeOrgId,
@@ -71,7 +71,7 @@ export class ContractService extends CollectionService<ContractState> {
       parentTermId: contract.parentTermId,
       specificity: contract.specificity,
       orgId: contract.orgId,
-    }, { write })
+    }, { write, params: { contractId }})
     if (sale.status === 'pending') this.update(contractId, { status: 'negotiating' }, { write })
     await write.commit()
   }

--- a/libs/contract/src/lib/contract/+state/contract.service.ts
+++ b/libs/contract/src/lib/contract/+state/contract.service.ts
@@ -57,7 +57,7 @@ export class ContractService extends CollectionService<ContractState> {
     const write = this.batch();
     const sale = await this.valueChanges(contractId).pipe(first()).toPromise();
 
-    await this.negotiationService.add({
+    this.negotiationService.add({
       _meta: createDocumentMeta({ createdAt: new Date(), }),
       status: 'pending',
       createdByOrg: activeOrgId,


### PR DESCRIPTION
- set negotiationForm as pristine only once we've finished adding the negotiation.
- added lacking contractId during addition of new negotiation.