### PR TITLE
Fix user export hotfix

### DIFF
--- a/apps/crm/crm/src/app/crm/pages/users/users.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.ts
@@ -80,15 +80,15 @@ export class UsersComponent implements OnInit {
       this.exporting = true;
       this.cdr.markForCheck()
 
-      const roles = await this.permissionsService.getValue();
-      const getMemberRole = (orgId: string, uid: string) => {
-        const role = roles.find(role => role.id === orgId);
-        if (!role) return
-        return role.roles[uid];
+      const roles = await this.permissionsService.load();
+      const getMemberRole = (r: CrmUser) => {
+        const role = roles.find(role => role.id === r.orgId);
+        if (!role) return;
+        return role.roles[r.uid];
       }
 
       const getRows = users.map(async r => {
-        const role = getMemberRole(r.orgId, r.uid)
+        const role = getMemberRole(r);
         const type = r.org ? getOrgModuleAccess(r.org).includes('dashboard') ? 'seller' : 'buyer' : '--';
         const row = {
           'userId': r.uid,

--- a/apps/crm/crm/src/app/crm/pages/users/users.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.ts
@@ -8,6 +8,7 @@ import { OrganizationService } from '@blockframes/organization/service';
 import { map } from 'rxjs/operators';
 import { combineLatest, Observable } from 'rxjs';
 import { sorts } from '@blockframes/ui/list/table/sorts';
+import { PermissionsService } from '@blockframes/permissions/service';
 
 interface CrmUser extends User {
   firstConnection: Date;
@@ -36,6 +37,7 @@ export class UsersComponent implements OnInit {
     private analyticsService: AnalyticsService,
     private orgService: OrganizationService,
     private router: Router,
+    private permissionsService: PermissionsService
   ) { }
 
   async ngOnInit() {
@@ -77,8 +79,16 @@ export class UsersComponent implements OnInit {
     try {
       this.exporting = true;
       this.cdr.markForCheck()
+
+      const roles = await this.permissionsService.getValue();
+      const getMemberRole = (orgId: string, uid: string) => {
+        const role = roles.find(role => role.id === orgId);
+        if (!role) return
+        return role.roles[uid];
+      }
+
       const getRows = users.map(async r => {
-        const role = r.org ? await this.orgService.getMemberRole(r.org, r.uid) : '--';
+        const role = getMemberRole(r.orgId, r.uid)
         const type = r.org ? getOrgModuleAccess(r.org).includes('dashboard') ? 'seller' : 'buyer' : '--';
         const row = {
           'userId': r.uid,


### PR DESCRIPTION
Original: https://github.com/blockframes/blockframes/pull/8820

ERROR: firebase/firestore: Firestore (9.6.10): Using maximum backoff delay to prevent overloading the backend.
This is because Firestore doesn't like it if the same doc is queried multiple times at once.

In the code, we iterated over 4000 users and queried their permissions document. There is one permissions document per organization, and since users share the same organization, the same doc was queried many times at once.