### PR TITLE
error should be displayed to console even if snackbar is already open

### DIFF
--- a/libs/utils/src/lib/error-logger.module.ts
+++ b/libs/utils/src/lib/error-logger.module.ts
@@ -12,8 +12,8 @@ export class ErrorLoggerHandler implements ErrorHandler {
   constructor(private snackBar: MatSnackBar) { }
 
   handleError(error: Error | string) {
+    console.error(error);
     if (this.snackBar._openedSnackBarRef === null) {
-      console.error(error);
       this.snackBar.open(`${error}`.substring(0, 100), 'close');
     }
   }


### PR DESCRIPTION
error should be displayed to console even if snackbar is already open