### PR TITLE
7689 add back no titles ui for dashboard

### DIFF
--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="titles$ | async as titles; else loading">
+<ng-container *ngIf="titles$ | async; else loading">
   <ng-container *ngIf="(hasAcceptedMovies$ | async) else noAcceptedMovies">
     <header>
       <h1>Dashboard</h1>
@@ -51,19 +51,19 @@
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
         <ng-container *ngIf="hasDraftMovies$ | async">
-          <mat-card fxLayout="column" fxLayoutalign="center center">
+          <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>
-          </mat-card>
+          </div>
         </ng-container>
-        <mat-card fxLayout="column" fxLayoutalign="center center">
+        <div class="surface" fxLayout="column" fxLayoutalign="center center">
           <img asset="add_title.svg" alt="Add title image">
           <a routerLink="../title/lobby" mat-button color="primary">Add one title</a>
-        </mat-card>
-        <mat-card fxLayout="column">
+        </div>
+        <div class="surface" fxLayout="column">
           <img asset="add_files.svg" alt="Upload files image">
           <a routerLink="../import" mat-button color="primary" test-id="import">Import titles in bulk</a>
-        </mat-card>
+        </div>
       </article>
       <h3>Or</h3>
       <button (click)="openIntercom()" mat-flat-button color="primary">

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="titles$ | async as titles; else loading">
-  <ng-container *ngIf="titles | hasAppStatus:['accepted']; else noAcceptedMovies">
+  <ng-container *ngIf="titles | hasAppStatus:'accepted'; else noAcceptedMovies">
     <header>
       <h1>Dashboard</h1>
       <a mat-fab color="black" routerLink="../title/lobby">
@@ -50,7 +50,7 @@
       </ng-template>
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
-        <ng-container *ngIf="titles | hasAppStatus:['draft']">
+        <ng-container *ngIf="titles | hasAppStatus:'draft'">
           <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -1,33 +1,83 @@
-<header>
-  <h1>Dashboard</h1>
-  <a mat-fab color="black" routerLink="../title/lobby">
-    <mat-icon svgIcon="add"></mat-icon>
-  </a>
-  <a mat-fab color="black" routerLink="../title">
-    <mat-icon svgIcon="movie"></mat-icon>
-  </a>
-  <a mat-fab color="black" routerLink="../import">
-    <mat-icon svgIcon="excel"></mat-icon>
-  </a>
-</header>
-<section class="surface carousel-container">
-  <article *ngIf="popularTitle$ | async as title">
-    <h3>{{ title.title.international }}</h3>
-    <a mat-flat-button [routerLink]="['/c/o/dashboard/analytics', title.id]">
-      <span>See Analytics details</span>
-      <mat-icon svgIcon="arrow_forward"></mat-icon>
-    </a>
+<ng-container *ngIf="titles$ | async as titles; else loading">
+  <ng-container *ngIf="(hasAcceptedMovies$ | async) else noAcceptedMovies">
+    <header>
+      <h1>Dashboard</h1>
+      <a mat-fab color="black" routerLink="../title/lobby">
+        <mat-icon svgIcon="add"></mat-icon>
+      </a>
+      <a mat-fab color="black" routerLink="../title">
+        <mat-icon svgIcon="movie"></mat-icon>
+      </a>
+      <a mat-fab color="black" routerLink="../import">
+        <mat-icon svgIcon="excel"></mat-icon>
+      </a>
+    </header>
+    <section class="surface carousel-container">
+      <article *ngIf="popularTitle$ | async as title">
+        <h3>{{ title.title.international }}</h3>
+        <a mat-flat-button [routerLink]="['/c/o/dashboard/analytics', title.id]">
+          <span>See Analytics details</span>
+          <mat-icon svgIcon="arrow_forward"></mat-icon>
+        </a>
+      </article>
+      <p class="mat-body-1">Some insights about your most popular title.<br/>Published on Archipel Market: 01/25/2022</p>
+      <bf-carousel flex layout>
+        <analytics-pie-chart fxFlex class="surface" carouselItem [col]="2" [data]="orgActivityOfPopularTitle$ | async"></analytics-pie-chart>
+        <analytics-map fxFlex class="surface" carouselItem [col]="2" [data]="territoryActivityOfPopularTitle$ | async"></analytics-map>
+      </bf-carousel>
+      <a mat-flat-button class="see_titles" routerLink="/c/o/dashboard/analytics">
+        <span>View all Titles Activity</span>
+        <mat-icon svgIcon="arrow_forward"></mat-icon>
+      </a>
+    </section>
+  </ng-container>
+  <ng-template #noAcceptedMovies>
+    <section fxLayout="column" fxLayoutAlign="center center" class="no-accepted-movies">
+      <ng-container *ngIf="(hasMovies$ | async) else noMovies">
+        <h1>No title to display.</h1>
+        <p class="mat-body-1">
+          As long as you have no title to display, your organization will not appear on the marketplace.
+          <br>
+          You can either add several titles at once through bulk import, or just one at a time.
+        </p>
+        <p class="mat-body-2">
+          N.B.: Only submitted projects will appear on the marketplace, not drafts.
+        </p>
+
+      </ng-container>
+      <ng-template #noMovies>
+        <dashboard-no-title></dashboard-no-title>
+      </ng-template>
+      <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
+        <!-- Should only be shown for noAcceptedMovies && !noMovies -->
+        <ng-container *ngIf="hasDraftMovies$ | async">
+          <mat-card fxLayout="column" fxLayoutalign="center center">
+            <img asset="add_draft.svg" alt="Manage Drafts">
+            <a routerLink="../title" mat-button color="primary">Manage Drafts</a>
+          </mat-card>
+        </ng-container>
+        <mat-card fxLayout="column" fxLayoutalign="center center">
+          <img asset="add_title.svg" alt="Add title image">
+          <a routerLink="../title/lobby" mat-button color="primary">Add one title</a>
+        </mat-card>
+        <mat-card fxLayout="column">
+          <img asset="add_files.svg" alt="Upload files image">
+          <a routerLink="../import" mat-button color="primary" test-id="import">Import titles in bulk</a>
+        </mat-card>
+      </article>
+      <h3>Or</h3>
+      <button (click)="openIntercom()" mat-flat-button color="primary">
+        Contact the {{ app | appName }} team
+      </button>
+    </section>
+  </ng-template>
+</ng-container>
+<ng-template #loading>
+  <article fxLayout="column" fxLayoutAlign="center center">
+    <mat-spinner color="primary"></mat-spinner>
   </article>
