### PR TITLE
7834 sellers analytics remarks

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { AnalyticsService } from "@blockframes/analytics/+state/analytics.service";
 import { aggregate } from "@blockframes/analytics/+state/utils";
 import { AggregatedAnalytic } from "@blockframes/model";
-import { MovieService } from "@blockframes/movie/+state/movie.service";
+import { fromOrgAndAccepted, MovieService } from "@blockframes/movie/+state/movie.service";
 import { OrganizationService } from "@blockframes/organization/+state";
 import { UserService } from "@blockframes/user/+state";
 import { App } from "@blockframes/utils/apps";
@@ -21,7 +21,7 @@ import { map } from "rxjs/operators";
 export class BuyersAnalyticsComponent {
 
   // The analytics of each buyer who interacted with sellers' title
-  buyersAnalytics$ = this.titleService.queryDashboard(this.app).pipe(
+  buyersAnalytics$ = this.titleService.valueChanges(fromOrgAndAccepted(this.orgService.org.id, this.app)).pipe(
     joinWith({
       analytics: title => this.analytics.getTitleAnalytics({ titleId: title.id }),
     }, { shouldAwait: true }),

--- a/apps/festival/festival/src/app/dashboard/analytics/titles/titles-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/titles/titles-analytics.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs/operators";
 // Blockframes
 import { AggregatedAnalytic, Analytics, createAggregatedAnalytic, Movie } from "@blockframes/model";
-import { MovieService } from "@blockframes/movie/+state/movie.service";
+import { fromOrgAndAccepted, MovieService } from "@blockframes/movie/+state/movie.service";
 import { App } from "@blockframes/utils/apps";
 import { APP } from "@blockframes/utils/routes/utils";
 import { joinWith } from "@blockframes/utils/operators";
@@ -11,6 +11,7 @@ import { EventService } from "@blockframes/event/+state";
 import { Event } from '@blockframes/model'
 import { where } from "firebase/firestore";
 import { AnalyticsService } from "@blockframes/analytics/+state/analytics.service";
+import { OrganizationService } from "@blockframes/organization/+state";
 
 interface AggregatedPerTitle extends AggregatedAnalytic {
   screenings: number;
@@ -44,7 +45,7 @@ function countAnalytics(title: Movie & { analytics?: Analytics[], events?: Event
 })
 export class TitlesAnalyticsComponent {
 
-  titlesAnalytics$ = this.service.queryDashboard(this.app).pipe(
+  titlesAnalytics$ = this.service.valueChanges(fromOrgAndAccepted(this.orgService.org.id, this.app)).pipe(
     joinWith({
       analytics: title => this.analytics.getTitleAnalytics({ titleId: title.id }),
       events: title => this.eventService.valueChanges([
@@ -61,6 +62,7 @@ export class TitlesAnalyticsComponent {
     private router: Router,
     private service: MovieService,
     private eventService: EventService,
+    private orgService: OrganizationService,
     @Inject(APP) public app: App
   ) {}
 

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -15,26 +15,36 @@
       </div>   
     </header>
     <section class="surface carousel-container">
-      <header *ngIf="popularTitle$ | async as title">
-        <h3>{{ title.title.international }}</h3>
-        <a mat-flat-button [routerLink]="['title', title.id]">
-          <span>See Analytics details</span>
-          <mat-icon svgIcon="arrow_forward"></mat-icon>
-        </a>
-      </header>
-      <bf-carousel flex layout>
-        <analytics-pie-chart class="surface" carouselItem [data]="orgActivityOfPopularTitle$ | async"></analytics-pie-chart>
-        <analytics-map class="surface" carouselItem [data]="territoryActivityOfPopularTitle$ | async"></analytics-map>
-        <analytics-line-chart class="surface" carouselItem [eventNames]="interactions" [data]="interactionsOfPopularTitle$ | async">
-          <mat-icon svgIcon="switch_access_shortcut"></mat-icon>
-          <h5>Interactions</h5>
-        </analytics-line-chart>
-        <analytics-line-chart class="surface" carouselItem [eventNames]="['pageView']" [data]="pageViewsOfPopularTitle$ | async">
-          <mat-icon svgIcon="visibility"></mat-icon>
-          <h5>Film Page Views</h5>
-        </analytics-line-chart>
-      </bf-carousel>
-      <a mat-flat-button class="see_titles" routerLink="title">
+      <ng-container *ngIf="popularTitle$ | async as title else loading">
+        <header>
+          <h3>{{ title.title.international }}</h3>
+          <a mat-button [routerLink]="['title', title.id]">
+            <span>See Analytics details</span>
+            <mat-icon svgIcon="arrow_forward"></mat-icon>
+          </a>
+        </header>
+        <bf-carousel flex layout>
+          <analytics-pie-chart class="surface" carouselItem [data]="orgActivityOfPopularTitle$ | async"></analytics-pie-chart>
+          <analytics-map class="surface" carouselItem [data]="territoryActivityOfPopularTitle$ | async"></analytics-map>
+          <analytics-line-chart class="surface" carouselItem [eventNames]="interactions" [data]="interactionsOfPopularTitle$ | async">
+            <mat-icon svgIcon="switch_access_shortcut"></mat-icon>
+            <div>
+              <h5>Interactions</h5>
+              <p class="mat-caption">Learn how people interact with your Title.</p>
+            </div>
+
+          </analytics-line-chart>
+          <analytics-line-chart class="surface" carouselItem [eventNames]="['pageView']" [data]="pageViewsOfPopularTitle$ | async">
+            <mat-icon svgIcon="visibility"></mat-icon>
+            <div>
+              <h5>Film Page Views</h5>
+              <p class="mat-caption">See how many Buyers viewed your Film Page recently.</p>
+            </div>
+            </analytics-line-chart>
+        </bf-carousel>
+      </ng-container>
+
+      <a mat-button class="see_titles" routerLink="title">
         <span>View all Titles Activity</span>
         <mat-icon svgIcon="arrow_forward"></mat-icon>
       </a>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -50,7 +50,7 @@ export class HomeComponent {
     switchMap(([popularEvent]) => this.movieService.getValue(popularEvent.key))
   );
 
-  private titleAnalyticsOfPopularTitle$ = combineLatest([ this.popularTitle$, this.titleAnalytics$ ]).pipe(
+  titleAnalyticsOfPopularTitle$ = combineLatest([ this.popularTitle$, this.titleAnalytics$ ]).pipe(
     map(([title, titleAnalytics]) => titleAnalytics.filter(analytics => analytics.meta.titleId === title.id)),
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -50,7 +50,7 @@ export class HomeComponent {
     switchMap(([popularEvent]) => this.movieService.getValue(popularEvent.key))
   );
 
-  titleAnalyticsOfPopularTitle$ = combineLatest([ this.popularTitle$, this.titleAnalytics$ ]).pipe(
+  private titleAnalyticsOfPopularTitle$ = combineLatest([ this.popularTitle$, this.titleAnalytics$ ]).pipe(
     map(([title, titleAnalytics]) => titleAnalytics.filter(analytics => analytics.meta.titleId === title.id)),
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.html
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.html
@@ -1,24 +1,33 @@
 <header>
   <ng-content></ng-content>
 </header>
-<ng-container *ngIf="lineChartOptions.series?.length; else noData">
-  <section>
-    <button mat-button [disabled]="period === 'day'" (click)="changePeriod('day')">Per day</button>
-    <button mat-button [disabled]="period === 'week'" (click)="changePeriod('week')">Per week</button>
-    <button mat-button [disabled]="period === 'month'" (click)="changePeriod('month')">Per month</button>
-  </section>
-  <apx-chart
-    #chart
-    [series]="lineChartOptions.series"
-    [chart]="lineChartOptions.chart"
-    [theme]="lineChartOptions.theme"
-    [legend]="lineChartOptions.legend"
-    [yaxis]="lineChartOptions.yaxis"
-    [xaxis]="lineChartOptions.xaxis"
-    [dataLabels]="lineChartOptions.dataLabels"
-    [stroke]="lineChartOptions.stroke"
-  ></apx-chart>
+<ng-container *ngIf="!isLoading else loading">
+  <ng-container *ngIf="lineChartOptions.series?.length; else empty">
+    <section>
+      <button mat-button [disabled]="period === 'day'" (click)="changePeriod('day')">Per day</button>
+      <button mat-button [disabled]="period === 'week'" (click)="changePeriod('week')">Per week</button>
+      <button mat-button [disabled]="period === 'month'" (click)="changePeriod('month')">Per month</button>
+    </section>
+    <apx-chart
+      #chart
+      [series]="lineChartOptions.series"
+      [chart]="lineChartOptions.chart"
+      [theme]="lineChartOptions.theme"
+      [legend]="lineChartOptions.legend"
+      [yaxis]="lineChartOptions.yaxis"
+      [xaxis]="lineChartOptions.xaxis"
+      [dataLabels]="lineChartOptions.dataLabels"
+      [stroke]="lineChartOptions.stroke"
+    ></apx-chart>
+  </ng-container>
 </ng-container>
-<ng-template #noData>
+
+<ng-template #empty>
   <img asset="empty_line_chart.svg" alt="Line chart">
+</ng-template>
+
+<ng-template #loading>
+  <article class="loading">
+    <mat-spinner color="primary"></mat-spinner>
+  </article>
 </ng-template>

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.html
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.html
@@ -27,7 +27,5 @@
 </ng-template>
 
 <ng-template #loading>
-  <article class="loading">
-    <mat-spinner color="primary"></mat-spinner>
-  </article>
+  <mat-spinner color="primary"></mat-spinner>
 </ng-template>

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.scss
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.scss
@@ -26,3 +26,8 @@ analytics-line-chart {
     }
   }
 }
+
+.loading {
+  display: flex;
+  justify-content: center;
+}

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.scss
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.scss
@@ -27,7 +27,6 @@ analytics-line-chart {
   }
 }
 
-.loading {
-  display: flex;
-  justify-content: center;
+mat-spinner {
+  margin: auto;
 }

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
@@ -121,7 +121,7 @@ export class LineChartComponent {
     if (!data?.length) {
       this.chart?.updateSeries([]);
       this.isLoading = false;
-    return;
+      return; 
     }
 
     const analytics = data.sort((a, b) => a._meta.createdAt.getTime() - b._meta.createdAt.getTime());

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
@@ -61,6 +61,7 @@ const dateFunctions: Record<Period, Record<'interval' | 'isSame', any>> = {
 })
 export class LineChartComponent {
   @ViewChild("chart") chart: ChartComponent;
+  isLoading = true;
 
   period?: Period;
   lineChartOptions: LineChartOptions = {
@@ -117,6 +118,7 @@ export class LineChartComponent {
   @Input() eventNames: EventName[] = [];
   private analytics?: Analytics[];
   @Input() set data(data: Analytics[]) {
+    if (data) this.isLoading = false;
     if (!data?.length) {
       this.chart?.updateSeries([]);
       return;

--- a/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.component.ts
@@ -118,10 +118,10 @@ export class LineChartComponent {
   @Input() eventNames: EventName[] = [];
   private analytics?: Analytics[];
   @Input() set data(data: Analytics[]) {
-    if (data) this.isLoading = false;
     if (!data?.length) {
       this.chart?.updateSeries([]);
-      return;
+      this.isLoading = false;
+    return;
     }
 
     const analytics = data.sort((a, b) => a._meta.createdAt.getTime() - b._meta.createdAt.getTime());

--- a/libs/analytics/src/lib/components/line-chart/line-chart.module.ts
+++ b/libs/analytics/src/lib/components/line-chart/line-chart.module.ts
@@ -7,6 +7,7 @@ import { LineChartComponent } from './line-chart.component';
 
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import { MatButtonModule } from '@angular/material/button';
 
     MatIconModule,
     MatButtonModule,
+    MatProgressSpinnerModule
   ],
   declarations: [LineChartComponent],
   exports: [LineChartComponent]

--- a/libs/analytics/src/lib/components/map/map.component.html
+++ b/libs/analytics/src/lib/components/map/map.component.html
@@ -1,43 +1,54 @@
 <header>
   <mat-icon svgIcon="landscape"></mat-icon>
-  <h5>Split by Company Territory</h5>
+  <article>
+    <h5>Split by Company Territory</h5>
+    <p class="mat-caption">Learn where are the interested people from.</p>
+  </article>
   <button mat-icon-button *ngIf="selected" (click)="toggleSelect(selected)" matTooltip="Remove selection">
     <mat-icon svgIcon="refresh_filters"></mat-icon>
   </button>
 </header>
 
-<world-map *ngIf="top3.length; else noData">
-  <!-- MAP LAYERS -->
-  <ng-container *ngFor="let isoA3 of zero">
-    <map-feature [tag]="isoA3" color="#ebeef3" (click)="toggleSelect(isoA3)"></map-feature>
-  </ng-container>
+<ng-container *ngIf="!isLoading else loading">
+  <world-map *ngIf="top3.length; else empty">
+    <!-- MAP LAYERS -->
+    <ng-container *ngFor="let isoA3 of zero">
+      <map-feature [tag]="isoA3" color="#ebeef3" (click)="toggleSelect(isoA3)"></map-feature>
+    </ng-container>
+  
+    <ng-container *ngFor="let isoA3 of lessThanFive">
+      <map-feature [tag]="isoA3" color="#dee5ff" (click)="toggleSelect(isoA3)"></map-feature>
+    </ng-container>
+  
+    <ng-container *ngFor="let isoA3 of lessThanFifty">
+      <map-feature [tag]="isoA3" color="#8da4fa" (click)="toggleSelect(isoA3)"></map-feature>
+    </ng-container>
+  
+    <ng-container *ngFor="let isoA3 of moreThanFifty">
+      <map-feature [tag]="isoA3" color="#001ec7" (click)="toggleSelect(isoA3)"></map-feature>
+    </ng-container>
+  
+    <ng-container *ngIf="selected">
+      <map-feature [tag]="selected" color="#3c64f7" (click)="toggleSelect(selected)"></map-feature>
+    </ng-container>
+  </world-map>
+  
+  <mat-list>
+    <mat-list-item *ngFor="let top of top3">
+      <span matLine>{{ top.label }}</span>
+      <span>{{ top.count }}</span>
+  
+      <mat-divider></mat-divider>
+    </mat-list-item>
+  </mat-list>
+</ng-container>
 
-  <ng-container *ngFor="let isoA3 of lessThanFive">
-    <map-feature [tag]="isoA3" color="#dee5ff" (click)="toggleSelect(isoA3)"></map-feature>
-  </ng-container>
-
-  <ng-container *ngFor="let isoA3 of lessThanFifty">
-    <map-feature [tag]="isoA3" color="#8da4fa" (click)="toggleSelect(isoA3)"></map-feature>
-  </ng-container>
-
-  <ng-container *ngFor="let isoA3 of moreThanFifty">
-    <map-feature [tag]="isoA3" color="#001ec7" (click)="toggleSelect(isoA3)"></map-feature>
-  </ng-container>
-
-  <ng-container *ngIf="selected">
-    <map-feature [tag]="selected" color="#3c64f7" (click)="toggleSelect(selected)"></map-feature>
-  </ng-container>
-</world-map>
-
-<mat-list>
-  <mat-list-item *ngFor="let top of top3">
-    <span matLine>{{ top.label }}</span>
-    <span>{{ top.count }}</span>
-
-    <mat-divider></mat-divider>
-  </mat-list-item>
-</mat-list>
-
-<ng-template #noData>
+<ng-template #empty>
   <img asset="empty_state_analytics_map.svg" alt="Image, you have no movies yet">
+</ng-template>
+
+<ng-template #loading>
+  <article class="loading">
+    <mat-spinner color="primary"></mat-spinner>
+  </article>
 </ng-template>

--- a/libs/analytics/src/lib/components/map/map.component.html
+++ b/libs/analytics/src/lib/components/map/map.component.html
@@ -48,7 +48,5 @@
 </ng-template>
 
 <ng-template #loading>
-  <article class="loading">
-    <mat-spinner color="primary"></mat-spinner>
-  </article>
+  <mat-spinner color="primary"></mat-spinner>
 </ng-template>

--- a/libs/analytics/src/lib/components/map/map.component.scss
+++ b/libs/analytics/src/lib/components/map/map.component.scss
@@ -4,7 +4,6 @@
 
 header {
   display: flex;
-  align-items: center;
   gap: 8px;
 }
 
@@ -23,4 +22,9 @@ img {
 
 button {
   margin-left: auto;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
 }

--- a/libs/analytics/src/lib/components/map/map.component.scss
+++ b/libs/analytics/src/lib/components/map/map.component.scss
@@ -24,7 +24,7 @@ button {
   margin-left: auto;
 }
 
-.loading {
-  display: flex;
-  justify-content: center;
+
+mat-spinner {
+  margin: auto;
 }

--- a/libs/analytics/src/lib/components/map/map.component.ts
+++ b/libs/analytics/src/lib/components/map/map.component.ts
@@ -13,6 +13,7 @@ const territories = parseToAll('territories', 'world') as Territory[];
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AnalyticsMapComponent {
+  isLoading = true;
 
   zero: TerritoryISOA3Value[] = [];
   lessThanFive: TerritoryISOA3Value[] = [];
@@ -24,6 +25,7 @@ export class AnalyticsMapComponent {
 
   @Input() set data(data: AnalyticData[]) {
     if (!data) return;
+    this.isLoading = false;
 
     for (const territory of territories) {
       const isoA3 = territoriesISOA3[territory];

--- a/libs/analytics/src/lib/components/map/map.module.ts
+++ b/libs/analytics/src/lib/components/map/map.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { AnalyticsMapComponent } from './map.component';
 import { ImageModule } from "@blockframes/media/image/directives/image.module";
@@ -13,12 +12,11 @@ import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip'; 
-
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   imports: [
     CommonModule,
-    FlexLayoutModule,
 
     ToLabelModule,
     MapModule,
@@ -28,7 +26,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatListModule,
     MatButtonModule,
     MatDividerModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatProgressSpinnerModule
   ],
   declarations: [AnalyticsMapComponent],
   exports: [AnalyticsMapComponent]

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.component.html
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.component.html
@@ -30,7 +30,5 @@
 </ng-template>
 
 <ng-template #loading>
-  <article class="loading">
-    <mat-spinner color="primary"></mat-spinner>
-  </article>
+  <mat-spinner color="primary"></mat-spinner>
 </ng-template>

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.component.html
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.component.html
@@ -1,22 +1,36 @@
 <header>
   <mat-icon svgIcon="business"></mat-icon>
-  <h5>Split by Company Activity</h5>
+  <article>
+    <h5>Split by Company Activity</h5>
+    <p class="mat-caption">Learn who are the users who were interested in this Title.</p>
+  </article>
+
   <button mat-icon-button (click)="toggleSelect()" *ngIf="previousSelection" matTooltip="Remove selection">
     <mat-icon svgIcon="refresh_filters"></mat-icon>
   </button>
 </header>
-<ng-container *ngIf="pieChartOptions.series?.length; else noData">
-  <apx-chart
-    #chart
-    [series]="pieChartOptions.series"
-    [chart]="pieChartOptions.chart"
-    [labels]="pieChartOptions.labels"
-    [dataLabels]="pieChartOptions.dataLabels"
-    [theme]="pieChartOptions.theme"
-    [stroke]="pieChartOptions.stroke"
-    [legend]="pieChartOptions.legend"
-  ></apx-chart>
+
+<ng-container *ngIf="!isLoading else loading">
+  <ng-container *ngIf="pieChartOptions.series?.length; else empty">
+    <apx-chart
+      #chart
+      [series]="pieChartOptions.series"
+      [chart]="pieChartOptions.chart"
+      [labels]="pieChartOptions.labels"
+      [dataLabels]="pieChartOptions.dataLabels"
+      [theme]="pieChartOptions.theme"
+      [stroke]="pieChartOptions.stroke"
+      [legend]="pieChartOptions.legend"
+    ></apx-chart>
+  </ng-container>
 </ng-container>
-<ng-template #noData>
+
+<ng-template #empty>
   <img asset="empty_state_analytics_pie_chart.svg" alt="Image, you have no movies yet">
+</ng-template>
+
+<ng-template #loading>
+  <article class="loading">
+    <mat-spinner color="primary"></mat-spinner>
+  </article>
 </ng-template>

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.component.scss
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.component.scss
@@ -5,7 +5,6 @@
 
 header {
   display: flex;
-  align-items: center;
   gap: 8px;
 }
 
@@ -20,4 +19,9 @@ img {
 
 button {
   margin-left: auto;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
 }

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.component.scss
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.component.scss
@@ -21,7 +21,6 @@ button {
   margin-left: auto;
 }
 
-.loading {
-  display: flex;
-  justify-content: center;
+mat-spinner {
+  margin: auto;
 }

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.component.ts
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.component.ts
@@ -28,6 +28,7 @@ interface PieChartOptions {
 })
 export class PieChartComponent {
   @ViewChild("chart") chart: ChartComponent;
+  isLoading = true;
 
   pieChartOptions: Partial<PieChartOptions> = {
     series: [],
@@ -65,6 +66,7 @@ export class PieChartComponent {
 
   @Input() set data(data: AnalyticData[]) {
     if (!data) return;
+    this.isLoading = false;
 
     this.pieChartOptions.labels = Object.values(data).map(d => d.label);
     this.pieChartOptions.series = Object.values(data).map(d => d.count);

--- a/libs/analytics/src/lib/components/pie-chart/pie-chart.module.ts
+++ b/libs/analytics/src/lib/components/pie-chart/pie-chart.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { NgApexchartsModule } from "ng-apexcharts";
 import { ImageModule } from "@blockframes/media/image/directives/image.module";
 
@@ -9,17 +8,18 @@ import { PieChartComponent } from './pie-chart.component';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   imports: [
     CommonModule,
-    FlexLayoutModule,
     NgApexchartsModule,
     ImageModule,
 
     MatIconModule,
     MatButtonModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatProgressSpinnerModule
   ],
   declarations: [PieChartComponent],
   exports: [PieChartComponent]


### PR DESCRIPTION
#7834

- [x] (B) There is a jumps from loading from the "empty" to "full" state. Maybe need to calculate the that the empty state size = the full state to avoid it?

![jump from empty state.gif](https://images.zenhubusercontent.com/5dd54528c0ccd300013672c3/47e1516a-b1c8-4559-9d69-e0c76684e522)

- [x] (A) The subtitle explanations are missing (maybe Remco you are still working on it?)

![minitext.png](https://images.zenhubusercontent.com/5dd54528c0ccd300013672c3/ff01734c-8a23-4fd2-9900-12de5b7f9cb6)

title: `Split by Company Activity`
subtitle:` Learn who are the users who were interested in this Title.` 

title: `Split by Company Territory` 
subtitle: `Learn where are the interested people from.`

title: `Interactions`
subtitle: `Learn how people interact with your Title.`

title: `Film Page Views`
subtitle: `See how many Buyers viewed your Film Page recently.`

- [x] (B) Tell me if i'm wrong, but the "View all Titles Activity" is a mat button, and it's usual behavior is to get a "squared" background on hover, (as in our footer for example), now it's rounded only in active state (nothing on hover), @stephanie-cascade8 could you please confirm what form should it take and if hover should be added? 

![mat button cosistency.gif](https://images.zenhubusercontent.com/5dd54528c0ccd300013672c3/bf5b7db3-bb2a-44e4-8030-ce94a6210461)

- [x] (A) On the page Titles' Activity we have all the table that doesn't show the International Titles. At the same time, on the Dashboard page we have Bigfoot title that is published.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/93206363/164414810-9c44a5c9-9e88-428f-8b8b-73d76e500205.png">

- [x] (A) It seems that even not published movies are in this table, but we should show only the Accepted titles, because only accepted Titles are published on the Marketplace.

![empty title activity.png](https://images.zenhubusercontent.com/5dd54528c0ccd300013672c3/692e3fe5-c531-4314-b0ed-69e07a580d99)