### PR TITLE
feat: ignore competitor analytics when showing title/buyer analytics

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
@@ -36,6 +36,14 @@ export class BuyersAnalyticsComponent {
       users: ({ uids }) => this.userService.valueChanges(uids),
       orgs: ({ orgIds }) => this.orgService.valueChanges(orgIds)
     }, { shouldAwait: true }),
+    map(({ orgs, analytics, users, ...rest }) => {
+      const buyerOrg = orgs.filter(org => !org.appAccess.festival.dashboard);
+      const buyerOrgIds = buyerOrg.map(({ id }) => id);
+      const buyerAnalytics = analytics.filter(({ meta }) => buyerOrgIds.includes(meta.orgId))
+      const buyerUsers = buyerAnalytics.map(({ meta }) => meta.uid);
+      const filteredUsers = users.filter(({ uid }) => buyerUsers.includes(uid));
+      return { ...rest, users: filteredUsers, orgs: buyerOrg, analytics: buyerAnalytics };
+    }),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 

--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { toCards } from '@blockframes/analytics/components/metric-card-list/metric-card-list.component';
 import { AnalyticsService } from '@blockframes/analytics/service';
 import { aggregate, countedToAnalyticData, counter } from '@blockframes/analytics/utils';
-import { AggregatedAnalytic, App } from '@blockframes/model';
+import { AggregatedAnalytic, App, Organization, Analytics, User } from '@blockframes/model';
 import { fromOrgAndAccepted, MovieService } from '@blockframes/movie/service';
 import { OrganizationService } from '@blockframes/organization/service';
 import { UserService } from '@blockframes/user/service';
@@ -37,12 +37,8 @@ export class BuyersAnalyticsComponent {
       orgs: ({ orgIds }) => this.orgService.valueChanges(orgIds)
     }, { shouldAwait: true }),
     map(({ orgs, analytics, users, ...rest }) => {
-      const buyerOrg = orgs.filter(org => !org.appAccess.festival.dashboard);
-      const buyerOrgIds = buyerOrg.map(({ id }) => id);
-      const buyerAnalytics = analytics.filter(({ meta }) => buyerOrgIds.includes(meta.orgId))
-      const buyerUsers = buyerAnalytics.map(({ meta }) => meta.uid);
-      const filteredUsers = users.filter(({ uid }) => buyerUsers.includes(uid));
-      return { ...rest, users: filteredUsers, orgs: buyerOrg, analytics: buyerAnalytics };
+      const filteredData = this.removeSellerData(orgs, analytics, users,);
+      return { ...rest, ...filteredData };
     }),
     shareReplay({ bufferSize: 1, refCount: true })
   );
@@ -75,6 +71,15 @@ export class BuyersAnalyticsComponent {
     private orgService: OrganizationService,
     @Inject(APP) public app: App
   ) { }
+
+  removeSellerData(orgs: Organization[], analytics: Analytics<"title">[], users: User[]) {
+    const buyerOrg = orgs.filter(org => !org.appAccess.festival.dashboard);
+    const buyerOrgIds = buyerOrg.map(({ id }) => id);
+    const buyerAnalytics = analytics.filter(({ meta }) => buyerOrgIds.includes(meta.orgId))
+    const buyerUsers = buyerAnalytics.map(({ meta }) => meta.uid);
+    const filteredUsers = users.filter(({ uid }) => buyerUsers.includes(uid));
+    return { users: filteredUsers, orgs: buyerOrg, analytics: buyerAnalytics };
+  }
 
   goToBuyer(data: AggregatedAnalytic) {
     this.router.navigate([data.user.uid], { relativeTo: this.route });

--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.html
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.html
@@ -101,8 +101,9 @@
     <h3>Last Screenings</h3>
     <mat-icon svgIcon="info" matTooltip="Statistics are updated in real time."></mat-icon>
     <ng-container *ngIf="ongoingScreenings$ | async as events">
-      <a ongoing-event-button routerLink="/c/o/dashboard/event/{{events[0].id}}/statistics">Ongoing
-        Screenings</a>
+      <a ongoing-event-button routerLink="/c/o/dashboard/event/{{events[0].id}}/statistics">
+        Ongoing Screenings
+      </a>
     </ng-container>
   </header>
   <article class="surface">

--- a/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/title/title-analytics.component.ts
@@ -117,6 +117,9 @@ export class TitleAnalyticsComponent {
       org: analytic => this.orgService.valueChanges(analytic.meta.orgId),
       user: analytic => this.userService.valueChanges(analytic.meta.uid)
     }, { shouldAwait: true }),
+    map(analyticsWithOrg => {
+      return analyticsWithOrg.filter(({ org }) => !org.appAccess.festival.dashboard);
+    }),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 

--- a/apps/festival/festival/src/app/dashboard/analytics/titles/titles-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/titles/titles-analytics.component.ts
@@ -46,7 +46,7 @@ export class TitlesAnalyticsComponent {
 
   titlesAnalytics$ = this.service.valueChanges(fromOrgAndAccepted(this.orgService.org.id, this.app)).pipe(
     joinWith({
-      analytics: title => this.analytics.getTitleAnalytics({ titleId: title.id }),
+      analytics: title => this.getTitleAnalytics(title.id),
       events: title => this.eventService.valueChanges([
         where('type', '==', 'screening'),
         where('meta.titleId', '==', title.id)
@@ -64,6 +64,17 @@ export class TitlesAnalyticsComponent {
     private orgService: OrganizationService,
     @Inject(APP) public app: App
   ) { }
+
+  getTitleAnalytics(titleId:string){
+    return this.analytics.getTitleAnalytics({ titleId }).pipe(
+      joinWith({
+        org: ({meta}) => this.orgService.valueChanges(meta.orgId)
+      }, {shouldAwait:true}),
+      map(analyticsWithOrg => {
+        return analyticsWithOrg.filter(({ org }) => !org.appAccess.festival.dashboard);
+      })
+    );
+  }
 
   goToTitle(data: AggregatedAnalytic) {
     this.router.navigate([data.title.id], { relativeTo: this.route });

--- a/apps/festival/festival/src/app/dashboard/home/home.component.ts
+++ b/apps/festival/festival/src/app/dashboard/home/home.component.ts
@@ -53,6 +53,9 @@ export class HomeComponent {
     joinWith({
       org: analytic => this.orgService.valueChanges(analytic.meta.orgId)
     }, { shouldAwait: true }),
+    map(analyticsWithOrg => {
+      return analyticsWithOrg.filter(({ org }) => !org.appAccess.festival.dashboard);
+    }),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 


### PR DESCRIPTION
Fixed: #8644
Ignore seller analytics on following pages:
1. Festival Dashboard `c/o/dashboard/home`
2. title list `/c/o/dashboard/home/title`
3. title analytics `/c/o/dashboard/home/title/{titleId}`
4. buyer list `/c/o/dashboard/home/buyer`