### PR TITLE
made languages optional in import template

### DIFF
--- a/libs/import/src/lib/utils.ts
+++ b/libs/import/src/lib/utils.ts
@@ -100,7 +100,7 @@ export async function getTitleId(
     ? ref => ref.where('title.international', '==', nameOrId)
     : ref => ref.where('title.international', '==', nameOrId).where('orgIds', 'array-contains', userOrgId);
   const titles = await titleService.getValue(queryFn);
-  if (!titles.length) throw new Error(`No title found with name "${nameOrId}".`);
+  if (!titles.length) throw new Error(`No title found with name/id "${nameOrId}".`);
   if (titles.length !== 1) throw new Error(`Multiple titles with name "${nameOrId}" found.`);
   return memo(nameOrId, titles[0]);
 }

--- a/libs/import/src/lib/view-extracted-elements/contract/utils.ts
+++ b/libs/import/src/lib/view-extracted-elements/contract/utils.ts
@@ -82,7 +82,7 @@ function toTerm(rawTerm: FieldsConfig['term'][number], contractId: string, fires
 
   const languages: Term['languages'] = {};
 
-  const updateLanguage = (key: keyof MovieLanguageSpecification, rawLanguages: Language[]) => {
+  const updateLanguage = (key: keyof MovieLanguageSpecification, rawLanguages: Language[] = []) => {
     for (const language of rawLanguages) {
       if (!languages[language])
         languages[language] = { caption: false, dubbed: false, subtitle: false };


### PR DESCRIPTION
For optional fields like `caption` , `dubbed` and `subtitle`, we set a default value of `[]` during term creation.
