### PR TITLE
avoid diving 0 by zero and missing buyers page button

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
@@ -33,11 +33,18 @@ import { displayPerson } from "@blockframes/utils/pipes";
 function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: Partial<InvitationWithAnalytics>[]): MetricCard[] {
   const attendees = invitations.filter(invitation => invitation.watchTime);
   const accepted = invitations.filter(invitation => invitation.status === 'accepted');
-  const participationRate = Math.round(attendees.length / invitations.length) * 100;
-  const acceptationRate = Math.round(accepted.length / invitations.length) * 100;
+
   const averageWatchTime = Math.round(sum(attendees, inv => inv.watchTime) / invitations.length) || 0
   const parsedTime = `${Math.floor(averageWatchTime / 60)} min ${averageWatchTime % 60} s`
-  const traction = Math.round(screeningRequests.length / (invitations.length + screeningRequests.length)) * 100;
+  let traction = 0;
+  let participationRate = 0;
+  let acceptationRate = 0;
+  if (invitations.length) {
+    participationRate = Math.round(attendees.length / invitations.length) * 100;
+    acceptationRate = Math.round(accepted.length / invitations.length) * 100;
+    if (screeningRequests.length)
+      traction = Math.round(screeningRequests.length / (invitations.length + screeningRequests.length)) * 100;
+  }
   return [
     {
       title: 'Guests',

--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
+
 import {
   AggregatedAnalytic,
   Analytics,
@@ -24,10 +25,11 @@ import { getGuest } from "@blockframes/invitation/pipes/guest.pipe";
 import { InvitationService } from "@blockframes/invitation/service";
 import { EventService } from "@blockframes/event/service";
 import { OrganizationService } from '@blockframes/organization/service';
+import { displayPerson } from "@blockframes/utils/pipes";
+
 import { filter, map, pluck, shareReplay, switchMap } from "rxjs/operators";
 import { combineLatest, firstValueFrom, Observable, of } from "rxjs";
 import { joinWith } from 'ngfire';
-import { displayPerson } from "@blockframes/utils/pipes";
 
 
 function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: Partial<InvitationWithAnalytics>[]): MetricCard[] {
@@ -36,15 +38,10 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
 
   const averageWatchTime = Math.round(sum(attendees, inv => inv.watchTime) / invitations.length) || 0
   const parsedTime = `${Math.floor(averageWatchTime / 60)} min ${averageWatchTime % 60} s`
-  let traction = 0;
-  let participationRate = 0;
-  let acceptationRate = 0;
-  if (invitations.length) {
-    participationRate = Math.round(attendees.length / invitations.length) * 100;
-    acceptationRate = Math.round(accepted.length / invitations.length) * 100;
-    if (screeningRequests.length)
-      traction = Math.round(screeningRequests.length / (invitations.length + screeningRequests.length)) * 100;
-  }
+  const participationRate = Math.round(attendees.length / invitations.length) * 100;
+  const acceptationRate = Math.round(accepted.length / invitations.length) * 100;
+  const invitationAndRequestCount = invitations.length + screeningRequests.length;
+  const traction = Math.round(screeningRequests.length / invitationAndRequestCount) * 100;
   return [
     {
       title: 'Guests',
@@ -63,17 +60,17 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
     },
     {
       title: 'Participation Rate',
-      value: `${participationRate}%`,
+      value: !invitations.length ? '-' : `${participationRate}%`,
       icon: 'front_hand'
     },
     {
       title: 'Acceptation Rate',
-      value: `${acceptationRate}%`,
+      value: !invitations.length ? '-' : `${acceptationRate}%`,
       icon: 'sentiment_satisfied'
     },
     {
       title: 'Traction Rate',
-      value: `${traction}%`,
+      value: !invitationAndRequestCount ? '-' : `${traction}%`,
       icon: 'magnet_electricity'
     }
   ];

--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
@@ -36,8 +36,8 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
   const attendees = invitations.filter(invitation => invitation.watchTime);
   const accepted = invitations.filter(invitation => invitation.status === 'accepted');
 
-  const averageWatchTime = Math.round(sum(attendees, inv => inv.watchTime) / invitations.length) || 0
-  const parsedTime = `${Math.floor(averageWatchTime / 60)} min ${averageWatchTime % 60} s`
+  const averageWatchTime = Math.round(sum(attendees, inv => inv.watchTime) / invitations.length) || 0;
+  const parsedTime = `${Math.floor(averageWatchTime / 60)} min ${averageWatchTime % 60} s`;
   const participationRate = Math.round(attendees.length / accepted.length) * 100;
   const acceptationRate = Math.round(accepted.length / invitations.length) * 100;
   const traction = Math.round(screeningRequests.length / invitations.length) * 100;
@@ -59,17 +59,17 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
     },
     {
       title: 'Participation Rate',
-      value: !invitations.length ? '-' : `${participationRate}%`,
+      value: invitations.length ? `${participationRate}%` : '-',
       icon: 'front_hand'
     },
     {
       title: 'Acceptation Rate',
-      value: !invitations.length ? '-' : `${acceptationRate}%`,
+      value: invitations.length ? `${acceptationRate}%` : '-',
       icon: 'sentiment_satisfied'
     },
     {
       title: 'Traction Rate',
-      value: !invitations.length ? '-' : `${traction}%`,
+      value: invitations.length ? `${traction}%` : '-',
       icon: 'magnet_electricity'
     }
   ];

--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
@@ -38,10 +38,9 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
 
   const averageWatchTime = Math.round(sum(attendees, inv => inv.watchTime) / invitations.length) || 0
   const parsedTime = `${Math.floor(averageWatchTime / 60)} min ${averageWatchTime % 60} s`
-  const participationRate = Math.round(attendees.length / invitations.length) * 100;
+  const participationRate = Math.round(attendees.length / accepted.length) * 100;
   const acceptationRate = Math.round(accepted.length / invitations.length) * 100;
-  const invitationAndRequestCount = invitations.length + screeningRequests.length;
-  const traction = Math.round(screeningRequests.length / invitationAndRequestCount) * 100;
+  const traction = Math.round(screeningRequests.length / invitations.length) * 100;
   return [
     {
       title: 'Guests',
@@ -70,7 +69,7 @@ function toScreenerCards(screeningRequests: Analytics<'title'>[], invitations: P
     },
     {
       title: 'Traction Rate',
-      value: !invitationAndRequestCount ? '-' : `${traction}%`,
+      value: !invitations.length ? '-' : `${traction}%`,
       icon: 'magnet_electricity'
     }
   ];

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -72,7 +72,7 @@
           </a>
         </section>
 
-        <section class="surface">
+        <section class="surface insights-wrapper">
           <analytics-map
             class="insights-map"
             [data]="activeCountries$ | async"
@@ -125,6 +125,8 @@
               {{ askingPriceRequested }}
             </ng-template>
           </bf-table>
+
+          <button mat-button routerLink="c/o/dashboard/home/buyer">View All Buyers' Activity</button>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -126,7 +126,7 @@
             </ng-template>
           </bf-table>
 
-          <button mat-button routerLink="c/o/dashboard/home/buyer">View All Buyers' Activity</button>
+          <button mat-button routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</button>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -66,7 +66,7 @@
             </bf-carousel>
           </ng-container>
 
-          <a mat-button class="see_titles" routerLink="title">
+          <a mat-button class="link_buttons" routerLink="title">
             <span>View all Titles Activity</span>
             <mat-icon svgIcon="arrow_forward"></mat-icon>
           </a>
@@ -127,7 +127,7 @@
             </ng-template>
           </bf-table>
 
-          <button mat-button class="see_titles" routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</button>
+          <a mat-button class="link_buttons" routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</a>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -127,7 +127,7 @@
             </ng-template>
           </bf-table>
 
-          <a mat-button class="link_buttons" routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</a>
+          <a mat-button class="link_buttons" routerLink="buyer">View All Buyers' Activity</a>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -127,7 +127,7 @@
             </ng-template>
           </bf-table>
 
-          <a mat-button class="link_buttons" routerLink="buyer">View All Buyers' Activity</a>
+          <a mat-button class="link_buttons" routerLink="buyer">View All Buyers' Activities</a>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -72,9 +72,9 @@
           </a>
         </section>
 
-        <section class="surface insights-wrapper">
+        <section class="surface">
           <analytics-map
-            class="insights-map"
+            class="margin-bottom"
             [data]="activeCountries$ | async"
             (selection)="selectedCountry = $event"
             [topCount]="5"
@@ -93,6 +93,7 @@
             [source]="activeBuyers$ | async"
             [filterValue]="selectedCountry"
             (rowClick)="showBuyer($event)"
+            class="margin-bottom"
             clickable
             useFilter
             pagination="5"
@@ -126,7 +127,7 @@
             </ng-template>
           </bf-table>
 
-          <button mat-button routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</button>
+          <button mat-button class="see_titles" routerLink="/c/o/dashboard/home/buyer">View All Buyers' Activity</button>
         </section>
       </ng-container>
     </ng-container>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -52,12 +52,6 @@ analytics-map.carousel-map {
   height: 100%;
 }
 
-@include layout-bp(xs) {
-  header {
-    flex-direction: column;
-  }
-}
-
 analytics-map h3 {
   display: flex;
   align-items: center;
@@ -67,7 +61,13 @@ analytics-map h3 {
   margin-bottom: 24px;
 }
 
-.see_titles {
+.link_buttons {
   display: block;
   margin: auto;
+}
+
+@include layout-bp(xs) {
+  header {
+    flex-direction: column;
+  }
 }

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -64,7 +64,7 @@ analytics-map h3 {
 .link_buttons {
   display: block;
   margin: auto;
-  width: min-content;
+  width: fit-content;
 }
 
 @include layout-bp(xs) {

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -70,3 +70,12 @@ analytics-map h3{
 .insights-map{
   margin-bottom: 24px;
 }
+
+.insights-wrapper{
+  flex-direction: column;
+  display: flex;
+  button{
+    align-self: center;
+    margin-top: 16px;
+  }
+}

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -24,10 +24,6 @@ header {
       display: flex;
     }
   }
-
-  .see_titles {
-    margin: 24px auto auto auto;
-  }
 }
 
 .no-analytics {
@@ -62,20 +58,16 @@ analytics-map.carousel-map {
   }
 }
 
-analytics-map h3{
+analytics-map h3 {
   display: flex;
   align-items: center;
 }
 
-.insights-map{
+.margin-bottom {
   margin-bottom: 24px;
 }
 
-.insights-wrapper{
-  flex-direction: column;
-  display: flex;
-  button{
-    align-self: center;
-    margin-top: 16px;
-  }
+.see_titles {
+  display: block;
+  margin: auto;
 }

--- a/apps/festival/festival/src/app/dashboard/home/home.component.scss
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.scss
@@ -64,6 +64,7 @@ analytics-map h3 {
 .link_buttons {
   display: block;
   margin: auto;
+  width: min-content;
 }
 
 @include layout-bp(xs) {


### PR DESCRIPTION
Avoid showing NAN as result of division in percentage fields.
<img width="1440" alt="Bildschirmfoto 2022-06-02 um 8 55 47 AM" src="https://user-images.githubusercontent.com/22674720/171586959-716b7a43-b765-448a-be46-cc7bfadec8b2.png">

Fixed https://github.com/blockframes/blockframes/issues/8512#issuecomment-1134610130 : missing `View all buyers' activies` button on dashboard.