### PR TITLE
fixes for 7981 7983

### DIFF
--- a/apps/festival/festival/src/app/marketplace/marketplace.component.html
+++ b/apps/festival/festival/src/app/marketplace/marketplace.component.html
@@ -3,10 +3,7 @@
     <marketplace-aside></marketplace-aside>
   </aside> 
 
-  <header fxFlex fxLayout fxLayoutAlign="space-between center" class="marketplace-header">
-    <a class="festival-logo" href="https://www.screendaily.com/" target="_blank">
-      <img asset="screen-logo.png" />
-    </a> 
+  <header fxFlex fxLayout fxLayoutAlign="end center" class="marketplace-header">
 
     <div fxLayoutAlign="center center" fxLayoutGap="24px">
       <a mat-button class="link-to-app" color="primary" [href]="applicationUrl.catalog" target="_blank">        

--- a/apps/festival/festival/src/styles.scss
+++ b/apps/festival/festival/src/styles.scss
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 @import "../../../../styles/style.scss";
 @import "../../../../styles/themes/builder.scss";
-@import "../../../../styles/themes/screen-daily.scss";
+@import "../../../../styles/themes/blockframes.scss";
 
 
 .dark-theme {

--- a/libs/media/src/lib/image/uploader/uploader.component.ts
+++ b/libs/media/src/lib/image/uploader/uploader.component.ts
@@ -318,6 +318,7 @@ export class ImageUploaderComponent implements OnInit, OnDestroy {
 
     this.fileUploader.nativeElement.value = null;
     this.selectionChange.emit('removed');
+    this.form?.markAsDirty();
 
     this.nextStep('drop');
   }

--- a/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
+++ b/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
@@ -45,7 +45,7 @@ const titleType: Record<NotificationTypesBase, NotificationSetting> = {
 const tables: { title: string, types: string[], appAuthorized: App[] }[] = [
   {
     title: 'Company Management',
-    types: ['requestFromUserToJoinOrgCreate', 'orgMemberUpdated', 'requestFromUserToJoinOrgDeclined'],
+    types: ['requestFromUserToJoinOrgCreate', 'orgMemberUpdated'],
     appAuthorized: ['catalog', 'festival', 'financiers']
   },
   {

--- a/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
+++ b/libs/user/src/lib/auth/forms/notifications-form/notifications-form.component.ts
@@ -29,7 +29,7 @@ const titleType: Record<NotificationTypesBase, NotificationSetting> = {
   invitationToAttendMeetingCreated: { text: 'You are invited to a meeting. (RECOMMENDED)', tooltip: true },
   invitationToAttendScreeningCreated: { text: 'You are invited to a screening. (RECOMMENDED)', tooltip: true },
   screeningRequested: { text: 'A screening has been requested. (RECOMMENDED)', tooltip: false },
-  screeningRequestSent: { text: 'Your screening request for screening was successfully sent', tooltip: false },
+  screeningRequestSent: { text: 'Your screening request was successfully sent', tooltip: false },
   offerCreatedConfirmation: { text: 'Your offer is successfully sent', tooltip: false },
   contractCreated: { text: 'An offer has been made on one of your titles. (RECOMMENDED)', tooltip: true },
   createdCounterOffer: { text: 'You\'ve created a counter offer.', tooltip: true },

--- a/libs/user/src/lib/auth/pages/profile/profile.component.ts
+++ b/libs/user/src/lib/auth/pages/profile/profile.component.ts
@@ -53,6 +53,7 @@ export class ProfileComponent implements OnInit {
         const { current, next } = this.passwordForm.value;
         await this.authService.updatePassword(current, next);
         this.snackBar.open('Password changed.', 'close', { duration: 2000 });
+        this.passwordForm.reset();
         this.passwordForm.markAsPristine();
       }
     } catch (error) {


### PR DESCRIPTION
#7981
- [x] (A) We can switch archipel market's theme back to the standard one (without the Screen colors).

#7983
- [x] (C) **Update Profile information** > **Update Profile**
Impossible to remove the profil image alone, for remove it, I have to change another field too.

- [x] When changing the password, it should reset all the fields or go back to the previous page. Staying on the same page with all 3 fields still filled seems strange :
![password](https://user-images.githubusercontent.com/78768220/158814653-c7945605-903e-484f-9c92-8b6479d42a4b.gif)

- [x] In `notification`, the last line is not clear :
![image](https://user-images.githubusercontent.com/78768220/158814730-839c1d29-c603-4a2e-b32b-eba55880732f.png)
Might be : "Your screening request was successfully sent"