### PR TITLE
Fix overlapping of main content and the cookie banner

### DIFF
--- a/libs/utils/src/lib/gdpr-cookie/cookie-banner/cookie-banner.component.scss
+++ b/libs/utils/src/lib/gdpr-cookie/cookie-banner/cookie-banner.component.scss
@@ -1,6 +1,6 @@
 :host {
   position: fixed;
   bottom: 0;
-  z-index: 1;
+  z-index: 2;
   width: 100%;
 }


### PR DESCRIPTION
Start from: https://github.com/blockframes/blockframes/issues/7896