### PR TITLE
8681 fix video saved as map instead of array

### DIFF
--- a/apps/backend-functions/src/media.ts
+++ b/apps/backend-functions/src/media.ts
@@ -152,7 +152,18 @@ export async function linkFile(data: storage.ObjectMetadata) {
 
       let fieldValue: StorageFile | StorageFile[] = get(doc, metadata.field);
 
-      if (Array.isArray(fieldValue)) {
+      const fileLists = [
+        'documents.notes',
+        'documents.videos',
+        'promotional.still_photo',
+        'promotional.videos.otherVideos',
+        'promotional.notes'
+      ];
+      const isList = fileLists.includes(metadata.field);
+    
+      if (fieldValue === undefined && isList) {
+        fieldValue = [uploadData];
+      } else if (Array.isArray(fieldValue)) {
         fieldValue.push(uploadData);
       } else {
         fieldValue = uploadData;


### PR DESCRIPTION
fix #8681
I checked the db and no orgs have video file saved as map instead of in an array at the moment. So I didn't create a migration. Although, it could happen in the upcoming time because it happens when an org doesn't have `videos` in `documents.videos` yet (empty array).