### PR TITLE
fixes for 7981 and 7979

### DIFF
--- a/apps/crm/crm/src/app/crm/pages/organization/organization.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/organization/organization.component.ts
@@ -97,20 +97,18 @@ export class OrganizationComponent implements OnInit {
   }
 
   private async getMembers() {
-    const [ members, role ] = await Promise.all([
+    const [members, role] = await Promise.all([
       this.organizationService.getMembers(this.orgId),
       this.permissionService.getValue(this.orgId)
     ]);
-    return members.map((m) => {
-      return {
-        ...createOrganizationMember(m, role.roles[m.uid] ? role.roles[m.uid] : undefined),
-        userId: m.uid,
-        edit: {
-          id: m.uid,
-          link: `/c/o/dashboard/crm/user/${m.uid}`,
-        },
-      };
-    });
+    return members.map((m) => ({
+      ...createOrganizationMember(m, role.roles[m.uid] ? role.roles[m.uid] : undefined),
+      userId: m.uid,
+      edit: {
+        id: m.uid,
+        link: `/c/o/dashboard/crm/user/${m.uid}`,
+      },
+    }));
   }
 
   public async update() {

--- a/apps/crm/crm/src/app/crm/pages/organization/organization.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/organization/organization.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { OrganizationCrmForm } from '@blockframes/admin/crm/forms/organization-crm.form';
 import { fromOrg, MovieService } from '@blockframes/movie/+state/movie.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Organization, Movie, Invitation, UserRole } from '@blockframes/model';
+import { Organization, Movie, Invitation, UserRole, createOrganizationMember } from '@blockframes/model';
 import { OrganizationService } from '@blockframes/organization/+state/organization.service';
 import { FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
@@ -97,15 +97,20 @@ export class OrganizationComponent implements OnInit {
   }
 
   private async getMembers() {
-    const members = await this.organizationService.getMembers(this.orgId);
-    return members.map((m) => ({
-      ...m,
-      userId: m.uid,
-      edit: {
-        id: m.uid,
-        link: `/c/o/dashboard/crm/user/${m.uid}`,
-      },
-    }));
+    const [ members, role ] = await Promise.all([
+      this.organizationService.getMembers(this.orgId),
+      this.permissionService.getValue(this.orgId)
+    ]);
+    return members.map((m) => {
+      return {
+        ...createOrganizationMember(m, role.roles[m.uid] ? role.roles[m.uid] : undefined),
+        userId: m.uid,
+        edit: {
+          id: m.uid,
+          link: `/c/o/dashboard/crm/user/${m.uid}`,
+        },
+      };
+    });
   }
 
   public async update() {

--- a/libs/media/src/lib/file/explorer/explorer.component.scss
+++ b/libs/media/src/lib/file/explorer/explorer.component.scss
@@ -44,6 +44,10 @@
         }
       }
     }
+
+    mat-divider {
+      position: initial;
+    }
   }
 }
 

--- a/libs/media/src/lib/file/file-uploader/file-uploader.component.html
+++ b/libs/media/src/lib/file/file-uploader/file-uploader.component.html
@@ -39,7 +39,7 @@
   <img [asset]="fileName | fileTypeImage" alt="file image" class="file-uploaded">
   <h3>{{ fileName | fileName }}</h3>
   <span *ngIf="!!file" class="mat-body-2">{{ file.size | fileSize }}</span>
-  <button mat-mini-fab color="divider">
-    <mat-icon (click)="delete()" svgIcon="close" matTooltip="Delete File"></mat-icon>
+  <button mat-mini-fab color="divider" (click)="delete()">
+    <mat-icon svgIcon="close" matTooltip="Delete File"></mat-icon>
   </button>
 </ng-template>

--- a/libs/media/src/lib/image/uploader/uploader.component.html
+++ b/libs/media/src/lib/image/uploader/uploader.component.html
@@ -25,11 +25,11 @@
     <image-cropper [imageFile]="file" [aspectRatio]="cropRatio" format="webp" [containWithinAspectRatio]="false"
       [resizeToWidth]="setWidth || parentWidth" (imageCropped)="imageCropped($event)"></image-cropper>
     <div class="buttons" fxLayout="row" fxLayoutAlign="space-evenly center">
