### PR TITLE
8299 scroll app bar on small screen

### DIFF
--- a/libs/event/src/lib/components/screening-item/screening-item.component.html
+++ b/libs/event/src/lib/components/screening-item/screening-item.component.html
@@ -31,7 +31,7 @@
       <ng-template #notOwner>
         <ng-container *ngIf="invitation !== undefined">
           <invitation-action @fade [invitation]="invitation" [event]="event"></invitation-action>
-          <button mat-button class="translucent" [disabled]="requestSent" (click)="requestAskingPrice(event.meta.titleId)">
+          <button mat-button [disabled]="requestSent" (click)="requestAskingPrice(event.meta.titleId)">
             <mat-icon svgIcon="local_offer"></mat-icon>
             <span>Request Asking Price</span>
           </button>

--- a/libs/movie/src/lib/movie/marketplace/shell/shell.component.scss
+++ b/libs/movie/src/lib/movie/marketplace/shell/shell.component.scss
@@ -4,6 +4,15 @@ nav {
   margin: 0 24px;
 }
 
+header {
+  overflow: auto; // enable scrolling for small screen
+  scrollbar-width: none;  // Hide scrollbar for firefox
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 footer {
   margin: 24px 24px 72px 24px;
 


### PR DESCRIPTION
#8299
Proposed several solutions to Ana and hiding the scrollbar was her favorite. See proposals further down in this PR.

- [x] (A) When scrolling down the film page, the Tabs are also moving to the top, inside the toolbar. Nevertheless, they are not scrollable. Either we need to add a possibility to move the tabs (better solution), either to hide them for mobile (user will still be able to scroll to the begging of the page where we have the tabs).
 
![Image d’iOS (4)](https://user-images.githubusercontent.com/55499036/166240636-c0641048-d8b8-4770-8f6f-bcbbebb55871.png) 
![Image d’iOS (3)](https://user-images.githubusercontent.com/55499036/166240687-30adb95d-4ffd-49c6-aabd-a5b6129c38da.png)

### Possible solutions
1. Same navigation as on the tabs (image 1 and 2) rather big change in UI and code
2. Keep it as it is but with an invisible scrollbar (image 3)
3. Keep it as it is but with a visible scrollbar (image 4)
4. As you suggested, hide the toolbar for small screen

Image 1:
![image](https://user-images.githubusercontent.com/27687382/166898235-50c8b917-63f5-466c-908e-2d52461c2058.png)

Image 2:
![image](https://user-images.githubusercontent.com/27687382/166898265-afea014a-0916-46c2-93d0-c3d8fe8708f1.png)

Image 3:
![image](https://user-images.githubusercontent.com/27687382/166898289-005b989a-9312-4081-b6bc-3e3590a6d303.png)

Image 3:
![image](https://user-images.githubusercontent.com/27687382/166898316-b2d047ed-dda7-48ee-b5a8-3459151b4d4b.png)
