### PR TITLE
quickfixes

### DIFF
--- a/apps/catalog/catalog-e2e/src/integration/dashboard/deal-seller-negotiatiation.spec.ts
+++ b/apps/catalog/catalog-e2e/src/integration/dashboard/deal-seller-negotiatiation.spec.ts
@@ -218,8 +218,8 @@ describe('Deal negotiation', () => {
 
 function checkConfirmationEmails(decision: ContractStatus) {
   for (const user of ['buyer', 'seller', 'admin']) {
-    interceptEmail({ sentTo: mailData[user].recipient }).then(mail => {
-      expect(mail.subject).to.eq(mailData[user].subject[decision]);
+    interceptEmail({ sentTo: mailData[user].recipient, subject: mailData[user].subject[decision] }).then(mail => {
+      cy.log(`mail received by ${user} ${mailData[user].recipient}: ${mailData[user].subject[decision]}`);
       return deleteEmail(mail.id);
     });
   }

--- a/apps/crm/crm-e2e/src/fixtures/create-org.ts
+++ b/apps/crm/crm-e2e/src/fixtures/create-org.ts
@@ -110,6 +110,8 @@ function createOrgWithuser(status: OrganizationStatus, apps: Exclude<App, 'crm' 
 }
 
 function getRandom<S extends Scope>(base: S): keyof StaticModel[S] {
-  const keys = Object.keys(staticModel[base]);
+  // we filter to avoid 'world' as there is not such option in mat-select
+  // it won't affect the result for random orgActivity
+  const keys = Object.keys(staticModel[base]).filter(territory => territory !== 'world');
   return keys[(keys.length * Math.random()) << 0] as any;
 }

--- a/apps/crm/crm-e2e/src/fixtures/create-org.ts
+++ b/apps/crm/crm-e2e/src/fixtures/create-org.ts
@@ -92,7 +92,7 @@ function createOrgWithuser(status: OrganizationStatus, apps: Exclude<App, 'crm' 
       description: `E2E ${status} - ${apps.join(' & ')} - ${modules.join(' & ')} org`,
       addresses: {
         main: {
-          country: getRandom('territories'),
+          country: getRandom('territories', ['world']),
           region: '', // not in the form
           city: faker.address.cityName(),
           zipCode: faker.address.zipCode(),
@@ -109,9 +109,7 @@ function createOrgWithuser(status: OrganizationStatus, apps: Exclude<App, 'crm' 
   };
 }
 
-function getRandom<S extends Scope>(base: S): keyof StaticModel[S] {
-  // we filter to avoid 'world' as there is not such option in mat-select
-  // it won't affect the result for random orgActivity
-  const keys = Object.keys(staticModel[base]).filter(territory => territory !== 'world');
+function getRandom<S extends Scope>(base: S, withoutValues: string[] = []): keyof StaticModel[S] {
+  const keys = Object.keys(staticModel[base]).filter(k => !withoutValues.includes(k));
   return keys[(keys.length * Math.random()) << 0] as any;
 }


### PR DESCRIPTION
- [x] E2E crm : in `create-org test`, once in 240 times, `getRandom()` would select `world` as a random territory. As there is no such option in the from, the test would crash

- [x] E2E catalog : in `deal-seller-negociation test`, emails could arrive in an unpredicted order, leading to a crash, as one recipient could receive 2 mails, and we were checking the subject afterwards. To prevent this, we now intercept emails depending on both recipient AND subject.