-  <p class="mat-body-1">Some insights about your most popular title.<br/>Published on Archipel Market: 01/25/2022</p>
-  <bf-carousel flex layout>
-    <analytics-pie-chart fxFlex class="surface" carouselItem [col]="2" [data]="orgActivityOfPopularTitle$ | async"></analytics-pie-chart>
-    <analytics-map fxFlex class="surface" carouselItem [col]="2" [data]="territoryActivityOfPopularTitle$ | async"></analytics-map>
-  </bf-carousel>
-  <a mat-flat-button class="see_titles" routerLink="/c/o/dashboard/analytics">
-    <span>View all Titles Activity</span>
-    <mat-icon svgIcon="arrow_forward"></mat-icon>
-  </a>
-</section>
+</ng-template>
+
 <ng-template #loading>
   <article fxLayout="column" fxLayoutAlign="center center">
     <mat-spinner color="primary"></mat-spinner>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -1,5 +1,5 @@
-<ng-container *ngIf="titles$ | async; else loading">
-  <ng-container *ngIf="(hasAcceptedMovies$ | async) else noAcceptedMovies">
+<ng-container *ngIf="titles$ | async as titles; else loading">
+  <ng-container *ngIf="titles | hasAppStatus:['accepted']; else noAcceptedMovies">
     <header>
       <h1>Dashboard</h1>
       <a mat-fab color="black" routerLink="../title/lobby">
@@ -33,7 +33,7 @@
   </ng-container>
   <ng-template #noAcceptedMovies>
     <section fxLayout="column" fxLayoutAlign="center center" class="no-accepted-movies">
-      <ng-container *ngIf="(hasMovies$ | async) else noMovies">
+      <ng-container *ngIf="titles.length; else noMovies">
         <h1>No title to display.</h1>
         <p class="mat-body-1">
           As long as you have no title to display, your organization will not appear on the marketplace.
