### PR TITLE
8299 listen to file changes in movie form

### DIFF
--- a/libs/media/src/lib/file/file-uploader/file-uploader.component.ts
+++ b/libs/media/src/lib/file/file-uploader/file-uploader.component.ts
@@ -18,7 +18,7 @@ import {
   sanitizeFileName,
 } from '@blockframes/utils/file-sanitizer';
 import { FileUploaderService } from '@blockframes/media/+state';
-import { FileMetaData } from '@blockframes/model';
+import { createStorageFile, FileMetaData } from '@blockframes/model';
 import { allowedFiles, AllowedFileType, fileSizeToString, maxAllowedFileSize } from '@blockframes/utils/utils';
 import { CollectionHoldingFile, FileLabel, getFileMetadata, getFileStoragePath } from '../../+state/static-files';
 import { StorageFileForm } from '@blockframes/media/form/media.form';
@@ -111,16 +111,16 @@ export class FileUploaderComponent implements OnInit, OnDestroy {
     if (this.listenToChanges) {
       const ref = doc(this.db,`${this.metadata.collection}/${this.metadata.docId}`);
       this.docSub = docData(ref).subscribe(data => {
-        const media = this.formIndex !== undefined
+        const incoming = this.formIndex !== undefined
           ? getDeepValue(data, this.metadata.field)[this.formIndex]
           : getDeepValue(data, this.metadata.field);
-        if (media) {
-          const extra = this.getExtra();
-          // jwPlayer comes from the doc, not from the form.
-          delete extra?.['jwPlayerId'];
-          this.form.patchValue({ ...media, ...extra });
+        const current = this.form.value;
+
+        if (incoming.storagePath !== current.storagePath) {
+          const storageFile = createStorageFile(incoming, false);
+          this.form.patchValue(storageFile);
         }
-      })
+      });
     }
   }
 

--- a/libs/model/src/lib/media.ts
+++ b/libs/model/src/lib/media.ts
@@ -13,15 +13,16 @@ export interface StorageFile {
   [K: string]: string; // extra-data
 }
 
