### PR TITLE
8702 fix loading pie chart

### DIFF
--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
@@ -50,7 +50,8 @@ export class BuyersAnalyticsComponent {
         const analyticsOfUser = analytics.filter(analytic => analytic.meta.uid === user.uid);
         return aggregate(analyticsOfUser, { user, org });
       });
-    })
+    }),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   orgActivity$ = this.buyersAnalytics$.pipe(

--- a/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
+++ b/apps/festival/festival/src/app/dashboard/analytics/buyers/buyers-analytics.component.ts
@@ -33,8 +33,8 @@ export class BuyersAnalyticsComponent {
       return { uids, orgIds, analytics };
     }),
     joinWith({
-      users: ({ uids }) => this.userService.valueChanges(uids),
-      orgs: ({ orgIds }) => this.orgService.valueChanges(orgIds)
+      users: ({ uids }) => this.userService.load(uids),
+      orgs: ({ orgIds }) => this.orgService.load(orgIds)
     }, { shouldAwait: true }),
     map(({ orgs, analytics, users, ...rest }) => {
       const filteredData = this.removeSellerData(orgs, analytics, users,);

--- a/libs/organization/src/lib/organization/service.ts
+++ b/libs/organization/src/lib/organization/service.ts
@@ -27,7 +27,6 @@ import { BlockframesCollection } from '@blockframes/utils/abstract-service';
 @Injectable({ providedIn: 'root' })
 export class OrganizationService extends BlockframesCollection<Organization> {
   readonly path = 'orgs';
-  readonly memorize = false;
 
   // Organization of the current logged in user or undefined if user have no org
   org: Organization; // For this to be defined, one of the observable below must be called before

--- a/libs/organization/src/lib/organization/service.ts
+++ b/libs/organization/src/lib/organization/service.ts
@@ -27,6 +27,7 @@ import { BlockframesCollection } from '@blockframes/utils/abstract-service';
 @Injectable({ providedIn: 'root' })
 export class OrganizationService extends BlockframesCollection<Organization> {
   readonly path = 'orgs';
+  readonly memorize = false;
 
   // Organization of the current logged in user or undefined if user have no org
   org: Organization; // For this to be defined, one of the observable below must be called before


### PR DESCRIPTION
fix #8702
To reproduce the bug consistently I went to
1. /c/o/dashboard/title
2. Navigate to Dashboard
3. Click on "View all Buyers' Activitites"

On /c/o/dashboard/title, all the titles of the sellers org are queried. When going to the Buyers Activities page, it triggers the observables twice. First is for the sellers' org, and then again with more data. This is a bug that has been seen on CRM before.

However, this time, the `orgService.valueChanges(orgIds)` kept triggering infinitely (and thus the pie chart kept trying to re-render). Turning of memorization helped, or changing valueChangess to getValue also helped.

This is likely a bug in ngfire lib 



Might be caused by the same bug as https://github.com/blockframes/blockframes/issues/8509