### PR TITLE
8299 prevent add to wishlist for users without org

### DIFF
--- a/libs/organization/src/lib/organization/components/wishlist-button/wishlist-button.component.ts
+++ b/libs/organization/src/lib/organization/components/wishlist-button/wishlist-button.component.ts
@@ -8,6 +8,7 @@ import { MovieService } from '@blockframes/movie/+state/movie.service';
 import { Observable } from 'rxjs';
 import { OrganizationService } from '@blockframes/organization/+state';
 import { Router } from '@angular/router';
+import { AuthService } from '@blockframes/auth/+state';
 
 
 @Component({
@@ -28,6 +29,7 @@ export class WishlistButtonComponent implements OnInit {
   @Output() added = new EventEmitter<string>()
 
   constructor(
+    private auth: AuthService,
     private movieService: MovieService,
     private orgService: OrganizationService,
     private router: Router,
@@ -42,7 +44,7 @@ export class WishlistButtonComponent implements OnInit {
     event.stopPropagation();
     event.preventDefault();
 
-    if (!this.orgService.org?.id) {
+    if (await this.auth.isSignedInAnonymously()) {
       return this.router.navigate(['/auth/identity']);
     }
 

--- a/libs/organization/src/lib/organization/components/wishlist-button/wishlist-button.component.ts
+++ b/libs/organization/src/lib/organization/components/wishlist-button/wishlist-button.component.ts
@@ -41,6 +41,11 @@ export class WishlistButtonComponent implements OnInit {
   public async addToWishlist(event?: Event) {
     event.stopPropagation();
     event.preventDefault();
+
+    if (!this.orgService.org?.id) {
+      return this.router.navigate(['/auth/identity']);
+    }
+
     const movie = await this.movieService.getValue(this.movieId);
     const title = movie.title?.international ?? movie.title.original;
     this.orgService.updateWishlist(movie);


### PR DESCRIPTION
When I'm connected as an anonymous user (for the Public Presentations, no account on Archipel Market) I can still "add" a title to wishlist... 

- [x] Possible solutions: hide this feature for not connected users / Send a user to the Account Creation page (as we do when they click on "View more") 
<img width="1282" alt="Снимок экрана 2022-05-02 в 16 32 53" src="https://user-images.githubusercontent.com/55499036/166252518-d5273e97-05b5-4f86-ae67-9de4405a2066.png">