@@ -50,7 +50,7 @@
       </ng-template>
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
-        <ng-container *ngIf="hasDraftMovies$ | async">
+        <ng-container *ngIf="titles | hasAppStatus:['draft']">
           <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -36,10 +36,9 @@ header {
 }
 
 .no-accepted-movies {
-  mat-card {
+  .surface {
     width: 330px;
-    height: 220px;
-  
+
     img {
       width: 100px;
       align-self: center;

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -34,3 +34,19 @@ header {
     margin: 24px auto auto auto;
   }
 }
+
+.no-accepted-movies {
+  mat-card {
+    width: 330px;
+    height: 220px;
+  
+    img {
+      width: 100px;
+      align-self: center;
+    }
+  }
+  
+  h3 {
+    margin-top: 24px;
+  }
+}

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -80,13 +80,13 @@ export class HomeComponent implements OnInit {
     );
 
     this.hasAcceptedMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some((movie) => movie.app[this.app].status === 'accepted'))
+      map((movies) => movies.some(hasAppStatus(this.app, ['accepted'])))
     );
 
     this.hasMovies$ = allMoviesFromOrg$.pipe(map((movies) => !!movies.length));
 
     this.hasDraftMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some((movie) => movie.app[this.app].status === 'draft'))
+      map((movies) => movies.some(hasAppStatus(this.app, ['draft'])))
     );
 
     this.titles$ = allMoviesFromOrg$.pipe(

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -1,11 +1,11 @@
 // Angular
-import { Component, OnInit, ChangeDetectionStrategy, Optional, Inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Optional, Inject } from '@angular/core';
 
 // Blockframes
 import { MovieService, fromOrg } from '@blockframes/movie/+state/movie.service';
 import { OrganizationService } from '@blockframes/organization/+state';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
-import { hasAppStatus, Movie } from '@blockframes/model';
+import { hasAppStatus } from '@blockframes/model';
 import { App } from '@blockframes/utils/apps';
 import { APP } from '@blockframes/utils/routes/utils';
 import { AnalyticsService } from '@blockframes/analytics/+state/analytics.service';
@@ -14,7 +14,7 @@ import { counter } from '@blockframes/analytics/+state/utils';
 
 // RxJs
 import { map, switchMap, shareReplay, tap, filter } from 'rxjs/operators';
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest } from 'rxjs';
 
 // Intercom
 import { Intercom } from 'ng-intercom';