-      <button mat-mini-fab color="primary">
-        <mat-icon (click)="cropIt()" svgIcon="check"></mat-icon>
+      <button mat-mini-fab color="primary" (click)="cropIt()">
+        <mat-icon svgIcon="check"></mat-icon>
       </button>
-      <button mat-mini-fab color="warn">
-        <mat-icon (click)="nextStep('drop')" svgIcon="close"></mat-icon>
+      <button mat-mini-fab color="warn" (click)="nextStep('drop')">
+        <mat-icon svgIcon="close"></mat-icon>
       </button>
     </div>
   </article>
@@ -39,16 +39,16 @@
     <img class="croppedImage" [src]="croppedImage || (previewUrl$ | async)" />
     <div class="buttons" fxLayout="row" fxLayoutAlign="space-evenly center">
       <ng-container *ngIf="useFileUploader">
-        <button mat-mini-fab color="primary">
-          <mat-icon (click)="fileUploader.click()" svgIcon="image" matTooltip="Select new picture"></mat-icon>
+        <button mat-mini-fab color="primary" (click)="fileUploader.click()">
+          <mat-icon svgIcon="image" matTooltip="Select new picture"></mat-icon>
         </button>
       </ng-container>
       <button mat-mini-fab color="accent" *ngIf="(previewUrl$ | async) as url">
         <mat-icon [cdkCopyToClipboard]="url" svgIcon="archive" matTooltip="Copy image url"></mat-icon>
       </button>
       <ng-container *ngIf="useDelete">
-        <button mat-mini-fab color="warn">
-          <mat-icon (click)="delete()" svgIcon="delete" matTooltip="Delete current picture"></mat-icon>
+        <button mat-mini-fab color="warn" (click)="delete()">
+          <mat-icon svgIcon="delete" matTooltip="Delete current picture"></mat-icon>
         </button>
       </ng-container>
     </div>

--- a/libs/organization/src/lib/organization/+state/organization.service.ts
+++ b/libs/organization/src/lib/organization/+state/organization.service.ts
@@ -6,7 +6,6 @@ import { AngularFireFunctions } from '@angular/fire/functions';
 import { UserService } from '@blockframes/user/+state';
 import { 
   OrganizationMember,
-  createOrganizationMember,
   PublicUser,
   User,
   Movie,
@@ -14,7 +13,8 @@ import {
   createOrganization,
   OrganizationDocument,
   createPermissions,
-  UserRole
+  UserRole,
+  createPublicUser
 } from '@blockframes/model';
 import { PermissionsService } from '@blockframes/permissions/+state/permissions.service';
 import { App, Module, createOrgAppAccess } from '@blockframes/utils/apps';
@@ -158,14 +158,11 @@ export class OrganizationService extends CollectionService<OrganizationState> {
     return this.update(orgId, { userIds });
   }
 
-  public async getMembers(orgId: string): Promise<OrganizationMember[]> {
+  public async getMembers(orgId: string): Promise<PublicUser[]> {
     const org = await this.getValue(orgId);
     const promises = org.userIds.map((uid) => this.userService.getValue(uid));
     const users = await Promise.all(promises);
-    const role = await this.permissionsService.getValue(orgId);
-    return users.map((u) =>
-      createOrganizationMember(u, role.roles[u.uid] ? role.roles[u.uid] : undefined)
-    );
+    return users.map((u) => createPublicUser(u));
   }
 
   public async getMemberRole(_org: Organization | string, uid): Promise<UserRole> {


### PR DESCRIPTION
#7981
- [x] When trying to validate a picture with the dedicated button, clicking close to the border of the button activate the 'click effect' but without the 'validate action'. It's the same with the other picture related buttons (like delete). The button's hitbox should be the circle and not just the icon inside, the user could think the app isn't working properly :
![Validating picture](https://user-images.githubusercontent.com/78768220/158815569-d38c341a-08b9-43b0-88f4-ef6c2c5e9917.gif)

#7979
- [x] (A) Overview of org members is displayed
- [x] (C) Style CSS - Organization ressource