### PR TITLE
8299 fix video section and request screening

### DIFF
--- a/apps/festival/festival/src/app/marketplace/title/list/list.component.html
+++ b/apps/festival/festival/src/app/marketplace/title/list/list.component.html
@@ -84,7 +84,7 @@
   <!-- TITLE CARD -->
   <ng-template listPageCard let-title>
     <movie-card [movie]="title" [link]="['/c/o/marketplace/title',  title.objectID]" size="poster">
-      <event-request-screening [movieId]="title.id" iconOnly></event-request-screening>
+      <event-request-screening [movieId]="title.objectID" iconOnly></event-request-screening>
     </movie-card>
   </ng-template>
 

--- a/libs/media/src/lib/video/viewer/viewer.component.scss
+++ b/libs/media/src/lib/video/viewer/viewer.component.scss
@@ -5,7 +5,6 @@
  * We need to use ViewEncapsulation.None, that's why we don't use :host { }
  */
  video-viewer {
-  height: 100%;
 
   section {
     height: 100%;

--- a/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
+++ b/libs/movie/src/lib/movie/marketplace/shell/shell.component.html
@@ -85,7 +85,7 @@
 
     <ng-container *ngIf="hasPublicVideos(movie)">
       <h2>Videos</h2>
-      <section class="videos">
+      <section class="videos" id="videoFooter"> <!-- id videoFooter is used for promotional links -->
         <ng-container *ngFor="let video of movie.promotional.videos.otherVideos">
           <article *ngIf="video.privacy === 'public'">
             <video-viewer [ref]="video" *ngIf="video.jwPlayerId" (stateChange)="videoStateChanged(movie, $event)"></video-viewer>

--- a/libs/movie/src/lib/movie/marketplace/shell/shell.component.scss
+++ b/libs/movie/src/lib/movie/marketplace/shell/shell.component.scss
@@ -43,8 +43,8 @@ footer {
       margin: 0 24px;
       video-viewer {
         display: block;
-        height: 100%;
       }
+
       p {
         padding-top: 8px;
         text-align: center;


### PR DESCRIPTION
#8299

- [x] Click on video trailer doesn't anchor to video section
https://user-images.githubusercontent.com/93206363/166881794-f1f1ac5d-3310-4cb9-af44-5253f97556b4.mp4

- [x] (A) Button "Ask for a Screening" on the library page has infinite loading after clicking (desktop + mobile)
<img width="846" alt="Снимок экрана 2022-05-03 в 15 36 44" src="https://user-images.githubusercontent.com/55499036/166463328-23210b4b-ab6a-46f9-98b6-4655803e5cf3.png">
![Image d’iOS](https://user-images.githubusercontent.com/55499036/166463368-90f56232-dade-4f33-ba7d-adf5ab7e3795.jpg)