### PR TITLE
8512 Page view in tables and more

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.html
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.html
@@ -45,6 +45,9 @@
       <ng-template colRef="title.originalLanguages" label="Original Language" let-languages sort>
         {{ languages | toLabel:'languages' }}
       </ng-template>
+      <ng-template colRef="pageView" label="# Views" let-pageView sort>
+        {{ pageView }}
+      </ng-template>
       <ng-template colRef label="In wishlist" let-wishlist sort>
         {{ inWishlist(wishlist) ? 'Yes' : '-' }}
       </ng-template>

--- a/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyer/buyer-analytics.component.ts
@@ -140,7 +140,9 @@ export class BuyerAnalyticsComponent {
   filter$ = new BehaviorSubject('');
   filtered$ = combineLatest([
     this.filter$.asObservable(),
-    this.aggregatedPerTitle$
+    this.aggregatedPerTitle$.pipe(
+      map(aggregated => aggregated.filter(a => a.total > 0))
+    )
   ]).pipe(
     map(([filter, analytics]) => filterAnalytics(filter, analytics))
   );

--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.html
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.html
@@ -29,6 +29,9 @@
   <ng-template colRef="org.activity" label="Activity" let-activity sort>
     {{ activity | toLabel:'orgActivity' }}
   </ng-template>
+  <ng-template colRef="pageView" label="# Title Page Views" let-pageView sort>
+    {{ pageView }}
+  </ng-template>
   <ng-template colRef="addedToWishlist" label="Titles in Wishlist" let-wishlist sort>
     {{ wishlist }}
   </ng-template>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.html
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.html
@@ -107,6 +107,9 @@
             <ng-template colRef="org.activity" label="Activity" let-activity sort>
               {{ activity | toLabel:'orgActivity' }}
             </ng-template>
+            <ng-template colRef="pageView" label="# Title Page Views" let-pageView sort>
+              {{ pageView }}
+            </ng-template>
             <ng-template colRef="addedToWishlist" label="Titles in Wishlist" let-wishlist sort>
               {{ wishlist }}
             </ng-template>

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -108,7 +108,7 @@ export class HomeComponent {
         return aggregate(analyticsOfUser, { user, org });
       });
     }),
-    map(users => users.sort((userA, userB) => userA.total - userB.total))
+    map(users => users.sort((userA, userB) => userB.total - userA.total))
   );
 
 


### PR DESCRIPTION
#8512

- [ ] On the page /home/buyer/[buyerId] the table shows **all** the titles from the Seller, and indicates if there was an interaction by the buyer. So there can be some titles in the table where the Buyer didn't interact with. I think it should **only** show the titles with which the Buyer interacted with

If this isn't possible then we shouldn't put this title for the table because it's misleading `Buyer was interested in these titles`

- [ ] I think we should add the PageViews in all the tables (home, buyer list, buyer page). If this is too much work now, then we need to add some "clarification sentences" like we did for the Title analysis. (ie. `Discover with which titles the Buyer interacted with` ; `Discover the Buyers who interacted with your Titles` )