-export function createStorageFile(file: Partial<StorageFile> = {}): StorageFile {
-  return {
-    privacy: 'public',
-    collection: 'movies',
-    docId: '',
-    field: '',
-    storagePath: '',
-    ...file,
-  };
+export function createStorageFile(file: Partial<StorageFile> = {}, extraFields = true): StorageFile {
+  const mandatory: StorageFile = {
+    privacy: file.privacy ?? 'public',
+    collection: file.collection ?? 'movies',
+    docId: file.docId ?? '',
+    field: file.field ?? '',
+    storagePath: file.storagePath ?? ''
+  }
+
+  return extraFields ? { ...mandatory, ...file } : mandatory;
 }
 
 export interface StorageVideo extends StorageFile {

--- a/libs/movie/src/lib/movie/form/available-materials/available-materials.component.html
+++ b/libs/movie/src/lib/movie/form/available-materials/available-materials.component.html
@@ -2,7 +2,7 @@
   <section tunnel-form fxLayout="column" fxLayoutGap="32px" class="surface">
     <span><b>Please upload your available material list</b></span>
     <file-uploader [form]="fileForm" [meta]="['movies', 'delivery', movieId]"
-      [accept]="['pdf','xls', 'docx']" listenToChanges>
+      [accept]="['pdf','xls', 'docx']">
       <h3 title>Document</h3>
     </file-uploader>
     <small>Please note that this document will be available for download on the marketplace.</small>

--- a/libs/movie/src/lib/movie/form/main/main.component.html
+++ b/libs/movie/src/lib/movie/form/main/main.component.html
@@ -98,7 +98,7 @@
           The poster image will be used as the main image to represent your film on the marketplace, and, more
           generally, for all film components requiring vertical formats on the marketplace.
         </p>
-        <image-uploader [meta]="['movies', 'poster', movieId]" ratio="poster" [form]="form.poster" listenToChanges>
+        <image-uploader [meta]="['movies', 'poster', movieId]" ratio="poster" [form]="form.poster">
           <h3 title>Film Poster</h3>
         </image-uploader>
         <span class="mat-caption">Please note that this document will be available for download on the
@@ -111,7 +111,7 @@
           The banner image will be used as a cover picture on your project page on the marketplace, and, more generally,
           for all film components requiring horizontal formats on the marketplace.
         </p>
-        <image-uploader [meta]="['movies', 'banner', movieId]" ratio="banner" [form]="form.banner" listenToChanges>
+        <image-uploader [meta]="['movies', 'banner', movieId]" ratio="banner" [form]="form.banner">
           <h3 title>Film Banner Image</h3>
         </image-uploader>
         <span class="mat-caption">Please note that this document will be available for download on the

--- a/libs/movie/src/lib/movie/form/media-files/media-files.component.html
+++ b/libs/movie/src/lib/movie/form/media-files/media-files.component.html
@@ -9,7 +9,6 @@
         accept="pdf"
         [form]="form.promotional.get('presentation_deck')"
         [meta]="['movies', 'presentation_deck', movieId]"
-        listenToChanges
       >
         <h3 title>Upload Presentation Deck</h3>
       </file-uploader>
@@ -24,7 +23,6 @@
         accept="pdf"
         [form]="form.promotional.get('scenario')"
         [meta]="['movies', 'scenario', movieId]"
-        listenToChanges
       >
         <h3 title>Upload Scenario</h3>
       </file-uploader>
@@ -39,7 +37,6 @@
         accept="pdf"
         [form]="form.promotional.get('moodboard')"
         [meta]="['movies', 'moodboard', movieId]"
-        listenToChanges
       >
         <h3 title>Upload Moodboard / Artistic Deck</h3>
       </file-uploader>

--- a/libs/movie/src/lib/movie/form/media-images/media-images.component.html
+++ b/libs/movie/src/lib/movie/form/media-images/media-images.component.html
@@ -13,7 +13,6 @@
             [queueIndex]="i | fileListIndex: stillPhoto.value"
             [form]="still"
             [formIndex]="i"
-            listenToChanges
           >
             <h3 title>Stills</h3>
           </image-uploader>

--- a/libs/movie/src/lib/movie/form/media-videos/media-videos.component.html
+++ b/libs/movie/src/lib/movie/form/media-videos/media-videos.component.html
@@ -41,7 +41,7 @@
     <h3>Screener</h3>
     <section>
       <p>The screener is the full video of this title, it will be used for virtual screenings.</p>
-      <file-uploader [form]="screenerForm" [meta]="['movies', 'screener', movieId]" accept="video" listenToChanges>
+      <file-uploader [form]="screenerForm" [meta]="['movies', 'screener', movieId]" accept="video">
         <h3 title>Upload Screener</h3>
       </file-uploader>
       <p class="mat-caption">This video is <strong>private</strong> and <strong>cannot be seen by anyone</strong>
@@ -61,7 +61,7 @@
       <mat-checkbox [checked]="salesPitchForm.isPublic" (change)="salesPitchForm.togglePrivacy($event.checked)" color="primary">
         <b>Public</b> (Buyers can see video on Marketplace)
       </mat-checkbox>
-      <file-uploader [form]="salesPitchForm" [meta]="['movies', 'salesPitch', movieId]" accept="video" listenToChanges>
+      <file-uploader [form]="salesPitchForm" [meta]="['movies', 'salesPitch', movieId]" accept="video">
         <h3 title>Sales Pitch Video</h3>
       </file-uploader>
     </section>

--- a/libs/movie/src/lib/movie/form/movie.form.ts
+++ b/libs/movie/src/lib/movie/form/movie.form.ts
@@ -643,9 +643,13 @@ export class MoviePromotionalElementsForm extends FormEntity<MoviePromotionalEle
     super(createMoviePromotionalElementsControls(promotionalElements));
   }
 
-  get videos() {
-    return this.get('videos');
-  }
+  get moodboard() { return this.get('moodboard'); }
+  get notes() { return this.get('notes'); }
+  get presentation_deck() { return this.get('presentation_deck'); }
+  get scenario() { return this.get('scenario'); }
+  get still_photo() { return this.get('still_photo'); }
+  get videos() { return this.get('videos'); }
+
 }
 
 // ------------------------------
@@ -1083,6 +1087,8 @@ class MovieDeliveryForm extends FormEntity<MovieDeliveryControl> {
   constructor(delivery: Partial<Movie['delivery']> = {}) {
     super(createMovieDeliveryControls(delivery));
   }
+
+  get file() { return this.get('file'); }
 }
 
 function createMovieDeliveryControls(delivery: Partial<Movie['delivery']>) {


### PR DESCRIPTION
In the movie form, we were listening to file changes on the `file-uploader` components. But the movie form consists of multiple pages and the `file-uploader` component was destroyed when switching pages and thus the listener too.

With this PR, we listen to file changes in the whole tunnel. So no matter what page you're at and an upload is completed, it will update the form.


This fixes the followin gissues in #8299
- [x] (A) When a Film Poster and Film Banner were uploaded and saved, they still couldn't be displayed on the summary page
![Снимок экрана 2022-05-03 в 14.00.10.png](https://images.zenhubusercontent.com/5dd54528c0ccd300013672c3/a7765094-79e1-4cb3-a250-cf27789c978e)
=> Camille note: I think the issue is when user uploads a media (image or video) and clicks next on the movie tunnel, it does not save the media. So when user reaches the end of the movie tunnel, it's like nothing has been uploaded. I can't tell if this bug is recent or it has always been this way.

(A)
- [x] if none uploaded yet, the popup should say something like 'will be visible after saving data'
- [x] after saving, the uploaded documents' names don't update, you need to refresh. They should be updated after save.
![Last step - uploaded documents' names](https://user-images.githubusercontent.com/78768220/166688789-8ddc415e-56c6-4cf2-a7c5-4f4b86db81b8.gif)