### PR TITLE
8512 top 5 in bar chart and cursor on metric card

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.ts
@@ -134,7 +134,11 @@ export class BuyerAnalyticsComponent {
   );
 
   totalAnalyticsPerTitle$ = this.aggregatedPerTitle$.pipe(
-    map(aggregatedToAnalyticData)
+    map(aggregatedToAnalyticData),
+    map(analyticData => {
+      const sorted = analyticData.sort((a, b) => b.count - a.count);
+      return sorted.splice(0, 5); // only show top 5
+    }),
   );
 
   filter$ = new BehaviorSubject('');

--- a/libs/analytics/src/lib/components/metric-card-list/metric-card-list.component.html
+++ b/libs/analytics/src/lib/components/metric-card-list/metric-card-list.component.html
@@ -1,6 +1,6 @@
 <ul>
   <li *ngFor="let card of cards">
-    <button (click)="toggleSelect(card.title)" class="surface mat-body-2" [ngClass]="card.selected ? 'selected' : null">
+    <button (click)="toggleSelect(card.title)" class="surface mat-body-2" [ngClass]="{ 'selected': card.selected, 'selectable': selectable }">
       <header>
         <mat-icon [svgIcon]="card.icon"></mat-icon>
       </header>

--- a/libs/analytics/src/lib/components/metric-card-list/metric-card-list.component.scss
+++ b/libs/analytics/src/lib/components/metric-card-list/metric-card-list.component.scss
@@ -14,6 +14,10 @@ ul {
     text-align: center;
     cursor: pointer;
 
+    .selectable {
+      cursor: pointer;
+    }
+
     header {
       background-color: var(--primary-lighter);
       border-radius: 4px;


### PR DESCRIPTION
#8512
- [ ] Could we have a little hand cursor and maybe some perspective on the card when hovering on it? It's not intuitive that these cards can be clicked and it filters the table below.

![image](https://user-images.githubusercontent.com/93206363/172129891-e57b2cbd-05d6-4485-af99-a9f0825c6e5d.png)

- [ ] This graph should be max 5 titles (the 5 with most interactions)
![image](https://user-images.githubusercontent.com/93206363/172130550-6c3c4a9d-23ec-4d41-942b-1b1483e5c89f.png)