@@ -25,12 +25,16 @@ import { Intercom } from 'ng-intercom';
   styleUrls: ['./home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomeComponent implements OnInit {
-  // accepted and submitted movies only
-  public titles$: Observable<Movie[]>;
-  public hasMovies$: Observable<boolean>;
-  public hasAcceptedMovies$: Observable<boolean>;
-  public hasDraftMovies$: Observable<boolean>;
+export class HomeComponent {
+  public titles$ = this.orgService.currentOrg$.pipe(
+    switchMap(({ id }) => this.movieService.valueChanges(fromOrg(id))),
+    map((titles) => titles.filter((title) => title.app[this.app].access)),
+    tap(titles => {
+      titles.filter(hasAppStatus(this.app, ['accepted', 'submitted'])).length
+        ? this.dynTitle.setPageTitle('Dashboard')
+        : this.dynTitle.setPageTitle('Dashboard', 'Empty');
+    })
+  );
 
   titleAnalytics$ = this.analyticsService.getAnalytics().pipe(
     joinWith({
@@ -71,33 +75,6 @@ export class HomeComponent implements OnInit {
     @Optional() private intercom: Intercom,
     @Inject(APP) public app: App
   ) { }
-
-  ngOnInit() {
-    const allMoviesFromOrg$ = this.orgService.currentOrg$.pipe(
-      switchMap(({ id }) => this.movieService.valueChanges(fromOrg(id))),
-      shareReplay({ refCount: true, bufferSize: 1 }),
-      map((titles) => titles.filter((title) => title.app[this.app].access))
-    );
-
-    this.hasAcceptedMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some(hasAppStatus(this.app, ['accepted'])))
-    );
-
-    this.hasMovies$ = allMoviesFromOrg$.pipe(map((movies) => !!movies.length));
-
-    this.hasDraftMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some(hasAppStatus(this.app, ['draft'])))
-    );
-
-    this.titles$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.filter(hasAppStatus(this.app, ['accepted', 'submitted']))),
-      tap((movies) => {
-        movies.length
-          ? this.dynTitle.setPageTitle('Dashboard')
-          : this.dynTitle.setPageTitle('Dashboard', 'Empty');
-      })
-    );
-  }
 
   public openIntercom(): void {
     return this.intercom.show();

--- a/apps/festival/festival/src/app/dashboard/home/home.module.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.module.ts
@@ -22,6 +22,7 @@ import { MatLayoutModule } from '@blockframes/ui/layout/layout.module';
 import { AppPipeModule } from '@blockframes/utils/pipes/app.pipe';
 import { NoTitleModule } from '@blockframes/ui/dashboard/components/no-title/no-title.module';
 import { ImageModule } from '@blockframes/media/image/directives/image.module';
+import { HasAppStatusModule } from '@blockframes/movie/pipes/has-app-status.pipe';
 
 @NgModule({
   declarations: [HomeComponent],
@@ -35,6 +36,7 @@ import { ImageModule } from '@blockframes/media/image/directives/image.module';
     AppPipeModule,
     NoTitleModule,
     ImageModule,
+    HasAppStatusModule,
 
     // Material
     MatButtonModule,

--- a/apps/festival/festival/src/app/dashboard/home/home.module.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.module.ts
@@ -19,6 +19,9 @@ import { CarouselModule } from '@blockframes/ui/carousel/carousel.module';
 import { PieChartModule } from '@blockframes/analytics/components/pie-chart/pie-chart.module';
 import { AnalyticsMapModule } from '@blockframes/analytics/components/map/map.module';
 import { MatLayoutModule } from '@blockframes/ui/layout/layout.module';
+import { AppPipeModule } from '@blockframes/utils/pipes/app.pipe';
+import { NoTitleModule } from '@blockframes/ui/dashboard/components/no-title/no-title.module';
+import { ImageModule } from '@blockframes/media/image/directives/image.module';
 
 @NgModule({
   declarations: [HomeComponent],
@@ -29,6 +32,9 @@ import { MatLayoutModule } from '@blockframes/ui/layout/layout.module';
     PieChartModule,
     AnalyticsMapModule,
     MatLayoutModule,
+    AppPipeModule,
+    NoTitleModule,
+    ImageModule,
 
     // Material
     MatButtonModule,

--- a/libs/movie/src/lib/movie/pipes/has-app-status.pipe.ts
+++ b/libs/movie/src/lib/movie/pipes/has-app-status.pipe.ts
@@ -1,0 +1,20 @@
+import { Inject, NgModule, Pipe, PipeTransform } from "@angular/core";
+import { hasAppStatus, Movie } from "@blockframes/model";
+import { App } from "@blockframes/utils/apps";
+import { APP } from "@blockframes/utils/routes/utils";
+import { StoreStatus } from "@blockframes/utils/static-model";
+
+@Pipe({ name: 'hasAppStatus' })
+export class HasAppStatusPipe implements PipeTransform {
+  constructor(@Inject(APP) public app: App) {}
+
+  transform(titles: Movie[], status: StoreStatus[]) {
+    return titles.some(hasAppStatus(this.app, status))
+  }
+}
+
+@NgModule({
+  exports: [HasAppStatusPipe],
+  declarations: [HasAppStatusPipe],
+})
+export class HasAppStatusModule { }

--- a/libs/movie/src/lib/movie/pipes/has-app-status.pipe.ts
+++ b/libs/movie/src/lib/movie/pipes/has-app-status.pipe.ts
@@ -8,8 +8,8 @@ import { StoreStatus } from "@blockframes/utils/static-model";
 export class HasAppStatusPipe implements PipeTransform {
   constructor(@Inject(APP) public app: App) {}
 
-  transform(titles: Movie[], status: StoreStatus[]) {
-    return titles.some(hasAppStatus(this.app, status))
+  transform(titles: Movie[], status: StoreStatus) {
+    return titles.some(hasAppStatus(this.app, [status]))
   }
 }
 

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.html
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="titles$ | async as titles; else loading">
-  <ng-container *ngIf="titles | hasAppStatus:['accepted']; else noAcceptedMovies">
+  <ng-container *ngIf="titles | hasAppStatus:'accepted'; else noAcceptedMovies">
     <header fxLayout="row" fxLayoutAlign="space-between center">
       <h1>Dashboard</h1>
       <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="24px">
@@ -39,7 +39,7 @@
       </ng-template>
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
-        <ng-container *ngIf="titles | hasAppStatus:['draft']">
+        <ng-container *ngIf="titles | hasAppStatus:'draft'">
           <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.html
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="titles$ | async as titles; else loading">
+<ng-container *ngIf="titles$ | async; else loading">
   <ng-container *ngIf="(hasAcceptedMovies$ | async) else noAcceptedMovies">
     <header fxLayout="row" fxLayoutAlign="space-between center">
       <h1>Dashboard</h1>
@@ -40,19 +40,19 @@
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
         <ng-container *ngIf="hasDraftMovies$ | async">
-          <mat-card fxLayout="column" fxLayoutalign="center center">
+          <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>
-          </mat-card>
+          </div>
         </ng-container>
-        <mat-card fxLayout="column" fxLayoutalign="center center">
+        <div class="surface" fxLayout="column" fxLayoutalign="center center">
           <img asset="add_title.svg" alt="Add title image">
           <a routerLink="../title/lobby" mat-button color="primary">Add one title</a>
-        </mat-card>
-        <mat-card fxLayout="column">
+        </div>
+        <div class="surface" fxLayout="column">
           <img asset="add_files.svg" alt="Upload files image">
           <a routerLink="../import" mat-button color="primary" test-id="import">Import titles in bulk</a>
-        </mat-card>
+        </div>
       </article>
       <h3>Or</h3>
       <button (click)="openIntercom()" mat-flat-button color="primary">

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.html
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.html
@@ -1,5 +1,5 @@
-<ng-container *ngIf="titles$ | async; else loading">
-  <ng-container *ngIf="(hasAcceptedMovies$ | async) else noAcceptedMovies">
+<ng-container *ngIf="titles$ | async as titles; else loading">
+  <ng-container *ngIf="titles | hasAppStatus:['accepted']; else noAcceptedMovies">
     <header fxLayout="row" fxLayoutAlign="space-between center">
       <h1>Dashboard</h1>
       <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="24px">
@@ -22,7 +22,7 @@
 
   <ng-template #noAcceptedMovies>
     <section fxLayout="column" fxLayoutAlign="center center">
-      <ng-container *ngIf="(hasMovies$ | async) else noMovies">
+      <ng-container *ngIf="titles.length else noMovies">
         <h1>No title to display.</h1>
         <p class="mat-body-1">
           As long as you have no title to display, your organization will not appear on the marketplace.
@@ -39,7 +39,7 @@
       </ng-template>
       <article fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center" fxLayoutGap="24px">
         <!-- Should only be shown for noAcceptedMovies && !noMovies -->
-        <ng-container *ngIf="hasDraftMovies$ | async">
+        <ng-container *ngIf="titles | hasAppStatus:['draft']">
           <div class="surface" fxLayout="column" fxLayoutalign="center center">
             <img asset="add_draft.svg" alt="Manage Drafts">
             <a routerLink="../title" mat-button color="primary">Manage Drafts</a>

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.scss
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.scss
@@ -11,16 +11,12 @@ header h1 {
   margin: 0;
 }
 
-mat-card {
+.surface {
   width: 330px;
-  height: 220px;
+  
   img {
     width: 100px;
     align-self: center;
-  }
-
-  bf-carousel {
-    margin-top: 24px;
   }
 }
 

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.ts
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.ts
@@ -1,11 +1,11 @@
 // Angular
-import { Component, OnInit, ChangeDetectionStrategy, Optional, Inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Optional, Inject } from '@angular/core';
 
 // Blockframes
 import { MovieService, fromOrg } from '@blockframes/movie/+state/movie.service';
 import { OrganizationService } from '@blockframes/organization/+state';
 import { DynamicTitleService } from '@blockframes/utils/dynamic-title/dynamic-title.service';
-import { hasAppStatus, Movie } from '@blockframes/model';
+import { hasAppStatus } from '@blockframes/model';
 import { App } from '@blockframes/utils/apps';
 import { APP } from '@blockframes/utils/routes/utils';
 import { MovieAnalytics } from '@blockframes/analytics/components/movie-analytics-chart/movie-analytics.model';
@@ -13,7 +13,7 @@ import { AnalyticsService } from '@blockframes/analytics/+state/analytics.servic
 import { toMovieAnalytics } from '@blockframes/analytics/components/movie-analytics-chart/utils';
 
 // RxJs
-import { map, switchMap, shareReplay, tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 // Intercom
@@ -25,12 +25,16 @@ import { Intercom } from 'ng-intercom';
   styleUrls: ['./home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomeComponent implements OnInit {
-  // accepted and submitted movies only
-  public titles$: Observable<Movie[]>;
-  public hasMovies$: Observable<boolean>;
-  public hasAcceptedMovies$: Observable<boolean>;
-  public hasDraftMovies$: Observable<boolean>;
+export class HomeComponent {
+  public titles$ = this.orgService.currentOrg$.pipe(
+    switchMap(({ id }) => this.movieService.valueChanges(fromOrg(id))),
+    map((titles) => titles.filter((title) => title.app[this.app].access)),
+    tap(titles => {
+      titles.filter(hasAppStatus(this.app, ['accepted', 'submitted'])).length
+        ? this.dynTitle.setPageTitle('Dashboard')
+        : this.dynTitle.setPageTitle('Dashboard', 'Empty');
+    })
+  );
 
   public titlesAnalytics$: Observable<MovieAnalytics[]> = this.orgService.currentOrg$.pipe(
     switchMap(({ id }) => this.analytics.valueChanges(ref => ref
@@ -48,33 +52,6 @@ export class HomeComponent implements OnInit {
     @Optional() private intercom: Intercom,
     @Inject(APP) public app: App
   ) {}
-
-  ngOnInit() {
-    const allMoviesFromOrg$ = this.orgService.currentOrg$.pipe(
-      switchMap(({ id }) => this.movieService.valueChanges(fromOrg(id))),
-      shareReplay({ refCount: true, bufferSize: 1 }),
-      map((titles) => titles.filter((title) => title.app[this.app].access))
-    );
-
-    this.hasAcceptedMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some(hasAppStatus(this.app, ['accepted'])))
-    );
-
-    this.hasMovies$ = allMoviesFromOrg$.pipe(map((movies) => !!movies.length));
-
-    this.hasDraftMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some(hasAppStatus(this.app, ['draft'])))
-    );
-
-    this.titles$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.filter(hasAppStatus(this.app, ['accepted', 'submitted']))),
-      tap((movies) => {
-        movies.length
-          ? this.dynTitle.setPageTitle('Dashboard')
-          : this.dynTitle.setPageTitle('Dashboard', 'Empty');
-      })
-    );
-  }
 
   public openIntercom(): void {
     return this.intercom.show();

--- a/libs/ui/src/lib/dashboard/pages/home/home.component.ts
+++ b/libs/ui/src/lib/dashboard/pages/home/home.component.ts
@@ -57,13 +57,13 @@ export class HomeComponent implements OnInit {
     );
 
     this.hasAcceptedMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some((movie) => movie.app[this.app].status === 'accepted'))
+      map((movies) => movies.some(hasAppStatus(this.app, ['accepted'])))
     );
 
     this.hasMovies$ = allMoviesFromOrg$.pipe(map((movies) => !!movies.length));
 
     this.hasDraftMovies$ = allMoviesFromOrg$.pipe(
-      map((movies) => movies.some((movie) => movie.app[this.app].status === 'draft'))
+      map((movies) => movies.some(hasAppStatus(this.app, ['draft'])))
     );
 
     this.titles$ = allMoviesFromOrg$.pipe(

--- a/libs/ui/src/lib/dashboard/pages/home/home.module.ts
+++ b/libs/ui/src/lib/dashboard/pages/home/home.module.ts
@@ -7,7 +7,6 @@ import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 // Libraries
@@ -36,7 +35,6 @@ import { AppPipeModule } from '@blockframes/utils/pipes/app.pipe';
     MatButtonModule,
     MatIconModule,
     MatTooltipModule,
-    MatCardModule,
     MatProgressSpinnerModule,
 
     // Routing

--- a/libs/ui/src/lib/dashboard/pages/home/home.module.ts
+++ b/libs/ui/src/lib/dashboard/pages/home/home.module.ts
@@ -3,7 +3,7 @@ import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-//Material
+// Material
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -20,6 +20,7 @@ import { MovieAnalyticsChartModule } from '@blockframes/analytics/components/mov
 import { ImageModule } from '@blockframes/media/image/directives/image.module';
 import { NoTitleModule } from '@blockframes/ui/dashboard/components/no-title/no-title.module';
 import { AppPipeModule } from '@blockframes/utils/pipes/app.pipe';
+import { HasAppStatusModule } from '@blockframes/movie/pipes/has-app-status.pipe';
 
 @NgModule({
   declarations: [HomeComponent],
@@ -30,6 +31,7 @@ import { AppPipeModule } from '@blockframes/utils/pipes/app.pipe';
     ImageModule,
     NoTitleModule,
     AppPipeModule,
+    HasAppStatusModule,
 
     // Material
     MatButtonModule,


### PR DESCRIPTION
The states of dashboard where an organization doesn't have any (accepted) movie yet was accidentally removed. This PR adds it back.
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/27687382/160860582-d3910b78-9f6b-4ff4-96f9-c384346b671d.png">
