### PR TITLE
new clean firebase init code 

### DIFF
--- a/libs/firebase-utils/src/lib/initialize.ts
+++ b/libs/firebase-utils/src/lib/initialize.ts
@@ -1,0 +1,76 @@
+import * as admin from 'firebase-admin';
+import * as firebaseConfig from 'firebase.json';
+
+/**
+ * Will ensure firebase app is initialised only once for a given name
+ * @returns `void`
+ */
+export function initAdmin(...args: Parameters<typeof admin.initializeApp>) {
+  const [options, name = '[DEFAULT]'] = args;
+  for (const app of admin.apps) if (app?.name === name) return app;
+  return admin.initializeApp({ credential: getCredentials(), ...options }, name);
+}
+
+function getCredentials(): admin.credential.Credential | undefined {
+  const SAK = process.env['GOOGLE_APPLICATION_CREDENTIALS'];
+  if (!SAK) return;
+  try {
+    const serviceAccount = JSON.parse(SAK) as admin.ServiceAccount;
+    return admin.credential.cert(serviceAccount);
+  } catch (e) {
+    return admin.credential.applicationDefault();
+  }
+}
+
+/**
+ * Makes sure Firebase is initialised and returns Firestore object
+ */
+export function getFirestoreEmulator(...args: Parameters<typeof admin.initializeApp>): FirebaseFirestore.Firestore {
+  const port = firebaseConfig?.emulators?.firestore?.port ?? 8080;
+  process.env['FIRESTORE_EMULATOR_HOST'] = `localhost:${port}`;
+  const db = getDb(...args);
+  db?.settings({
+    port,
+    merge: true,
+    ignoreUndefinedProperties: true,
+    host: 'localhost',
+    ssl: false,
+  });
+  return db;
+}
+
+export function getAuthEmulator(...args: Parameters<typeof admin.initializeApp>) {
+  const port = firebaseConfig?.emulators?.auth?.port ?? '9099';
+  process.env['FIREBASE_AUTH_EMULATOR_HOST'] = `localhost:${port}`;
+  return getAuth(...args);
+}
+
+/**
+ * Makes sure firebase app is initialised and returns Auth service
+ */
+export function getAuth(...args: Parameters<typeof admin.initializeApp>): admin.auth.Auth {
+  return admin.auth(initAdmin(...args));
+}
+
+/**
+ * Makes sure Firebase is initialised and returns Firestore object
+ */
+export function getDb(...args: Parameters<typeof admin.initializeApp>): FirebaseFirestore.Firestore {
+  return admin.firestore(initAdmin(...args));
+}
+
+/**
+ * Makes sure firebase app is initialised and returns Auth service
+ */
+ export function getStorage(...args: Parameters<typeof admin.initializeApp>): admin.storage.Storage {
+  return admin.storage(initAdmin(...args));
+}
+
+/**
+ * Makes sure firebase app is initialised and returns Auth service
+ */
+ export function getStorageEmulator(...args: Parameters<typeof admin.initializeApp>): admin.storage.Storage {
+  const port = firebaseConfig?.emulators?.storage?.port ?? 9199;
+  process.env['FIREBASE_STORAGE_EMULATOR_HOST'] = `localhost:${port}`;
+  return admin.storage(initAdmin(...args));
+}

--- a/libs/firebase-utils/src/lib/util.ts
+++ b/libs/firebase-utils/src/lib/util.ts
@@ -6,6 +6,7 @@ import requiredVars from 'tools/mandatory-env-vars.json';
 import { resolve } from 'path';
 import { firebase as firebaseProd } from 'env/env.blockframes';
 import { OrganizationDocument, App } from '@blockframes/model';
+import { getAuth, getDb, getStorage, initAdmin } from './initialize';
 
 /**
  * This function is an iterator that allows you to fetch documents from a collection in chunks
@@ -70,35 +71,13 @@ interface AdminServices {
 export function loadAdminServices(): AdminServices {
   config();
 
-  if (!admin.apps.length) {
-    admin.initializeApp({
-      ...firebase(),
-      credential: admin.credential.applicationDefault(),
-    });
-  }
-
   return {
-    getCI,
-    auth: admin.auth(),
-    db: admin.firestore(),
+    getCI: () => initAdmin(firebaseCI(), 'CI-app') ,
+    auth: getAuth(),
+    db: getDb(),
     firebaseConfig: firebase(),
-    storage: admin.storage(),
+    storage: getStorage(),
   };
-}
-
-let ci: admin.app.App;
-
-function getCI() {
-  if (!ci) {
-    ci = admin.initializeApp(
-      {
-        projectId: firebaseCI().projectId,
-        credential: admin.credential.applicationDefault(),
-      },
-      'CI-app'
-    );
-  }
-  return ci;
 }
 
 export const sleep = (ms: number) => new Promise<void>(res => setTimeout(res, ms));


### PR DESCRIPTION
- ongoing WIP
- new clean init code, to replace all calls to admin.init / admin.service

This will prevent double initialise bugs from occuring, or no init bug.

Each app has an environment file that is controlled via build flag / config. Based on this config, the apps should use the correct function to initialise firebase service. This can be done in the env file itself, so that emulator init code isnt bundled into production, or this can be handled in the app itself.

The other question is about backend/devops related code. In some cases, we only and always want to access either a live service or an emulator (lets say a function is supposed to update a Firestore backup and import it)

In other cases, we may want a generic function that operates on either emulated or non emulated services based on a configuration.

This should always be taken into account. Ideally, where possible, functions should take db/auth/storage as an input param, thereby removing side effects from the function. This can be the case for env as well.

On the other hand, we may want to separate concerns and have all initialisation logic, emulator/non-emulator choice logic in one file/module which is used and imported from around the codebase. However, this also has its downsides.

The cleanest approach is to pass as a param, and confine the selection logic to top-level functions and modules.

to fix #8376