### PR TITLE
General UI - CrossApp Confirm Modals

### DIFF
--- a/libs/ui/src/lib/confirm/confirm.component.scss
+++ b/libs/ui/src/lib/confirm/confirm.component.scss
@@ -9,3 +9,7 @@ section {
 p {
   max-width: 70%;
 }
+
+mat-dialog-actions {
+  margin-top: 36px;
+}


### PR DESCRIPTION
Add space of 36px between text and button like :
![preview](https://i.imgur.com/BcVlVGu.png)