### PR TITLE
8299 fix component added in media list when unsupported file

### DIFF
--- a/libs/media/src/lib/image/uploader/uploader.component.ts
+++ b/libs/media/src/lib/image/uploader/uploader.component.ts
@@ -256,6 +256,7 @@ export class ImageUploaderComponent implements OnInit, OnDestroy {
     if (!isFileTypeValid) {
       this.snackBar.open(`Unsupported file type: "${fileType}".`, 'close', { duration: 3000 });
       this.delete();
+      return;
     } else if (this.file.size >= this.maxSize) {
       this.snackBar.open(`Your image is too big: max allowed size is ${fileSizeToString(this.maxSize)}.`, 'close', { duration: 4000 });
       this.delete();
@@ -314,7 +315,7 @@ export class ImageUploaderComponent implements OnInit, OnDestroy {
     }
 
     this.uploaderService.removeFromQueue(this.storagePath, this.fileName);
-    this.form.reset();
+    this.form.reset(new StorageFileForm());
 
     this.fileUploader.nativeElement.value = null;
     this.selectionChange.emit('removed');


### PR DESCRIPTION
#8299
- [x] (A) If you try to upload an unsuported file, a second upload component appears
![Images - unsupported file adds an upload component](https://user-images.githubusercontent.com/78768220/166688456-80567491-2d09-4367-b1a9-24c96e718ed7.gif)