### PR TITLE
8834 export analytics

### DIFF
--- a/apps/crm/crm/src/app/crm/pages/movies/movies.component.html
+++ b/apps/crm/crm/src/app/crm/pages/movies/movies.component.html
@@ -1,13 +1,22 @@
 <main fxLayout="column">
   <crm-bread-crumb></crm-bread-crumb>
   <ng-container *ngIf="movies$ | async as movies; else loading">
-    <article fxLayout="column" fxLayoutAlign="center center">
+    <article>
       <button [disabled]="exporting" mat-flat-button color="primary" (click)="exportTable(movies)">
         <ng-container *ngIf="exporting else export">
           <span>Generating CSV...</span>
         </ng-container>
         <ng-template #export>
-          <span>Export to CSV</span>
+          <span>Export Movies to CSV</span>
+          <mat-icon svgIcon="arrow_upward"></mat-icon>
+        </ng-template>
+      </button>
+      <button [disabled]="exportingAnalytics" mat-flat-button color="primary" (click)="exportTitleAnalytics(movies)">
+        <ng-container *ngIf="exportingAnalytics else exportAnalytics">
+          <span>Generating CSV...</span>
+        </ng-container>
+        <ng-template #exportAnalytics>
+          <span>Export Analytics to CSV</span>
           <mat-icon svgIcon="arrow_upward"></mat-icon>
         </ng-template>
       </button>

--- a/apps/crm/crm/src/app/crm/pages/movies/movies.component.scss
+++ b/apps/crm/crm/src/app/crm/pages/movies/movies.component.scss
@@ -5,6 +5,9 @@
 
 article {
   margin-bottom: 24px;
+  display: flex;
+  gap: 16px;
+  justify-content: center;
 }
 
 .poster {

--- a/apps/crm/crm/src/app/crm/pages/movies/movies.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/movies/movies.component.ts
@@ -171,14 +171,12 @@ export class MoviesComponent implements OnInit {
     this.exportingAnalytics = true;
     this.cdr.markForCheck();
 
-    const query = [where('type', '==', 'title')]
+    const query = [where('type', '==', 'title')];
     const all = await this.analyticsService.load<Analytics<'title'>>(query);
     const allAnalytics = all.filter(analytic => !analytic.meta.ownerOrgIds.includes(analytic.meta.orgId));
-    console.log('analytics: ', allAnalytics);
 
     const allUids = unique(allAnalytics.map(analytic => analytic.meta.uid));
     const allUsers = await this.userService.load(allUids);
-    console.log('users: ', allUsers)
 
     const exportedRows = [];
     for (const title of titles) {
@@ -202,7 +200,7 @@ export class MoviesComponent implements OnInit {
           'promo element opened': a.promoElementOpened,
           'added to wishlist': a.addedToWishlist,
           'removed from wishlist': a.removedFromWishlist
-        })
+        });
       }
     }
     downloadCsvFromJson(exportedRows, 'movies-analytics-list');

--- a/apps/crm/crm/src/app/crm/pages/users/users.component.html
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.html
@@ -2,13 +2,22 @@
   <crm-bread-crumb></crm-bread-crumb>
   <ng-container *ngIf="users$ | async as users; else loading">
 
-    <article fxLayout="column" fxLayoutAlign="center center">
+    <article>
       <button [disabled]="exporting" mat-flat-button color="primary" (click)="exportTable(users)">
         <ng-container *ngIf="exporting else export">
           <span>Generating CSV...</span>
         </ng-container>
         <ng-template #export>
           <span>Export to CSV</span>
+          <mat-icon svgIcon="arrow_upward"></mat-icon>
+        </ng-template>
+      </button>
+      <button [disabled]="exportingAnalaytics" mat-flat-button color="primary" (click)="exportTitleAnalaytics(users)">
+        <ng-container *ngIf="exportingAnalaytics else exportAnalytics">
+          <span>Generating CSV...</span>
+        </ng-container>
+        <ng-template #exportAnalytics>
+          <span>Export Analytics to CSV</span>
           <mat-icon svgIcon="arrow_upward"></mat-icon>
         </ng-template>
       </button>

--- a/apps/crm/crm/src/app/crm/pages/users/users.component.scss
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.scss
@@ -5,6 +5,9 @@
 
 article {
   margin-bottom: 24px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
 }
 
 .avatar {

--- a/apps/crm/crm/src/app/crm/pages/users/users.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.ts
@@ -140,14 +140,12 @@ export class UsersComponent implements OnInit {
     this.exportingAnalaytics = true;
     this.cdr.markForCheck();
 
-    const query = [where('type', '==', 'title')]
+    const query = [where('type', '==', 'title')];
     const all = await this.analyticsService.load<Analytics<'title'>>(query);
     const allAnalytics = all.filter(analytic => !analytic.meta.ownerOrgIds.includes(analytic.meta.orgId));
-    console.log('analytics: ', allAnalytics);
 
     const allTitleIds = unique(allAnalytics.map(analytic => analytic.meta.titleId));
     const allTitles = await this.movieService.load(allTitleIds);
-    console.log('titles: ', allTitles)
 
     const exportedRows = [];
     for (const user of users) {
@@ -171,7 +169,7 @@ export class UsersComponent implements OnInit {
           'promo element opened': a.promoElementOpened,
           'added to wishlist': a.addedToWishlist,
           'removed from wishlist': a.removedFromWishlist
-        })
+        });
       }
     }
     downloadCsvFromJson(exportedRows, 'users-analytics-list');

--- a/apps/crm/crm/src/app/crm/pages/users/users.component.ts
+++ b/apps/crm/crm/src/app/crm/pages/users/users.component.ts
@@ -1,14 +1,17 @@
 import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { Router } from '@angular/router';
-import { downloadCsvFromJson } from '@blockframes/utils/helpers';
+import { downloadCsvFromJson, unique } from '@blockframes/utils/helpers';
 import { UserService } from '@blockframes/user/service';
-import { User, Organization, getAllAppsExcept, appName, getOrgModuleAccess, modules } from '@blockframes/model';
+import { User, Organization, getAllAppsExcept, appName, getOrgModuleAccess, modules, Analytics, displayName } from '@blockframes/model';
 import { AnalyticsService } from '@blockframes/analytics/service';
 import { OrganizationService } from '@blockframes/organization/service';
 import { map } from 'rxjs/operators';
 import { combineLatest, Observable } from 'rxjs';
 import { sorts } from '@blockframes/ui/list/table/sorts';
 import { PermissionsService } from '@blockframes/permissions/service';
+import { MovieService } from '@blockframes/movie/service';
+import { where } from 'firebase/firestore';
+import { aggregate } from '@blockframes/analytics/utils';
 
 interface CrmUser extends User {
   firstConnection: Date;
@@ -28,6 +31,7 @@ interface CrmUser extends User {
 export class UsersComponent implements OnInit {
   public users$?: Observable<CrmUser[]>;
   public exporting = false;
+  public exportingAnalaytics = false;
   public app = getAllAppsExcept(['crm']);
   public sorts = sorts;
 
@@ -37,7 +41,8 @@ export class UsersComponent implements OnInit {
     private analyticsService: AnalyticsService,
     private orgService: OrganizationService,
     private router: Router,
-    private permissionsService: PermissionsService
+    private permissionsService: PermissionsService,
+    private movieService: MovieService
   ) { }
 
   async ngOnInit() {
@@ -128,6 +133,50 @@ export class UsersComponent implements OnInit {
       console.error(err);
     }
     this.exporting = false;
+    this.cdr.markForCheck();
+  }
+
+  public async exportTitleAnalaytics(users: CrmUser[]) {
+    this.exportingAnalaytics = true;
+    this.cdr.markForCheck();
+
+    const query = [where('type', '==', 'title')]
+    const all = await this.analyticsService.load<Analytics<'title'>>(query);
+    const allAnalytics = all.filter(analytic => !analytic.meta.ownerOrgIds.includes(analytic.meta.orgId));
+    console.log('analytics: ', allAnalytics);
+
+    const allTitleIds = unique(allAnalytics.map(analytic => analytic.meta.titleId));
+    const allTitles = await this.movieService.load(allTitleIds);
+    console.log('titles: ', allTitles)
+
+    const exportedRows = [];
+    for (const user of users) {
+      const userAnalytics = allAnalytics.filter(analytic => analytic.meta.uid === user.uid);
+      const titles = allTitles.filter(title => userAnalytics.some(analytic => analytic.meta.titleId === title.id));
+
+      for (const title of titles) {
+        const titleAnalytics = userAnalytics.filter(analytic => analytic.meta.titleId === title.id);
+        const a = aggregate(titleAnalytics);
+
+        exportedRows.push({
+          uid: user.uid,
+          user: displayName(user),
+          email: user.email,
+          titleId: title.id,
+          title: title.title.international,
+          'total interactions': a.total,
+          'page views': a.pageView,
+          'screenings requested': a.screeningRequested,
+          'asking price requested': a.askingPriceRequested,
+          'promo element opened': a.promoElementOpened,
+          'added to wishlist': a.addedToWishlist,
+          'removed from wishlist': a.removedFromWishlist
+        })
+      }
+    }
+    downloadCsvFromJson(exportedRows, 'users-analytics-list');
+
+    this.exportingAnalaytics = false;
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
#8834
- [x] blockframesAdmin can export Analytics collection. Currently, some of this data is displayed on movie page, so we could either add it to the Movie export, either do a separate Analytics page. (FYI the query Bruce gave me in BigQuery to extract the buyer interactions doesn't return any data any more. I think it's because it was previously tracked with GA and now it's internally in firebase.